### PR TITLE
Fix Threading

### DIFF
--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -348,6 +348,10 @@ public class ShortestPathPlugin extends Plugin {
         }
 
         if (target == null) {
+            if (pathfinder != null) {
+                pathfinder.cancel();
+            }
+
             worldMapPointManager.remove(marker);
             marker = null;
             pathfinder = null;

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -348,13 +348,15 @@ public class ShortestPathPlugin extends Plugin {
         }
 
         if (target == null) {
-            if (pathfinder != null) {
-                pathfinder.cancel();
+            synchronized (pathfinderMutex) {
+                if (pathfinder != null) {
+                    pathfinder.cancel();
+                }
+                pathfinder = null;
             }
 
             worldMapPointManager.remove(marker);
             marker = null;
-            pathfinder = null;
             startPointSet = false;
         } else {
             worldMapPointManager.removeIf(x -> x == marker);

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -113,6 +113,7 @@ public class ShortestPathPlugin extends Plugin {
     private BufferedImage minimapSpriteResizeable;
     private Rectangle minimapRectangle = new Rectangle();
 
+    private final Object pathfinderMutex = new Object();
     @Getter
     private Pathfinder pathfinder;
     private PathfinderConfig pathfinderConfig;
@@ -162,6 +163,21 @@ public class ShortestPathPlugin extends Plugin {
         }
     }
 
+    public void restartPathfinding(WorldPoint start, WorldPoint end) {
+        synchronized (pathfinderMutex) {
+            if (pathfinder != null) {
+                pathfinder.cancel();
+            }
+        }
+
+        getClientThread().invokeLater(() -> {
+            pathfinderConfig.refresh();
+            synchronized (pathfinderMutex) {
+                pathfinder = new Pathfinder(pathfinderConfig, start, end);
+            }
+        });
+    }
+
     public boolean isNearPath(WorldPoint location) {
         if (pathfinder == null || pathfinder.getPath() == null || pathfinder.getPath().isEmpty() ||
             config.recalculateDistance() < 0 || lastLocation.equals(lastLocation = location)) {
@@ -201,7 +217,7 @@ public class ShortestPathPlugin extends Plugin {
                 setTarget(null);
                 return;
             }
-            pathfinder = new Pathfinder(pathfinderConfig, currentLocation, pathfinder.getTarget());
+            restartPathfinding(currentLocation, pathfinder.getTarget());
         }
     }
 
@@ -349,7 +365,7 @@ public class ShortestPathPlugin extends Plugin {
             if (startPointSet && pathfinder != null) {
                 start = pathfinder.getStart();
             }
-            pathfinder = new Pathfinder(pathfinderConfig, start, target);
+            restartPathfinding(start, target);
         }
     }
 
@@ -358,7 +374,7 @@ public class ShortestPathPlugin extends Plugin {
             return;
         }
         startPointSet = true;
-        pathfinder = new Pathfinder(pathfinderConfig, start, pathfinder.getTarget());
+        restartPathfinding(start, pathfinder.getTarget());
     }
 
     public WorldPoint calculateMapPoint(Point point) {

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -9,10 +9,15 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
 
 public class Pathfinder implements Runnable {
+    private AtomicBoolean done = new AtomicBoolean();
+    private AtomicBoolean cancelled = new AtomicBoolean();
+
     @Getter
     private final WorldPoint start;
     @Getter
@@ -25,16 +30,21 @@ public class Pathfinder implements Runnable {
 
     @Getter
     private List<WorldPoint> path = new ArrayList<>();
-    @Getter
-    private boolean done = false;
 
     public Pathfinder(PathfinderConfig config, WorldPoint start, WorldPoint target) {
         this.config = config;
         this.start = start;
         this.target = target;
-        this.config.refresh();
 
         new Thread(this).start();
+    }
+
+    public boolean isDone() {
+        return done.get();
+    }
+
+    public void cancel() {
+        cancelled.set(true);
     }
 
     private void addNeighbors(Node node) {
@@ -60,7 +70,7 @@ public class Pathfinder implements Runnable {
         long bestHeuristic = Integer.MAX_VALUE;
         Instant cutoffTime = Instant.now().plus(config.getCalculationCutoff());
 
-        while (!boundary.isEmpty() || !pending.isEmpty()) {
+        while (!cancelled.get() && (!boundary.isEmpty() || !pending.isEmpty())) {
             Node node = boundary.peekFirst();
             Node p = pending.peek();
 
@@ -92,7 +102,8 @@ public class Pathfinder implements Runnable {
             addNeighbors(node);
         }
 
-        done = true;
+        done.set(!cancelled.get());
+
         boundary.clear();
         visited.clear();
         pending.clear();

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -69,7 +69,8 @@ public class PathfinderConfig {
             strengthLevel = client.getBoostedSkillLevel(Skill.STRENGTH);
             prayerLevel = client.getBoostedSkillLevel(Skill.PRAYER);
             woodcuttingLevel = client.getBoostedSkillLevel(Skill.WOODCUTTING);
-            plugin.getClientThread().invokeLater(this::refreshQuests);
+
+            refreshQuests();
         }
     }
 


### PR DESCRIPTION
This should resolve the root of issue #6. There are some situations where two or more pathfinding threads may be running at the same time as old threads are never formally cancelled. This change also guarantees that `PathfinderConfig.refresh()` is always called on the client thread and is refreshed before creating a new `Pathfinder`.

There is one side-effect that may not be desirable: if the recalculate distance is too small (<=2) and a player is running around, then a path finding thread may be cancelled before it even begins leading to times where no path is drawn. I figure most people probably leave that value at the default or set it higher and wouldn't notice. If it is an issue, it can probably be addressed by cancelling the current pathfinding thread inside the `invokeLater` call rather than as early as possible.