### PR TITLE
Remove LoadingCache and replace with array

### DIFF
--- a/src/main/java/shortestpath/pathfinder/FlagMap.java
+++ b/src/main/java/shortestpath/pathfinder/FlagMap.java
@@ -2,6 +2,9 @@ package shortestpath.pathfinder;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
+import java.util.Locale;
+
+import static net.runelite.api.Constants.MAX_Z;
 
 public class FlagMap {
     public static final int PLANE_COUNT = 4;
@@ -49,7 +52,7 @@ public class FlagMap {
     }
 
     public boolean get(int x, int y, int z, int flag) {
-        if (x < minX || x > maxX || y < minY || y > maxY || z < 0 || z > PLANE_COUNT - 1) {
+        if (x < minX || x > maxX || y < minY || y > maxY || z < 0 || z >= MAX_Z) {
             return false;
         }
 
@@ -61,8 +64,14 @@ public class FlagMap {
     }
 
     private int index(int x, int y, int z, int flag) {
-        if (x < minX || x > maxX || y < minY || y > maxY || z < 0 || z > PLANE_COUNT - 1 || flag < 0 || flag > flagCount - 1) {
-            throw new IndexOutOfBoundsException(x + " " + y + " " + z);
+        if (x < minX || x > maxX || y < minY || y > maxY || z < 0 || z >= MAX_Z || flag < 0 || flag >= flagCount) {
+            throw new IndexOutOfBoundsException(
+                String.format(Locale.ENGLISH, "[%d,%d,%d,%d] when extents are [>=%d,>=%d,>=%d,>=%d] - [<=%d,<=%d,<%d,<%d]",
+                        x, y, z, flag,
+                        minX, minY, 0, 0,
+                        maxX, maxY, MAX_Z, flagCount
+                )
+            );
         }
 
         return (z * width * height + (y - minY) * width + (x - minX)) * flagCount + flag;

--- a/src/main/java/shortestpath/pathfinder/SplitFlagMap.java
+++ b/src/main/java/shortestpath/pathfinder/SplitFlagMap.java
@@ -13,7 +13,7 @@ import static net.runelite.api.Constants.REGION_SIZE;
 public abstract class SplitFlagMap {
 
     // Size is automatically chosen based on the max extents of the collision data
-    public final FlagMap[] regionMaps;
+    private final FlagMap[] regionMaps;
     private final CollisionMap.RegionExtent regionExtents;
     private final int widthInclusive;
     private final int flagCount;

--- a/src/main/java/shortestpath/pathfinder/SplitFlagMap.java
+++ b/src/main/java/shortestpath/pathfinder/SplitFlagMap.java
@@ -1,56 +1,59 @@
 package shortestpath.pathfinder;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.cache.Weigher;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.zip.GZIPInputStream;
 import shortestpath.Util;
 
 import static net.runelite.api.Constants.REGION_SIZE;
 
 public abstract class SplitFlagMap {
-    private static final int MAXIMUM_SIZE = 20 * 1024 * 1024;
 
-    private final LoadingCache<Integer, FlagMap> regionMaps;
+    // Size is automatically chosen based on the max extents of the collision data
+    public final FlagMap[] regionMaps;
+    private final CollisionMap.RegionExtent regionExtents;
+    private final int widthInclusive;
     private final int flagCount;
 
     public SplitFlagMap(Map<Integer, byte[]> compressedRegions, int flagCount) {
         this.flagCount = flagCount;
-        regionMaps = CacheBuilder
-                .newBuilder()
-                .weigher((Weigher<Integer, FlagMap>) (k, v) -> v.flags.size() / 8)
-                .maximumWeight(MAXIMUM_SIZE)
-                .build(CacheLoader.from(position -> {
-                    byte[] compressedRegion = compressedRegions.get(position);
 
-                    if (compressedRegion == null) {
-                        int x = unpackX(position);
-                        int y = unpackY(position);
-                        return new FlagMap(x * REGION_SIZE, y * REGION_SIZE, (x + 1) * REGION_SIZE - 1, (y + 1) * REGION_SIZE - 1, this.flagCount);
-                    }
+        regionExtents = CollisionMap.getRegionExtents();
+        widthInclusive = regionExtents.getWidth() + 1;
+        final int heightInclusive = regionExtents.getHeight() + 1;
+        regionMaps = new FlagMap[widthInclusive * heightInclusive];
 
-                    try (InputStream in = new GZIPInputStream(new ByteArrayInputStream(compressedRegion))) {
-                        return new FlagMap(Util.readAllBytes(in), this.flagCount);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }));
+        for (Map.Entry<Integer, byte[]> entry : compressedRegions.entrySet()) {
+            final int pos = entry.getKey();
+            final int x = unpackX(pos);
+            final int y = unpackY(pos);
+
+            FlagMap map;
+            try (InputStream in = new GZIPInputStream(new ByteArrayInputStream(entry.getValue()))) {
+                byte[] bytes = Util.readAllBytes(in);
+                map = new FlagMap(bytes, this.flagCount);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+
+            regionMaps[getIndex(x, y)] = map;
+        }
     }
 
     public boolean get(int x, int y, int z, int flag) {
-        try {
-            return regionMaps.get(packPosition(x / REGION_SIZE, y / REGION_SIZE)).get(x, y, z, flag);
-        } catch (ExecutionException e) {
-            throw new UncheckedExecutionException(e);
+        final int index = getIndex(x / REGION_SIZE, y / REGION_SIZE);
+        if (index < 0 || index >= regionMaps.length || regionMaps[index] == null) {
+            return false;
         }
+
+        return regionMaps[index].get(x, y, z, flag);
+    }
+
+    private int getIndex(int regionX, int regionY) {
+        return (regionX - regionExtents.getMinX()) + (regionY - regionExtents.getMinY()) * widthInclusive;
     }
 
     public static int unpackX(int position) {


### PR DESCRIPTION
Part 2 of performance changes. Last performance PR for now; this brings performance to near real-time levels and any further optimizations I've found either degrade readability or may alter path finding.

I noticed the previous `LoadingCache`'s max size was more than the uncompressed collision map data. It appears the max size was set so high due to empty `FlagMap`s with empty full-size bitsets which kept triggering the weigh constraint to load/unload old regions in the cache. This operation is expensive so I decided to look into if it was even necessary at all.

Changes made:
* Remove the `LoadingCache` and replace it with a minimum-size array similar to `VisitedTiles`.
* Regions with no collision data are null and never loaded; this saves the bulk of memory costs.


The total cost of the map now becomes uncompressed collision data + `FlagMap` member variables + 8 bytes per reference which comes out to... 2,903,256 bytes (2.8MB). The previous maximum cache size in bytes was 20,971,520 (20MB) + all of the compressed collision map data. This change actually ends up storing _less_ long-term data overall.

After this, the only other major optimization that I can find is packing all `WorldPoint`'s into ints in the hotpath but that comes at the expense of readability. I've already demo'd that change and found it reduced total allocations down to ~282MB with avoid wilderness off.

Hopefully after these performance changes, adding more transports/teleports or other features should be more feasible 😄

# Results

**Worst-Case:** GE to top-left corner of the map in the ocean
**Short-Case:** GE to a point west 100 tiles away

| Metric | Before (f596d1d) | After (bef718d) | After (Avoid Wilderness) | Difference |
| --- | --- | --- | --- | --- |
**Worst-Case Time** | 1213.4845ms | 174.7856ms | 151.2286ms | **1038.6989ms** -<br/>**1062.2559ms**
**Short-Case Time** | 28.5309ms | 2.5727ms | 2.1449ms | **25.9582ms** -<br/>**26.386ms**
**Allocations** | 1,286,051,528 bytes | 503,251,296 bytes | 728,338,632 bytes | **782,800,232 bytes** -<br/>**557,712,896 bytes**

## Before Optimization
**Note:** Didn't measure with avoid wilderness on as the difference is not noticeable over noise. Difference in allocation size are the same with/without this PR so see the After results below.

**Worst-Case Time**: 1213.4845ms
**Short-Case Time**: 28.5309ms

**CPU Samples:**
<img width="519" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/5f7047f9-508a-4a2d-8ffb-3bc29a39201f">

**Memory Allocations:**
<img width="601" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/44e826d8-e965-4b31-99fc-548f6b0667aa">

## After Optimization
**Worst-Case Time**: 174.7856ms
**Short-Case Time**: 2.5727ms

Additionally, now that path finding is so quick, there is a clear difference between having avoid wilderness on/off:
**Worst-Case Time** (Avoid Wilderness): 151.2286ms
**Short-Case Time** (Avoid Wilderness): 2.1449ms

Note: for CPU Samples, with/without avoid wilderness didn't make a difference in the call tree as it doesn't make enough samples
**CPU Samples:**
<img width="638" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/9fcc9a3d-3656-49ab-b506-2274c7d5d63a">

**Memory Allocations:**
<img width="542" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/481c9cbd-ab7d-4c7e-b03e-84bc40b31fcd">

**Memory Allocations (Avoid Wilderness):**
<img width="613" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/394e99be-6af0-491f-8a73-2f45315e2079">
