### PR TITLE
Performance fixes

### DIFF
--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -34,7 +34,6 @@ import net.runelite.api.worldmap.WorldMap;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -127,7 +127,7 @@ public class ShortestPathPlugin extends Plugin {
     @Override
     protected void startUp() {
         CollisionMap map = CollisionMap.fromResources();
-        Map<WorldPoint, List<Transport>> transports = Transport.fromResources(config);
+        Map<WorldPoint, List<Transport>> transports = Transport.loadAllFromResources();
 
         pathfinderConfig = new PathfinderConfig(map, transports, client, config, this);
 
@@ -143,23 +143,6 @@ public class ShortestPathPlugin extends Plugin {
         overlayManager.remove(pathMinimapOverlay);
         overlayManager.remove(pathMapOverlay);
         overlayManager.remove(pathMapTooltipOverlay);
-    }
-
-    @Subscribe
-    public void onConfigChanged(ConfigChanged event) {
-        if (!CONFIG_GROUP.equals(event.getGroup())) {
-            return;
-        }
-
-        boolean reloadTransports = "useAgilityShortcuts".equals(event.getKey()) ||
-            "useGrappleShortcuts".equals(event.getKey()) || "useBoats".equals(event.getKey()) ||
-            "useFairyRings".equals(event.getKey()) || "useTeleports".equals(event.getKey());
-
-        if (reloadTransports) {
-            Map<WorldPoint, List<Transport>> transports = Transport.fromResources(config);
-            pathfinderConfig.getTransports().clear();
-            pathfinderConfig.getTransports().putAll(transports);
-        }
     }
 
     public boolean isNearPath(WorldPoint location) {

--- a/src/main/java/shortestpath/Transport.java
+++ b/src/main/java/shortestpath/Transport.java
@@ -136,7 +136,7 @@ public class Transport {
         return null;
     }
 
-    private static void addTransports(Map<WorldPoint, List<Transport>> transports, ShortestPathConfig config, String path, TransportType transportType) {
+    private static void addTransports(Map<WorldPoint, List<Transport>> transports, String path, TransportType transportType) {
         try {
             String s = new String(Util.readAllBytes(ShortestPathPlugin.class.getResourceAsStream(path)), StandardCharsets.UTF_8);
             Scanner scanner = new Scanner(s);
@@ -157,12 +157,6 @@ public class Transport {
                     Transport transport = new Transport(line);
                     transport.isBoat = TransportType.BOAT.equals(transportType);
                     transport.isTeleport = TransportType.TELEPORT.equals(transportType);
-                    if (!config.useAgilityShortcuts() && transport.isAgilityShortcut) {
-                        continue;
-                    }
-                    if (!config.useGrappleShortcuts() && transport.isGrappleShortcut) {
-                        continue;
-                    }
                     WorldPoint origin = transport.getOrigin();
                     transports.computeIfAbsent(origin, k -> new ArrayList<>()).add(transport);
                 }
@@ -187,22 +181,13 @@ public class Transport {
         }
     }
 
-    public static HashMap<WorldPoint, List<Transport>> fromResources(ShortestPathConfig config) {
+    public static HashMap<WorldPoint, List<Transport>> loadAllFromResources() {
         HashMap<WorldPoint, List<Transport>> transports = new HashMap<>();
 
-        addTransports(transports, config, "/transports.txt", TransportType.TRANSPORT);
-
-        if (config.useBoats()) {
-            addTransports(transports, config, "/boats.txt", TransportType.BOAT);
-        }
-
-        if (config.useFairyRings()) {
-            addTransports(transports, config, "/fairy_rings.txt", TransportType.FAIRY_RING);
-        }
-
-        if (config.useTeleports()) {
-            addTransports(transports, config, "/teleports.txt", TransportType.TELEPORT);
-        }
+        addTransports(transports, "/transports.txt", TransportType.TRANSPORT);
+        addTransports(transports, "/boats.txt", TransportType.BOAT);
+        addTransports(transports, "/fairy_rings.txt", TransportType.FAIRY_RING);
+        addTransports(transports, "/teleports.txt", TransportType.TELEPORT);
 
         return transports;
     }

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -74,9 +74,13 @@ public class CollisionMap extends SplitFlagMap {
 
         List<Node> neighbors = new ArrayList<>();
 
+        @SuppressWarnings("unchecked") // Casting EMPTY_LIST to List<Transport> is safe here
+        List<Transport> transports = config.getTransports().getOrDefault(node.position, (List<Transport>)Collections.EMPTY_LIST);
+
         // Transports are pre-filtered by PathfinderConfig.refreshTransportData
         // Thus any transports in the list are guaranteed to be valid per the user's settings
-        for (Transport transport : config.getTransports().getOrDefault(node.position, (List<Transport>) Collections.EMPTY_LIST)) {
+        for (int i = 0; i < transports.size(); ++i) {
+            Transport transport = transports.get(i);
             neighbors.add(new TransportNode(transport.getDestination(), node, transport.getWait()));
         }
 
@@ -112,7 +116,10 @@ public class CollisionMap extends SplitFlagMap {
             if (traversable[i]) {
                 neighbors.add(new Node(neighbor, node));
             } else if (Math.abs(d.x + d.y) == 1 && isBlocked(x + d.x, y + d.y, z)) {
-                for (Transport transport : config.getTransports().getOrDefault(neighbor, (List<Transport>)Collections.EMPTY_LIST)) {
+                @SuppressWarnings("unchecked") // Casting EMPTY_LIST to List<Transport> is safe here
+                List<Transport> neighborTransports = config.getTransports().getOrDefault(neighbor, (List<Transport>)Collections.EMPTY_LIST);
+                for (int t = 0; t < neighborTransports.size(); ++t) {
+                    Transport transport = neighborTransports.get(t);
                     neighbors.add(new Node(transport.getOrigin(), node));
                 }
             }

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -61,9 +61,7 @@ public class CollisionMap extends SplitFlagMap {
         List<Node> neighbors = new ArrayList<>();
 
         for (Transport transport : config.getTransports().getOrDefault(node.position, new ArrayList<>())) {
-            if (config.useTransport(transport)) {
-                neighbors.add(new TransportNode(transport.getDestination(), node, transport.getWait()));
-            }
+            neighbors.add(new TransportNode(transport.getDestination(), node, transport.getWait()));
         }
 
         boolean[] traversable;

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -2,18 +2,26 @@ package shortestpath.pathfinder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import net.runelite.api.coords.WorldPoint;
 import shortestpath.ShortestPathPlugin;
 import shortestpath.Transport;
 import shortestpath.Util;
 
 public class CollisionMap extends SplitFlagMap {
+
     // Enum.values() makes copies every time which hurts performance in the hotpath
     private static final OrdinalDirection[] ORDINAL_VALUES = OrdinalDirection.values();
+    private static RegionExtent regionExtents = new RegionExtent(0, 0, 0, 0);
 
     public CollisionMap(Map<Integer, byte[]> compressedRegions) {
         super(compressedRegions, 2);
@@ -68,7 +76,7 @@ public class CollisionMap extends SplitFlagMap {
 
         // Transports are pre-filtered by PathfinderConfig.refreshTransportData
         // Thus any transports in the list are guaranteed to be valid per the user's settings
-        for (Transport transport : config.getTransports().getOrDefault(node.position, (List<Transport>)Collections.EMPTY_LIST)) {
+        for (Transport transport : config.getTransports().getOrDefault(node.position, (List<Transport>) Collections.EMPTY_LIST)) {
             neighbors.add(new TransportNode(transport.getDestination(), node, transport.getWait()));
         }
 
@@ -116,18 +124,49 @@ public class CollisionMap extends SplitFlagMap {
     public static CollisionMap fromResources() {
         Map<Integer, byte[]> compressedRegions = new HashMap<>();
         try (ZipInputStream in = new ZipInputStream(ShortestPathPlugin.class.getResourceAsStream("/collision-map.zip"))) {
+            int minX = Integer.MAX_VALUE;
+            int minY = Integer.MAX_VALUE;
+            int maxX = 0;
+            int maxY = 0;
+
             ZipEntry entry;
             while ((entry = in.getNextEntry()) != null) {
                 String[] n = entry.getName().split("_");
+                final int x = Integer.parseInt(n[0]);
+                final int y = Integer.parseInt(n[1]);
+                minX = Math.min(minX, x);
+                minY = Math.min(minY, y);
+                maxX = Math.max(maxX, x);
+                maxY = Math.max(maxY, y);
 
                 compressedRegions.put(
-                        SplitFlagMap.packPosition(Integer.parseInt(n[0]), Integer.parseInt(n[1])),
+                        SplitFlagMap.packPosition(x, y),
                         Util.readAllBytes(in)
                 );
             }
+
+            regionExtents = new RegionExtent(minX, minY, maxX, maxY);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
         return new CollisionMap(compressedRegions);
+    }
+
+    public static RegionExtent getRegionExtents() {
+        return regionExtents;
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    public static class RegionExtent {
+        public final int minX, minY, maxX, maxY;
+
+        public int getWidth() {
+            return maxX - minX;
+        }
+
+        public int getHeight() {
+            return maxY - minY;
+        }
     }
 }

--- a/src/main/java/shortestpath/pathfinder/OrdinalDirection.java
+++ b/src/main/java/shortestpath/pathfinder/OrdinalDirection.java
@@ -1,7 +1,5 @@
 package shortestpath.pathfinder;
 
-import net.runelite.api.coords.WorldPoint;
-
 public enum OrdinalDirection {
     WEST(-1, 0),
     EAST(1, 0),

--- a/src/main/java/shortestpath/pathfinder/OrdinalDirection.java
+++ b/src/main/java/shortestpath/pathfinder/OrdinalDirection.java
@@ -1,5 +1,7 @@
 package shortestpath.pathfinder;
 
+import net.runelite.api.coords.WorldPoint;
+
 public enum OrdinalDirection {
     WEST(-1, 0),
     EAST(1, 0),

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -1,7 +1,12 @@
 package shortestpath.pathfinder;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
 
 import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -50,7 +50,9 @@ public class Pathfinder implements Runnable {
     }
 
     private void addNeighbors(Node node) {
-        for (Node neighbor : config.getMap().getNeighbors(node, config)) {
+        List<Node> nodes = config.getMap().getNeighbors(node, config);
+        for (int i = 0; i < nodes.size(); ++i) {
+            Node neighbor = nodes.get(i);
             if (visited.get(neighbor.position) || (config.isAvoidWilderness() && config.avoidWilderness(node.position, neighbor.position, targetInWilderness))) {
                 continue;
             }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -51,7 +51,7 @@ public class Pathfinder implements Runnable {
 
     private void addNeighbors(Node node) {
         for (Node neighbor : config.getMap().getNeighbors(node, config)) {
-            if (!visited.get(node.position) && config.avoidWilderness(node.position, neighbor.position, targetInWilderness)) {
+            if (visited.get(neighbor.position) || (config.isAvoidWilderness() && config.avoidWilderness(node.position, neighbor.position, targetInWilderness))) {
                 continue;
             }
             if (visited.set(neighbor.position)) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -80,6 +80,9 @@ public class PathfinderConfig {
     }
 
     private void refreshTransportData() {
+        if (!Thread.currentThread().equals(client.getClientThread())) {
+            return; // Has to run on the client thread; data will be refreshed when path finding commences
+        }
         useFairyRings &= !QuestState.NOT_STARTED.equals(Quest.FAIRYTALE_II__CURE_A_QUEEN.getState(client));
 
         transports.clear();

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -44,6 +44,7 @@ public class PathfinderConfig {
     private int strengthLevel;
     private int prayerLevel;
     private int woodcuttingLevel;
+    private int recalculateDistance;
     private Map<Quest, QuestState> questStates = new HashMap<>();
 
     public PathfinderConfig(CollisionMap map, Map<WorldPoint, List<Transport>> transports, Client client,
@@ -59,6 +60,7 @@ public class PathfinderConfig {
 
     public void refresh() {
         calculationCutoff = Duration.ofMillis(config.calculationCutoff() * Constants.GAME_TICK_LENGTH);
+        recalculateDistance = config.recalculateDistance();
         avoidWilderness = config.avoidWilderness();
         useAgilityShortcuts = config.useAgilityShortcuts();
         useGrappleShortcuts = config.useGrappleShortcuts();
@@ -99,20 +101,20 @@ public class PathfinderConfig {
         }
     }
 
-    private boolean isInWilderness(WorldPoint p) {
+    public static boolean isInWilderness(WorldPoint p) {
         return WILDERNESS_ABOVE_GROUND.distanceTo(p) == 0 || WILDERNESS_UNDERGROUND.distanceTo(p) == 0;
     }
 
-    public boolean avoidWilderness(WorldPoint position, WorldPoint neighbor, WorldPoint target) {
-        return avoidWilderness && !isInWilderness(position) && isInWilderness(neighbor) && !isInWilderness(target);
+    public boolean avoidWilderness(WorldPoint position, WorldPoint neighbor, boolean targetInWilderness) {
+        return avoidWilderness && !isInWilderness(position) && isInWilderness(neighbor) && !targetInWilderness;
     }
 
     public boolean isNear(WorldPoint location) {
         if (plugin.isStartPointSet() || client.getLocalPlayer() == null) {
             return true;
         }
-        return config.recalculateDistance() < 0 ||
-               client.getLocalPlayer().getWorldLocation().distanceTo2D(location) <= config.recalculateDistance();
+        return recalculateDistance < 0 ||
+               client.getLocalPlayer().getWorldLocation().distanceTo2D(location) <= recalculateDistance;
     }
 
     private boolean useTransport(Transport transport) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -33,6 +33,7 @@ public class PathfinderConfig {
 
     @Getter
     private Duration calculationCutoff;
+    @Getter
     private boolean avoidWilderness;
     private boolean useAgilityShortcuts;
     private boolean useGrappleShortcuts;

--- a/src/main/java/shortestpath/pathfinder/SplitFlagMap.java
+++ b/src/main/java/shortestpath/pathfinder/SplitFlagMap.java
@@ -14,9 +14,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.zip.GZIPInputStream;
 import shortestpath.Util;
 
+import static net.runelite.api.Constants.REGION_SIZE;
+
 public abstract class SplitFlagMap {
     private static final int MAXIMUM_SIZE = 20 * 1024 * 1024;
-    private static final int REGION_SIZE = 64;
 
     private final LoadingCache<Integer, FlagMap> regionMaps;
     private final int flagCount;

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -1,0 +1,61 @@
+package shortestpath.pathfinder;
+
+import net.runelite.api.coords.WorldPoint;
+
+public class VisitedTiles {
+    private static final int TOTAL_PLANES = 4;
+    private static final int REGION_SIZE = 64;
+
+    // TODO: what is the max number of regions?
+    private static final int REGION_EXTENT_X = 192;
+    private static final int REGION_EXTENT_Y = 256;
+    private final VisitedRegion[] visitedRegions = new VisitedRegion[REGION_EXTENT_X * REGION_EXTENT_Y];
+
+    public boolean get(WorldPoint point) {
+        final int regionIndex = point.getRegionID();
+        final VisitedRegion region = visitedRegions[regionIndex];
+
+        if (region == null) {
+            return false;
+        }
+
+        return region.get(point.getRegionX(), point.getRegionY(), point.getPlane());
+    }
+    public boolean set(WorldPoint point) {
+        final int regionIndex = point.getRegionID();
+        VisitedRegion region = visitedRegions[regionIndex];
+
+        if (region == null) {
+            region = new VisitedRegion();
+            visitedRegions[regionIndex] = region;
+        }
+
+        return region.set(point.getRegionX(), point.getRegionY(), point.getPlane());
+    }
+
+    public void clear() {
+        for (int i = 0; i < visitedRegions.length; ++i) {
+            if (visitedRegions[i] != null) {
+                visitedRegions[i] = null;
+            }
+        }
+    }
+
+    private class VisitedRegion {
+        // This assumes a row is at most 64 tiles and fits in a long
+        private final long[] planes = new long[TOTAL_PLANES * REGION_SIZE];
+
+        // Sets a tile as visited in the tile bitset
+        // Returns true if the tile is unique and hasn't been seen before or false if it was seen before
+        public boolean set(int x, int y, int plane) {
+            final int index = y + plane * REGION_SIZE;
+            boolean unique = (planes[index] & (1L << x)) == 0;
+            planes[index] |= 1L << x;
+            return unique;
+        }
+
+        public boolean get(int x, int y, int plane) {
+            return (planes[y + plane * REGION_SIZE] & (1L << x)) != 0;
+        }
+    }
+}


### PR DESCRIPTION
Optimized pathfinding as much as I could without making any major refactors:

- Preloads all transports at startup and filters transports based on config settings before pathfinding rather than during. This saves a bit of time for each search and makes adding more transports a bit less expensive.
  - Transport options still function the same; `PathfinderConfig.useTransport` already checked if it should use various modes of transport so the checks in `Transport.fromResources` were redundant.
- Optimize data structures:
  - Using a `HashSet` for tracking visited nodes was expensive taking up 50% of the total execution time. I've replaced this with `VisitedTiles` which behaves the same but with significantly less overhead (and fewer allocations :) ).
  - Replaced `LinkedList` with `ArrayDeque`. `ArrayDeque` uses a circular array so inserting elements to the front or back of the queue is free. I've set conservative initial capacities for both queues that should avoid the need to grow either queue during the search.
- Remove `SplitFlagMap.Position` and used a packed Integer instead. Doesn't help performance all too much but significantly cuts back on the amount of data being allocated per search.
  - Using a sparse array instead of a `HashMap` for the `compressedRegion` map would likely speed up lookups but I don't think it's necessary as the cache lookups are the main performance cost.
- Cache `OrdinalDirection.values()` as every call makes an array copy despite the values never changing. This hurt both runtime performance and made many unnecessary allocations.
- `PathfinderConfig.isInWilderness()` is moderately expensive and makes many allocations so I avoid calculating it or cache the target wilderness status when possible.

# Results
Ran through a bunch of different paths short and long in-game to make sure the resulting path is still the same as OSRS's pathfinding.

**Worst-Case** test: from GE to top-left corner of the map in the middle of the ocean
**Short-Case** test: from GE to a point just west 105 tiles away

Ran a few paths before-hand to warm-up the JVM before recording results.
Screenshots are of the Intellij profiler of both CPU Samples and Memory Allocations

System used is an Intel i9-13900K with 64GB DDR5 RAM, OpenJDK 11.0.12.0 (a bit out of date). While not the average system by far, results should scale similarly on other machines.

| Metric | Before (1740a91) | After (6137611) | Difference |
| --- | --- | --- | --- |
**Worst-Case Time** | 2200.5582ms | 1224.3621ms | **976.1961ms**
**Short-Case Time** | 44.2161ms | 28.5745ms | **15.6416ms**
**Allocations** | 3,741,112,192 bytes | 1,314,359,520 bytes | **2,426,752,672 bytes**

## Before Optimizations

**Worst-Case**: 2200.5582ms
**Short-Case**: 44.2161ms

**CPU Samples (Worst-Case):**
<img width="465" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/fb1995dd-619d-4bad-abed-30fee252500b">

**Memory Allocations (Worst-Case):**
<img width="628" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/f18bec65-9e0e-4a7d-9a64-4b4378dbe50f">

## After Optimizations

**Worst-Case**: 1224.3621ms
**Short-Case**: 28.5745ms

**CPU Samples (Worst-Case):**
<img width="392" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/e2b1eb1d-f43e-4332-b056-19dc4c02fd1f">

**Memory Allocations (Worst-Case):**
<img width="613" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/26e4b109-33f3-48ad-b189-10f735d3ae56">
