### PR TITLE
Refactor: Pack WorldPoint into ints

### DIFF
--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -19,6 +19,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.worldmap.WorldMapOverlay;
+import shortestpath.pathfinder.CollisionMap;
 
 public class PathMapOverlay extends Overlay {
     private final Client client;
@@ -55,10 +56,11 @@ public class PathMapOverlay extends Overlay {
         if (config.drawCollisionMap()) {
             graphics.setColor(config.colourCollisionMap());
             Rectangle extent = getWorldMapExtent(client.getWidget(WidgetInfo.WORLD_MAP_VIEW).getBounds());
+            final CollisionMap map = plugin.getMap();
             final int z = client.getPlane();
             for (int x = extent.x; x < (extent.x + extent.width + 1); x++) {
                 for (int y = extent.y - extent.height; y < (extent.y + 1); y++) {
-                    if (plugin.getMap().isBlocked(x, y, z)) {
+                    if (map.isBlocked(x, y, z)) {
                         drawOnMap(graphics, new WorldPoint(x, y, z), false);
                     }
                 }

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -19,6 +19,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
+import shortestpath.pathfinder.CollisionMap;
 
 public class PathTileOverlay extends Overlay {
     private final Client client;
@@ -67,6 +68,7 @@ public class PathTileOverlay extends Overlay {
     }
 
     private void renderCollisionMap(Graphics2D graphics) {
+        CollisionMap map = plugin.getMap();
         for (Tile[] row : client.getScene().getTiles()[client.getPlane()]) {
             for (Tile tile : row) {
                 if (tile == null) {
@@ -85,12 +87,12 @@ public class PathTileOverlay extends Overlay {
                 int y = location.getY();
                 int z = location.getPlane();
 
-                String s = (!plugin.getMap().n(x, y, z) ? "n" : "") +
-                        (!plugin.getMap().s(x, y, z) ? "s" : "") +
-                        (!plugin.getMap().e(x, y, z) ? "e" : "") +
-                        (!plugin.getMap().w(x, y, z) ? "w" : "");
+                String s = (!map.n(x, y, z) ? "n" : "") +
+                        (!map.s(x, y, z) ? "s" : "") +
+                        (!map.e(x, y, z) ? "e" : "") +
+                        (!map.w(x, y, z) ? "w" : "");
 
-                if (plugin.getMap().isBlocked(x, y, z)) {
+                if (map.isBlocked(x, y, z)) {
                     graphics.setColor(config.colourCollisionMap());
                     graphics.fill(tilePolygon);
                 }

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -130,7 +130,7 @@ public class ShortestPathPlugin extends Plugin {
         SplitFlagMap map = SplitFlagMap.fromResources();
         Map<WorldPoint, List<Transport>> transports = Transport.loadAllFromResources();
 
-        pathfinderConfig = new PathfinderConfig(map, transports, client, config, this);
+        pathfinderConfig = new PathfinderConfig(map, transports, client, config);
 
         overlayManager.add(pathOverlay);
         overlayManager.add(pathMinimapOverlay);

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -48,6 +48,7 @@ import net.runelite.client.util.Text;
 import shortestpath.pathfinder.CollisionMap;
 import shortestpath.pathfinder.Pathfinder;
 import shortestpath.pathfinder.PathfinderConfig;
+import shortestpath.pathfinder.SplitFlagMap;
 
 @PluginDescriptor(
     name = "Shortest Path",
@@ -126,7 +127,7 @@ public class ShortestPathPlugin extends Plugin {
 
     @Override
     protected void startUp() {
-        CollisionMap map = CollisionMap.fromResources();
+        SplitFlagMap map = SplitFlagMap.fromResources();
         Map<WorldPoint, List<Transport>> transports = Transport.loadAllFromResources();
 
         pathfinderConfig = new PathfinderConfig(map, transports, client, config, this);

--- a/src/main/java/shortestpath/WorldPointUtil.java
+++ b/src/main/java/shortestpath/WorldPointUtil.java
@@ -1,0 +1,81 @@
+package shortestpath;
+
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+
+public class WorldPointUtil {
+    public static int packWorldPoint(WorldPoint point) {
+        return packWorldPoint(point.getX(), point.getY(), point.getPlane());
+    }
+
+    // Packs a world point into a single int
+    // First 15 bits are x, next 15 are y, last 2 bits are the plane
+    public static int packWorldPoint(int x, int y, int plane) {
+        return (x & 0x7FFF) | ((y & 0x7FFF) << 15) | ((plane & 0x3) << 30);
+    }
+
+    public static WorldPoint unpackWorldPoint(int packedPoint) {
+        final int x = unpackWorldX(packedPoint);
+        final int y = unpackWorldY(packedPoint);
+        final int plane = unpackWorldPlane(packedPoint);
+        return new WorldPoint(x, y, plane);
+    }
+
+    public static int unpackWorldX(int packedPoint) {
+        return packedPoint & 0x7FFF;
+    }
+
+    public static int unpackWorldY(int packedPoint) {
+        return (packedPoint >> 15) & 0x7FFF;
+    }
+
+    public static int unpackWorldPlane(int packedPoint) {
+        return (packedPoint >> 30) & 0x3;
+    }
+
+    public static int distanceBetween(int previousPacked, int currentPacked, int diagonal) {
+        final int previousX = WorldPointUtil.unpackWorldX(previousPacked);
+        final int previousY = WorldPointUtil.unpackWorldY(previousPacked);
+        final int currentX = WorldPointUtil.unpackWorldX(currentPacked);
+        final int currentY = WorldPointUtil.unpackWorldY(currentPacked);
+        final int dx = Math.abs(previousX - currentX);
+        final int dy = Math.abs(previousY - currentY);
+
+        if (diagonal == 1) {
+            return Math.max(dx, dy);
+        } else if (diagonal == 2) {
+            return dx + dy;
+        }
+
+        return Integer.MAX_VALUE;
+    }
+
+    public static int distanceBetween(int previousPacked, int currentPacked) {
+        return distanceBetween(previousPacked, currentPacked, 1);
+    }
+
+    public static int distanceBetween(WorldPoint previous, WorldPoint current) {
+        return distanceBetween(WorldPointUtil.packWorldPoint(previous), WorldPointUtil.packWorldPoint(current), 1);
+    }
+
+    public static int distanceBetween(WorldPoint previous, WorldPoint current, int diagonal) {
+        return distanceBetween(WorldPointUtil.packWorldPoint(previous), WorldPointUtil.packWorldPoint(current), diagonal);
+    }
+
+    // Matches WorldArea.distanceTo
+    public static int distanceToArea(int packedPoint, WorldArea area) {
+        final int plane = unpackWorldPlane(packedPoint);
+        if (area.getPlane() != plane) {
+            return Integer.MAX_VALUE;
+        }
+
+        final int y = unpackWorldY(packedPoint);
+        final int x = unpackWorldX(packedPoint);
+        final int areaMaxX = area.getX() + area.getWidth() - 1;
+        final int areaMaxY = area.getY() + area.getHeight() - 1;
+        final int dx = Math.max(Math.max(area.getX() - x, 0), x - areaMaxX);
+        final int dy = Math.max(Math.max(area.getY() - y, 0), y - areaMaxY);
+
+        return Math.max(dx, dy);
+    }
+}

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -1,30 +1,25 @@
 package shortestpath.pathfinder;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import shortestpath.ShortestPathPlugin;
 import shortestpath.Transport;
-import shortestpath.Util;
 import shortestpath.WorldPointUtil;
 
-public class CollisionMap extends SplitFlagMap {
+public class CollisionMap {
 
     // Enum.values() makes copies every time which hurts performance in the hotpath
     private static final OrdinalDirection[] ORDINAL_VALUES = OrdinalDirection.values();
-    private static RegionExtent regionExtents = new RegionExtent(0, 0, 0, 0);
 
-    public CollisionMap(Map<Integer, byte[]> compressedRegions) {
-        super(compressedRegions, 2);
+    private final SplitFlagMap collisionData;
+
+    public CollisionMap(SplitFlagMap collisionData) {
+        this.collisionData = collisionData;
+    }
+
+    public boolean get(int x, int y, int z, int flag) {
+        return collisionData.get(x, y, z, flag);
     }
 
     public boolean n(int x, int y, int z) {
@@ -70,12 +65,16 @@ public class CollisionMap extends SplitFlagMap {
         return WorldPointUtil.packWorldPoint(x + direction.x, y + direction.y, plane);
     }
 
+    // This is only safe if pathfinding is single-threaded
+    private final List<Node> neighbors = new ArrayList<>(16);
+    private final boolean[] traversable = new boolean[8];
+
     public List<Node> getNeighbors(Node node, PathfinderConfig config) {
         final int x = WorldPointUtil.unpackWorldX(node.packedPosition);
         final int y = WorldPointUtil.unpackWorldY(node.packedPosition);
         final int z = WorldPointUtil.unpackWorldPlane(node.packedPosition);
 
-        List<Node> neighbors = new ArrayList<>();
+        neighbors.clear();
 
         @SuppressWarnings("unchecked") // Casting EMPTY_LIST to List<Transport> is safe here
         List<Transport> transports = config.getTransportsPacked().getOrDefault(node.packedPosition, (List<Transport>)Collections.EMPTY_LIST);
@@ -87,7 +86,6 @@ public class CollisionMap extends SplitFlagMap {
             neighbors.add(new TransportNode(transport.getDestination(), node, transport.getWait()));
         }
 
-        boolean[] traversable;
         if (isBlocked(x, y, z)) {
             boolean westBlocked = isBlocked(x - 1, y, z);
             boolean eastBlocked = isBlocked(x + 1, y, z);
@@ -97,20 +95,23 @@ public class CollisionMap extends SplitFlagMap {
             boolean southEastBlocked = isBlocked(x + 1, y - 1, z);
             boolean northWestBlocked = isBlocked(x - 1, y + 1, z);
             boolean northEastBlocked = isBlocked(x + 1, y + 1, z);
-            traversable = new boolean[] {
-                !westBlocked,
-                !eastBlocked,
-                !southBlocked,
-                !northBlocked,
-                !southWestBlocked && !westBlocked && !southBlocked,
-                !southEastBlocked && !eastBlocked && !southBlocked,
-                !northWestBlocked && !westBlocked && !northBlocked,
-                !northEastBlocked && !eastBlocked && !northBlocked
-            };
+            traversable[0] = !westBlocked;
+            traversable[1] = !eastBlocked;
+            traversable[2] = !southBlocked;
+            traversable[3] = !northBlocked;
+            traversable[4] = !southWestBlocked && !westBlocked && !southBlocked;
+            traversable[5] = !southEastBlocked && !eastBlocked && !southBlocked;
+            traversable[6] = !northWestBlocked && !westBlocked && !northBlocked;
+            traversable[7] = !northEastBlocked && !eastBlocked && !northBlocked;
         } else {
-            traversable = new boolean[] {
-                w(x, y, z), e(x, y, z), s(x, y, z), n(x, y, z), sw(x, y, z), se(x, y, z), nw(x, y, z), ne(x, y, z)
-            };
+            traversable[0] = w(x, y, z);
+            traversable[1] = e(x, y, z);
+            traversable[2] = s(x, y, z);
+            traversable[3] = n(x, y, z);
+            traversable[4] = sw(x, y, z);
+            traversable[5] = se(x, y, z);
+            traversable[6] = nw(x, y, z);
+            traversable[7] = ne(x, y, z);
         }
 
         for (int i = 0; i < traversable.length; i++) {
@@ -129,54 +130,5 @@ public class CollisionMap extends SplitFlagMap {
         }
 
         return neighbors;
-    }
-
-    public static CollisionMap fromResources() {
-        Map<Integer, byte[]> compressedRegions = new HashMap<>();
-        try (ZipInputStream in = new ZipInputStream(ShortestPathPlugin.class.getResourceAsStream("/collision-map.zip"))) {
-            int minX = Integer.MAX_VALUE;
-            int minY = Integer.MAX_VALUE;
-            int maxX = 0;
-            int maxY = 0;
-
-            ZipEntry entry;
-            while ((entry = in.getNextEntry()) != null) {
-                String[] n = entry.getName().split("_");
-                final int x = Integer.parseInt(n[0]);
-                final int y = Integer.parseInt(n[1]);
-                minX = Math.min(minX, x);
-                minY = Math.min(minY, y);
-                maxX = Math.max(maxX, x);
-                maxY = Math.max(maxY, y);
-
-                compressedRegions.put(
-                        SplitFlagMap.packPosition(x, y),
-                        Util.readAllBytes(in)
-                );
-            }
-
-            regionExtents = new RegionExtent(minX, minY, maxX, maxY);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        return new CollisionMap(compressedRegions);
-    }
-
-    public static RegionExtent getRegionExtents() {
-        return regionExtents;
-    }
-
-    @RequiredArgsConstructor
-    @Getter
-    public static class RegionExtent {
-        public final int minX, minY, maxX, maxY;
-
-        public int getWidth() {
-            return maxX - minX;
-        }
-
-        public int getHeight() {
-            return maxY - minY;
-        }
     }
 }

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -12,7 +12,6 @@ import java.util.zip.ZipInputStream;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.runelite.api.coords.WorldPoint;
 import shortestpath.ShortestPathPlugin;
 import shortestpath.Transport;
 import shortestpath.Util;

--- a/src/main/java/shortestpath/pathfinder/Node.java
+++ b/src/main/java/shortestpath/pathfinder/Node.java
@@ -4,20 +4,31 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import net.runelite.api.coords.WorldPoint;
+import shortestpath.WorldPointUtil;
 
 public class Node {
-    public final WorldPoint position;
+    public final int packedPosition;
     public final Node previous;
     public final int cost;
 
     public Node(WorldPoint position, Node previous, int wait) {
-        this.position = position;
+        this.packedPosition = WorldPointUtil.packWorldPoint(position);
         this.previous = previous;
-        this.cost = cost(previous, position, wait);
+        this.cost = cost(previous, wait);
     }
 
     public Node(WorldPoint position, Node previous) {
         this(position, previous, 0);
+    }
+
+    public Node(int packedPosition, Node previous, int wait) {
+        this.packedPosition = packedPosition;
+        this.previous = previous;
+        this.cost = cost(previous, wait);
+    }
+
+    public Node(int packedPosition, Node previous) {
+        this(packedPosition, previous, 0);
     }
 
     public List<WorldPoint> getPath() {
@@ -25,44 +36,41 @@ public class Node {
         Node node = this;
 
         while (node != null) {
-            path.add(0, node.position);
+            WorldPoint position = WorldPointUtil.unpackWorldPoint(node.packedPosition);
+            path.add(0, position);
             node = node.previous;
         }
 
         return new ArrayList<>(path);
     }
 
-    private static int cost(Node previous, WorldPoint current, int wait) {
+    public List<Integer> getPathPacked() {
+        List<Integer> path = new LinkedList<>();
+        Node node = this;
+
+        while (node != null) {
+            path.add(0, node.packedPosition);
+            node = node.previous;
+        }
+
+        return new ArrayList<>(path);
+    }
+
+    private int cost(Node previous, int wait) {
         int previousCost = 0;
         int distance = 0;
 
         if (previous != null) {
             previousCost = previous.cost;
-            distance = distanceBetween(previous.position, current);
-
-            boolean isTransport = distance > 1 || previous.position.getPlane() != current.getPlane();
+            distance = WorldPointUtil.distanceBetween(previous.packedPosition, packedPosition);
+            final int previousPlane = WorldPointUtil.unpackWorldPlane(previous.packedPosition);
+            final int currentPlane = WorldPointUtil.unpackWorldPlane(previous.packedPosition);
+            boolean isTransport = distance > 1 || previousPlane != currentPlane;
             if (isTransport) {
                 distance = wait;
             }
         }
 
         return previousCost + distance;
-    }
-
-    public static int distanceBetween(WorldPoint previous, WorldPoint current, int diagonal) {
-        int dx = Math.abs(previous.getX() - current.getX());
-        int dy = Math.abs(previous.getY() - current.getY());
-
-        if (diagonal == 1) {
-            return Math.max(dx, dy);
-        } else if (diagonal == 2) {
-            return dx + dy;
-        }
-
-        return Integer.MAX_VALUE;
-    }
-
-    public static int distanceBetween(WorldPoint previous, WorldPoint current) {
-        return distanceBetween(previous, current, 1);
     }
 }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -25,6 +25,7 @@ public class Pathfinder implements Runnable {
     private final int targetPacked;
 
     private final PathfinderConfig config;
+    private final CollisionMap map;
     private final boolean targetInWilderness;
 
     // Capacities should be enough to store all nodes without requiring the queue to grow
@@ -40,6 +41,7 @@ public class Pathfinder implements Runnable {
 
     public Pathfinder(PathfinderConfig config, WorldPoint start, WorldPoint target) {
         this.config = config;
+        this.map = config.getMap();
         this.start = start;
         this.target = target;
         startPacked = WorldPointUtil.packWorldPoint(start);
@@ -72,7 +74,7 @@ public class Pathfinder implements Runnable {
     }
 
     private void addNeighbors(Node node) {
-        List<Node> nodes = config.getMap().getNeighbors(node, config);
+        List<Node> nodes = map.getNeighbors(node, config);
         for (int i = 0; i < nodes.size(); ++i) {
             Node neighbor = nodes.get(i);
             if (visited.get(neighbor.packedPosition) || (config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness))) {

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -59,7 +59,6 @@ public class Pathfinder implements Runnable {
         cancelled.set(true);
     }
 
-
     public List<WorldPoint> getPath() {
         Node lastNode = bestLastNode; // For thread safety, read bestLastNode once
         if (lastNode == null) {
@@ -68,6 +67,7 @@ public class Pathfinder implements Runnable {
 
         if (pathNeedsUpdate) {
             path = lastNode.getPath();
+            pathNeedsUpdate = false;
         }
 
         return path;

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -21,7 +21,6 @@ public class Pathfinder implements Runnable {
     @Getter
     private final WorldPoint target;
 
-    private final int startPacked;
     private final int targetPacked;
 
     private final PathfinderConfig config;
@@ -44,7 +43,6 @@ public class Pathfinder implements Runnable {
         this.map = config.getMap();
         this.start = start;
         this.target = target;
-        startPacked = WorldPointUtil.packWorldPoint(start);
         targetPacked = WorldPointUtil.packWorldPoint(target);
         targetInWilderness = PathfinderConfig.isInWilderness(target);
         
@@ -96,7 +94,7 @@ public class Pathfinder implements Runnable {
 
         int bestDistance = Integer.MAX_VALUE;
         long bestHeuristic = Integer.MAX_VALUE;
-        long cutoffDurationMillis = config.getCalculationCutoff().toMillis();
+        long cutoffDurationMillis = config.getCalculationCutoffMillis();
         long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
 
         while (!cancelled.get() && (!boundary.isEmpty() || !pending.isEmpty())) {

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -1,7 +1,6 @@
 package shortestpath.pathfinder;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -1,8 +1,8 @@
 package shortestpath.pathfinder;
 
-import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.Getter;
 import net.runelite.api.coords.WorldPoint;
+import shortestpath.WorldPointUtil;
 
 public class Pathfinder implements Runnable {
     private AtomicBoolean done = new AtomicBoolean();
@@ -20,6 +21,10 @@ public class Pathfinder implements Runnable {
     private final WorldPoint start;
     @Getter
     private final WorldPoint target;
+
+    private final int startPacked;
+    private final int targetPacked;
+
     private final PathfinderConfig config;
     private final boolean targetInWilderness;
 
@@ -29,13 +34,17 @@ public class Pathfinder implements Runnable {
     private final Queue<Node> pending = new PriorityQueue<>(256);
     private final VisitedTiles visited = new VisitedTiles();
 
-    @Getter
-    private List<WorldPoint> path = new ArrayList<>();
+    @SuppressWarnings("unchecked") // Casting EMPTY_LIST is safe here
+    private List<WorldPoint> path = (List<WorldPoint>)Collections.EMPTY_LIST;
+    private boolean pathNeedsUpdate = false;
+    private Node bestLastNode;
 
     public Pathfinder(PathfinderConfig config, WorldPoint start, WorldPoint target) {
         this.config = config;
         this.start = start;
         this.target = target;
+        startPacked = WorldPointUtil.packWorldPoint(start);
+        targetPacked = WorldPointUtil.packWorldPoint(target);
         targetInWilderness = PathfinderConfig.isInWilderness(target);
         
         new Thread(this).start();
@@ -49,14 +58,28 @@ public class Pathfinder implements Runnable {
         cancelled.set(true);
     }
 
+
+    public List<WorldPoint> getPath() {
+        Node lastNode = bestLastNode; // For thread safety, read bestLastNode once
+        if (lastNode == null) {
+            return path;
+        }
+
+        if (pathNeedsUpdate) {
+            path = lastNode.getPath();
+        }
+
+        return path;
+    }
+
     private void addNeighbors(Node node) {
         List<Node> nodes = config.getMap().getNeighbors(node, config);
         for (int i = 0; i < nodes.size(); ++i) {
             Node neighbor = nodes.get(i);
-            if (visited.get(neighbor.position) || (config.isAvoidWilderness() && config.avoidWilderness(node.position, neighbor.position, targetInWilderness))) {
+            if (visited.get(neighbor.packedPosition) || (config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness))) {
                 continue;
             }
-            if (visited.set(neighbor.position)) {
+            if (visited.set(neighbor.packedPosition)) {
                 if (neighbor instanceof TransportNode) {
                     pending.add(neighbor);
                 } else {
@@ -72,7 +95,8 @@ public class Pathfinder implements Runnable {
 
         int bestDistance = Integer.MAX_VALUE;
         long bestHeuristic = Integer.MAX_VALUE;
-        Instant cutoffTime = Instant.now().plus(config.getCalculationCutoff());
+        long cutoffDurationMillis = config.getCalculationCutoff().toMillis();
+        long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
 
         while (!cancelled.get() && (!boundary.isEmpty() || !pending.isEmpty())) {
             Node node = boundary.peekFirst();
@@ -85,21 +109,23 @@ public class Pathfinder implements Runnable {
 
             node = boundary.removeFirst();
 
-            if (node.position.equals(target) || !config.isNear(start)) {
-                path = node.getPath();
+            if (node.packedPosition == targetPacked || !config.isNear(start)) {
+                bestLastNode = node;
+                pathNeedsUpdate = true;
                 break;
             }
 
-            int distance = Node.distanceBetween(node.position, target);
-            long heuristic = distance + Node.distanceBetween(node.position, target, 2);
+            int distance = WorldPointUtil.distanceBetween(node.packedPosition, targetPacked);
+            long heuristic = distance + WorldPointUtil.distanceBetween(node.packedPosition, targetPacked, 2);
             if (heuristic < bestHeuristic || (heuristic <= bestHeuristic && distance < bestDistance)) {
-                path = node.getPath();
+                bestLastNode = node;
+                pathNeedsUpdate = true;
                 bestDistance = distance;
                 bestHeuristic = heuristic;
-                cutoffTime = Instant.now().plus(config.getCalculationCutoff());
+                cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
             }
 
-            if (Instant.now().isAfter(cutoffTime)) {
+            if (System.currentTimeMillis() > cutoffTimeMillis) {
                 break;
             }
 

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -110,7 +110,7 @@ public class Pathfinder implements Runnable {
 
             node = boundary.removeFirst();
 
-            if (node.packedPosition == targetPacked || !config.isNear(start)) {
+            if (node.packedPosition == targetPacked) {
                 bestLastNode = node;
                 pathNeedsUpdate = true;
                 break;

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -23,8 +23,8 @@ public class PathfinderConfig {
     private static final WorldArea WILDERNESS_ABOVE_GROUND = new WorldArea(2944, 3523, 448, 448, 0);
     private static final WorldArea WILDERNESS_UNDERGROUND = new WorldArea(2944, 9918, 320, 442, 0);
 
-    @Getter
-    private final CollisionMap map;
+    private final SplitFlagMap mapData;
+    private final ThreadLocal<CollisionMap> map;
     private final Map<WorldPoint, List<Transport>> allTransports;
     @Getter
     private Map<WorldPoint, List<Transport>> transports;
@@ -54,9 +54,10 @@ public class PathfinderConfig {
     private int recalculateDistance;
     private Map<Quest, QuestState> questStates = new HashMap<>();
 
-    public PathfinderConfig(CollisionMap map, Map<WorldPoint, List<Transport>> transports, Client client,
+    public PathfinderConfig(SplitFlagMap mapData, Map<WorldPoint, List<Transport>> transports, Client client,
                             ShortestPathConfig config, ShortestPathPlugin plugin) {
-        this.map = map;
+        this.mapData = mapData;
+        this.map = ThreadLocal.withInitial(() -> new CollisionMap(this.mapData));
         this.allTransports = transports;
         this.transports = new HashMap<>();
         this.transportsPacked = new HashMap<>();
@@ -64,6 +65,10 @@ public class PathfinderConfig {
         this.config = config;
         this.plugin = plugin;
         refresh();
+    }
+
+    public CollisionMap getMap() {
+        return map.get();
     }
 
     public void refresh() {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -99,6 +99,7 @@ public class PathfinderConfig {
         useFairyRings &= !QuestState.NOT_STARTED.equals(Quest.FAIRYTALE_II__CURE_A_QUEEN.getState(client));
 
         transports.clear();
+        transportsPacked.clear();
         for (Map.Entry<WorldPoint, List<Transport>> entry : allTransports.entrySet()) {
             List<Transport> usableTransports = new ArrayList<>(entry.getValue().size());
             for (Transport transport : entry.getValue()) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -51,7 +51,6 @@ public class PathfinderConfig {
     private int strengthLevel;
     private int prayerLevel;
     private int woodcuttingLevel;
-    private int recalculateDistance;
     private Map<Quest, QuestState> questStates = new HashMap<>();
 
     public PathfinderConfig(SplitFlagMap mapData, Map<WorldPoint, List<Transport>> transports, Client client,
@@ -73,7 +72,6 @@ public class PathfinderConfig {
 
     public void refresh() {
         calculationCutoff = Duration.ofMillis(config.calculationCutoff() * Constants.GAME_TICK_LENGTH);
-        recalculateDistance = config.recalculateDistance();
         avoidWilderness = config.avoidWilderness();
         useAgilityShortcuts = config.useAgilityShortcuts();
         useGrappleShortcuts = config.useGrappleShortcuts();
@@ -135,16 +133,6 @@ public class PathfinderConfig {
 
     public boolean avoidWilderness(int packedPosition, int packedNeightborPosition, boolean targetInWilderness) {
         return avoidWilderness && !isInWilderness(packedPosition) && isInWilderness(packedNeightborPosition) && !targetInWilderness;
-    }
-
-    public boolean isNear(WorldPoint location) {
-        if (plugin.isStartPointSet() || client.getLocalPlayer() == null) {
-            return true;
-        }
-        return recalculateDistance < 0 ||
-            (client.isInInstancedRegion() ?
-                WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()) :
-                client.getLocalPlayer().getWorldLocation()).distanceTo2D(location) <= recalculateDistance;
     }
 
     private boolean useTransport(Transport transport) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -1,6 +1,5 @@
 package shortestpath.pathfinder;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -15,7 +14,6 @@ import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import shortestpath.ShortestPathConfig;
-import shortestpath.ShortestPathPlugin;
 import shortestpath.Transport;
 import shortestpath.WorldPointUtil;
 
@@ -123,10 +121,6 @@ public class PathfinderConfig {
 
     public static boolean isInWilderness(int packedPoint) {
         return WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_ABOVE_GROUND) == 0 || WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_UNDERGROUND) == 0;
-    }
-
-    public boolean avoidWilderness(WorldPoint position, WorldPoint neighbor, boolean targetInWilderness) {
-        return avoidWilderness && !isInWilderness(position) && isInWilderness(neighbor) && !targetInWilderness;
     }
 
     public boolean avoidWilderness(int packedPosition, int packedNeightborPosition, boolean targetInWilderness) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -35,10 +35,9 @@ public class PathfinderConfig {
 
     private final Client client;
     private final ShortestPathConfig config;
-    private final ShortestPathPlugin plugin;
 
     @Getter
-    private Duration calculationCutoff;
+    private long calculationCutoffMillis;
     @Getter
     private boolean avoidWilderness;
     private boolean useAgilityShortcuts;
@@ -54,7 +53,7 @@ public class PathfinderConfig {
     private Map<Quest, QuestState> questStates = new HashMap<>();
 
     public PathfinderConfig(SplitFlagMap mapData, Map<WorldPoint, List<Transport>> transports, Client client,
-                            ShortestPathConfig config, ShortestPathPlugin plugin) {
+                            ShortestPathConfig config) {
         this.mapData = mapData;
         this.map = ThreadLocal.withInitial(() -> new CollisionMap(this.mapData));
         this.allTransports = transports;
@@ -62,7 +61,6 @@ public class PathfinderConfig {
         this.transportsPacked = new HashMap<>();
         this.client = client;
         this.config = config;
-        this.plugin = plugin;
         refresh();
     }
 
@@ -71,7 +69,7 @@ public class PathfinderConfig {
     }
 
     public void refresh() {
-        calculationCutoff = Duration.ofMillis(config.calculationCutoff() * Constants.GAME_TICK_LENGTH);
+        calculationCutoffMillis = config.calculationCutoff() * Constants.GAME_TICK_LENGTH;
         avoidWilderness = config.avoidWilderness();
         useAgilityShortcuts = config.useAgilityShortcuts();
         useGrappleShortcuts = config.useGrappleShortcuts();

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -1,6 +1,5 @@
 package shortestpath.pathfinder;
 
-import net.runelite.api.coords.WorldPoint;
 import shortestpath.WorldPointUtil;
 
 import static net.runelite.api.Constants.MAX_Z;

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -7,13 +7,13 @@ import static net.runelite.api.Constants.MAX_Z;
 import static net.runelite.api.Constants.REGION_SIZE;
 
 public class VisitedTiles {
-    private final CollisionMap.RegionExtent regionExtents;
+    private final SplitFlagMap.RegionExtent regionExtents;
     private final int widthInclusive;
 
     private final VisitedRegion[] visitedRegions;
 
     public VisitedTiles() {
-        regionExtents = CollisionMap.getRegionExtents();
+        regionExtents = SplitFlagMap.getRegionExtents();
         widthInclusive = regionExtents.getWidth() + 1;
         final int heightInclusive = regionExtents.getHeight() + 1;
 

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -20,10 +20,6 @@ public class VisitedTiles {
         visitedRegions = new VisitedRegion[widthInclusive * heightInclusive];
     }
 
-    public boolean get(WorldPoint point) {
-        return get(point.getX(), point.getY(), point.getPlane());
-    }
-
     public boolean get(int packedPoint) {
         final int x = WorldPointUtil.unpackWorldX(packedPoint);
         final int y = WorldPointUtil.unpackWorldY(packedPoint);
@@ -43,10 +39,6 @@ public class VisitedTiles {
         }
 
         return region.get(x % REGION_SIZE, y % REGION_SIZE, plane);
-    }
-
-    public boolean set(WorldPoint point) {
-        return set(point.getX(), point.getY(), point.getPlane());
     }
 
     public boolean set(int packedPoint) {

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -1,6 +1,7 @@
 package shortestpath.pathfinder;
 
 import net.runelite.api.coords.WorldPoint;
+import shortestpath.WorldPointUtil;
 
 import static net.runelite.api.Constants.MAX_Z;
 import static net.runelite.api.Constants.REGION_SIZE;
@@ -20,7 +21,18 @@ public class VisitedTiles {
     }
 
     public boolean get(WorldPoint point) {
-        final int regionIndex = getRegionIndex(point.getX() / REGION_SIZE, point.getY() / REGION_SIZE);
+        return get(point.getX(), point.getY(), point.getPlane());
+    }
+
+    public boolean get(int packedPoint) {
+        final int x = WorldPointUtil.unpackWorldX(packedPoint);
+        final int y = WorldPointUtil.unpackWorldY(packedPoint);
+        final int plane = WorldPointUtil.unpackWorldPlane(packedPoint);
+        return get(x, y, plane);
+    }
+
+    public boolean get(int x, int y, int plane) {
+        final int regionIndex = getRegionIndex(x / REGION_SIZE, y / REGION_SIZE);
         if (regionIndex < 0 || regionIndex >= visitedRegions.length) {
             return true; // Region is out of bounds; report that it's been visited to avoid exploring it further
         }
@@ -30,11 +42,22 @@ public class VisitedTiles {
             return false;
         }
 
-        return region.get(point.getRegionX(), point.getRegionY(), point.getPlane());
+        return region.get(x % REGION_SIZE, y % REGION_SIZE, plane);
     }
 
     public boolean set(WorldPoint point) {
-        final int regionIndex = getRegionIndex(point.getX() / REGION_SIZE, point.getY() / REGION_SIZE);
+        return set(point.getX(), point.getY(), point.getPlane());
+    }
+
+    public boolean set(int packedPoint) {
+        final int x = WorldPointUtil.unpackWorldX(packedPoint);
+        final int y = WorldPointUtil.unpackWorldY(packedPoint);
+        final int plane = WorldPointUtil.unpackWorldPlane(packedPoint);
+        return set(x, y, plane);
+    }
+
+    public boolean set(int x, int y, int plane) {
+        final int regionIndex = getRegionIndex(x / REGION_SIZE, y / REGION_SIZE);
         if (regionIndex < 0 || regionIndex >= visitedRegions.length) {
             return false; // Region is out of bounds; report that it's been visited to avoid exploring it further
         }
@@ -45,7 +68,7 @@ public class VisitedTiles {
             visitedRegions[regionIndex] = region;
         }
 
-        return region.set(point.getRegionX(), point.getRegionY(), point.getPlane());
+        return region.set(x % REGION_SIZE, y % REGION_SIZE, plane);
     }
 
     public void clear() {

--- a/src/test/java/pathfinder/WorldPointTests.java
+++ b/src/test/java/pathfinder/WorldPointTests.java
@@ -1,0 +1,37 @@
+package pathfinder;
+
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import shortestpath.WorldPointUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WorldPointTests {
+    private static final WorldArea WILDERNESS_ABOVE_GROUND = new WorldArea(2944, 3523, 448, 448, 0);
+
+    public static void main(String[] args) {
+        List<WorldPoint> testPoints = new ArrayList<>(10);
+        testPoints.add(new WorldPoint(2900, 3500, 0));
+        testPoints.add(new WorldPoint(3000, 3500, 0));
+        testPoints.add(new WorldPoint(3600, 3500, 0));
+        testPoints.add(new WorldPoint(2900, 3622, 0));
+        testPoints.add(new WorldPoint(3000, 3622, 0));
+        testPoints.add(new WorldPoint(3600, 3622, 0));
+        testPoints.add(new WorldPoint(2900, 4300, 0));
+        testPoints.add(new WorldPoint(3000, 4300, 0));
+        testPoints.add(new WorldPoint(3600, 4300, 0));
+        testPoints.add(new WorldPoint(3600, 4200, 1));
+
+        for (WorldPoint point : testPoints) {
+            final int areaDistance = WILDERNESS_ABOVE_GROUND.distanceTo(point);
+            final int packedPoint = WorldPointUtil.packWorldPoint(point);
+            final int worldUtilDistance = WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_ABOVE_GROUND);
+            if (areaDistance == worldUtilDistance) {
+                System.out.println(areaDistance + " == " + worldUtilDistance);
+            } else {
+                System.out.println(String.format("Error: %d != %d; Point: [%d,%d,%d]", areaDistance, worldUtilDistance, point.getX(), point.getY(), point.getPlane()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Yet another performance PR.

RuneLite's `WorldPoint` and `WorldArea` are immutable meaning any modifications to to them create an entirely new object. While that's good practice from an API design standpoint, it's not so good for performance-critical code like pathfinding. This PR packs all uses of `WorldPoint` in the hotpath into ints to prevent unnecessary allocations.

Changes made: 
* New `WorldPointUtil` with various helper functions to pack/unpack world points
  * Moved `Node.distanceBetween` here since it makes sense for that to live in a util file.
  * `WorldPointUtil.distanceToArea` should be guaranteed to match `WorldArea.distanceTo`. Added an additional test for clarity.
* Made a copy of `PathfinderConfig.transports` that uses the packed world point as a key. Doesn't copy the underlying lists so both `transports` and `transportsPacked` hold the same list references.
* `Pathfinder` no longer stores the entire path each time it finds a better one but instead stores the best last node in the path.
  * The path is lazily reconstructed and cached as needed rather than during the search.
* Removed instant and replaced with `System.currentTimeMillis()` to avoid making new `Instant` allocations.
* Decoupled `CollisionMap` from `SplitFlagMap`; `SplitFlagMap` is what stores data and is allocated once, `CollisionMap` holds a reference to `SplitFlagMap` and can be allocated once per thread.
  * Doing this allows me to remove the extra `boolean[]` and `ArrayList` allocations in `getNeighbors` without risk to thread-safety.
  * `ThreadLocal` incurs a hashmap lookup every time `get()` is called so I've also removed redundant calls to `plugin.getMap()`.

Main allocation cost now is making new nodes and a few-other more minor things ~~(can store a single boolean[] rather than [make a new one](https://github.com/Skretzo/shortest-path/blob/master/src/main/java/shortestpath/pathfinder/CollisionMap.java#L108) each time; same with the neighbors ArrayList)~~ (I've gone ahead and made this optimization, see first comment below). In theory, the node allocation cost can be addressed with an [Object Pool](https://en.wikipedia.org/wiki/Object_pool_pattern) (e.x. [Apache Commons' SoftReferenceObjectPool](https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/SoftReferenceObjectPool.html)), but it'd come with a not-insignificant runtime performance penalty.

# Results
Same setup as usual. See comment below for latest results with the `CollisionMap` changes.

**Worst-Case:** GE to top-left corner in the ocean
Didn't measure short-case this time as it doesn't make a huge difference for a small amount of nodes.

Forgive me for not including a table here, wanting to save some time. Overall this change ends up ~20ms faster with about 50% less allocated bytes (exact numbers in screenshots below).

## Before
**Worst-Case Time** (Avoid Wilderness): 156.9508ms
**Worst-Case Time**: 179.8608ms

**Memory Allocations:**
![image](https://github.com/Skretzo/shortest-path/assets/2230152/7e9453a2-2c7c-4945-81d0-74de6f08a2e1)

**Memory Allocations (Avoid Wilderness):**
![image](https://github.com/Skretzo/shortest-path/assets/2230152/2f30b667-219e-49c6-a95d-281155fa58e7)


## After
**Worst-Case Time** (Avoid Wilderness): 134.7586ms
**Worst-Case Time**: 156.9396ms

**Memory Allocations:**
<img width="607" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/97185fdb-6467-4f51-85aa-74730c1e0e28">

**Memory Allocations (Avoid Wilderness):**
<img width="494" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/efc6c16b-e929-4ca5-b8ba-ee688e0b332c">