### PR TITLE
Primitive int HashMap & smarter neighbors check

### DIFF
--- a/src/main/java/shortestpath/PrimitiveIntHashMap.java
+++ b/src/main/java/shortestpath/PrimitiveIntHashMap.java
@@ -195,13 +195,13 @@ public class PrimitiveIntHashMap<V> {
 
     private void recreateArrays() {
         @SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
-        IntNode<V>[][] temp = (IntNode<V>[][])Array.newInstance(IntNode[].class, maxSize);
+        IntNode<V>[][] temp = (IntNode<V>[][])new IntNode[maxSize][];
         buckets = temp;
     }
 
     private IntNode<V>[] createBucket(int size) {
         @SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
-        IntNode<V>[] temp = (IntNode<V>[])Array.newInstance(IntNode.class, size);
+        IntNode<V>[] temp = (IntNode<V>[])new IntNode[size];
         return temp;
     }
 

--- a/src/main/java/shortestpath/PrimitiveIntHashMap.java
+++ b/src/main/java/shortestpath/PrimitiveIntHashMap.java
@@ -1,0 +1,229 @@
+package shortestpath;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+
+// This class is not intended as a general purpose replacement for a hashmap; it lacks convenience features
+// found in regular maps and has no way to remove elements or get a list of keys/values.
+public class PrimitiveIntHashMap<V> {
+    private static final int MINIMUM_SIZE = 8;
+
+    // Unless the hash function is really unbalanced, most things should fit within at least 8-element buckets
+    // Buckets will grow as needed without forcing a rehash of the whole map
+    private static final int DEFAULT_BUCKET_SIZE = 4;
+
+    // How full the map should get before growing it again. Smaller values speed up lookup times at the expense of space
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+    private class IntNode<V> {
+        private int key;
+        private V value;
+
+        private IntNode(int key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    // If buckets become too large then it may be worth converting large buckets into an array-backed binary tree
+    private IntNode<V>[][] buckets;
+    private int size;
+    private int capacity;
+    private int maxSize;
+    private int mask;
+    private final float loadFactor;
+
+    public PrimitiveIntHashMap(int initialSize) {
+        this(initialSize, DEFAULT_LOAD_FACTOR);
+    }
+
+    public PrimitiveIntHashMap(int initialSize, float loadFactor) {
+        this.loadFactor = loadFactor;
+        size = 0;
+        setNewSize(initialSize);
+        recreateArrays();
+    }
+
+    public V get(int key) {
+        return getOrDefault(key, null);
+    }
+
+    public V getOrDefault(int key, V defaultValue) {
+        int bucket = getBucket(key);
+        int index = bucketIndex(key, bucket);
+        if (index == -1) {
+            return defaultValue;
+        }
+        return buckets[bucket][index].value;
+    }
+
+    public V put(int key, V value) {
+        int bucketIndex = getBucket(key);
+        IntNode<V>[] bucket = buckets[bucketIndex];
+
+        if (bucket == null) {
+            buckets[bucketIndex] = createBucket(DEFAULT_BUCKET_SIZE);
+            buckets[bucketIndex][0] = new IntNode<>(key, value);
+            incrementSize();
+            return null;
+        }
+
+        for (int i = 0; i < bucket.length; ++i) {
+            if (bucket[i] == null) {
+                bucket[i] = new IntNode<>(key, value);
+                incrementSize();
+                return null;
+            } else if (bucket[i].key == key) {
+                V previous = bucket[i].value;
+                bucket[i].value = value;
+                return previous;
+            }
+        }
+
+        // No space in the bucket, grow it
+        growBucket(bucketIndex)[bucket.length] = new IntNode<>(key, value);
+        incrementSize();
+        return null;
+    }
+
+    // This hash seems to be most effective for packed WorldPoint's
+    private static int hash(int value) {
+        return value ^ (value >>> 5) ^ (value >>> 25);
+    }
+
+    private int getBucket(int key) {
+        return (hash(key) & 0x7FFFFFFF) & mask;
+    }
+
+    private int bucketIndex(int key, int bucketIndex) {
+        IntNode<V>[] bucket = buckets[bucketIndex];
+        if (bucket == null) {
+            return -1;
+        }
+
+        for (int i = 0; i < bucket.length; ++i) {
+            if (bucket[i] == null) {
+                break;
+            }
+            if (bucket[i].key == key) {
+                return i;
+            }
+        }
+
+        // Searched the bucket and found nothing
+        return -1;
+    }
+
+    private void incrementSize() {
+        size++;
+        if (size >= capacity) {
+            rehash();
+        }
+    }
+
+    private IntNode<V>[] growBucket(int bucketIndex) {
+        IntNode<V>[] oldBucket = buckets[bucketIndex];
+        IntNode<V>[] newBucket = createBucket(oldBucket.length * 2);
+        System.arraycopy(oldBucket, 0, newBucket, 0, oldBucket.length);
+        buckets[bucketIndex] = newBucket;
+        return newBucket;
+    }
+
+    private int getNewMaxSize(int size) {
+        int nextPow2 = -1 >>> Integer.numberOfLeadingZeros(size);
+        if (nextPow2 >= (Integer.MAX_VALUE >>> 1)) {
+            return (Integer.MAX_VALUE >>> 1) + 1;
+        }
+        return nextPow2 + 1;
+    }
+
+    private void setNewSize(int size) {
+        if (size < MINIMUM_SIZE) {
+            size = MINIMUM_SIZE;
+        }
+
+        maxSize = getNewMaxSize(size);
+        mask = maxSize - 1;
+        capacity = (int)(maxSize * loadFactor);
+    }
+
+    private void growCapacity() {
+        setNewSize(maxSize);
+    }
+
+    // Grow the bucket array then rehash all the values into new buckets and discard the old ones
+    private void rehash() {
+        growCapacity();
+
+        IntNode<V>[][] oldBuckets = buckets;
+        recreateArrays();
+
+        for (int i = 0; i < oldBuckets.length; ++i) {
+            IntNode<V>[] oldBucket = oldBuckets[i];
+            if (oldBucket == null) {
+                continue;
+            }
+
+            for (int ind = 0; ind < oldBucket.length; ++ind) {
+                if (oldBucket[ind] == null) {
+                    break;
+                }
+
+                int bucketIndex = getBucket(oldBucket[ind].key);
+                IntNode<V>[] newBucket = buckets[bucketIndex];
+                if (newBucket == null) {
+                    newBucket = createBucket(DEFAULT_BUCKET_SIZE);
+                    newBucket[0] = oldBucket[ind];
+                    buckets[bucketIndex] = newBucket;
+                } else {
+                    int bInd;
+                    for (bInd = 0; bInd < newBucket.length; ++bInd) {
+                        if (newBucket[bInd] == null) {
+                            newBucket[bInd] = oldBucket[ind];
+                            break;
+                        }
+                    }
+
+                    if (bInd >= newBucket.length) {
+                        growBucket(bucketIndex)[newBucket.length] = oldBucket[ind];
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private void recreateArrays() {
+        @SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
+        IntNode<V>[][] temp = (IntNode<V>[][])Array.newInstance(IntNode[].class, maxSize);
+        buckets = temp;
+    }
+
+    private IntNode<V>[] createBucket(int size) {
+        @SuppressWarnings({"unchecked", "SuspiciousArrayCast"})
+        IntNode<V>[] temp = (IntNode<V>[])Array.newInstance(IntNode.class, size);
+        return temp;
+    }
+
+    // Debug helper to understand how effective a given hash may be at distributing values
+    public double calculateFullness() {
+        int size = 0;
+        int usedSize = 0;
+        for (int i = 0; i < buckets.length; ++i) {
+            if (buckets[i] == null) continue;
+            size += buckets[i].length;
+            for (int j = 0; j < buckets[i].length; ++j) {
+                if (buckets[i][j] == null) {
+                    usedSize += j;
+                    break;
+                }
+            }
+        }
+        return 100.0 * (double)usedSize / (double)size;
+    }
+
+    public void clear() {
+        size = 0;
+        Arrays.fill(buckets, null);
+    }
+}

--- a/src/main/java/shortestpath/PrimitiveIntHashMap.java
+++ b/src/main/java/shortestpath/PrimitiveIntHashMap.java
@@ -1,6 +1,5 @@
 package shortestpath;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 
 // This class is not intended as a general purpose replacement for a hashmap; it lacks convenience features
@@ -15,7 +14,7 @@ public class PrimitiveIntHashMap<V> {
     // How full the map should get before growing it again. Smaller values speed up lookup times at the expense of space
     private static final float DEFAULT_LOAD_FACTOR = 0.75f;
 
-    private class IntNode<V> {
+    private static class IntNode<V> {
         private int key;
         private V value;
 

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -69,7 +69,7 @@ public class CollisionMap {
     private final List<Node> neighbors = new ArrayList<>(16);
     private final boolean[] traversable = new boolean[8];
 
-    public List<Node> getNeighbors(Node node, PathfinderConfig config) {
+    public List<Node> getNeighbors(Node node, VisitedTiles visited, PathfinderConfig config) {
         final int x = WorldPointUtil.unpackWorldX(node.packedPosition);
         final int y = WorldPointUtil.unpackWorldY(node.packedPosition);
         final int z = WorldPointUtil.unpackWorldPlane(node.packedPosition);
@@ -83,6 +83,7 @@ public class CollisionMap {
         // Thus any transports in the list are guaranteed to be valid per the user's settings
         for (int i = 0; i < transports.size(); ++i) {
             Transport transport = transports.get(i);
+            if (visited.get(transport.getDestination())) continue;
             neighbors.add(new TransportNode(transport.getDestination(), node, transport.getWait()));
         }
 
@@ -117,6 +118,8 @@ public class CollisionMap {
         for (int i = 0; i < traversable.length; i++) {
             OrdinalDirection d = ORDINAL_VALUES[i];
             int neighborPacked = packedPointFromOrdinal(node.packedPosition, d);
+            if (visited.get(neighborPacked)) continue;
+
             if (traversable[i]) {
                 neighbors.add(new Node(neighborPacked, node));
             } else if (Math.abs(d.x + d.y) == 1 && isBlocked(x + d.x, y + d.y, z)) {
@@ -124,6 +127,7 @@ public class CollisionMap {
                 List<Transport> neighborTransports = config.getTransportsPacked().getOrDefault(neighborPacked, (List<Transport>)Collections.EMPTY_LIST);
                 for (int t = 0; t < neighborTransports.size(); ++t) {
                     Transport transport = neighborTransports.get(t);
+                    if (visited.get(transport.getDestination())) continue;
                     neighbors.add(new Node(transport.getOrigin(), node));
                 }
             }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -75,7 +75,7 @@ public class Pathfinder implements Runnable {
         List<Node> nodes = map.getNeighbors(node, visited, config);
         for (int i = 0; i < nodes.size(); ++i) {
             Node neighbor = nodes.get(i);
-            if ((config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness))) {
+            if (config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness)) {
                 continue;
             }
 

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -45,7 +45,7 @@ public class Pathfinder implements Runnable {
         this.target = target;
         targetPacked = WorldPointUtil.packWorldPoint(target);
         targetInWilderness = PathfinderConfig.isInWilderness(target);
-        
+
         new Thread(this).start();
     }
 
@@ -72,18 +72,18 @@ public class Pathfinder implements Runnable {
     }
 
     private void addNeighbors(Node node) {
-        List<Node> nodes = map.getNeighbors(node, config);
+        List<Node> nodes = map.getNeighbors(node, visited, config);
         for (int i = 0; i < nodes.size(); ++i) {
             Node neighbor = nodes.get(i);
-            if (visited.get(neighbor.packedPosition) || (config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness))) {
+            if ((config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness))) {
                 continue;
             }
-            if (visited.set(neighbor.packedPosition)) {
-                if (neighbor instanceof TransportNode) {
-                    pending.add(neighbor);
-                } else {
-                    boundary.addLast(neighbor);
-                }
+
+            visited.set(neighbor.packedPosition);
+            if (neighbor instanceof TransportNode) {
+                pending.add(neighbor);
+            } else {
+                boundary.addLast(neighbor);
             }
         }
     }

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -14,6 +14,7 @@ import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import shortestpath.ShortestPathConfig;
+import shortestpath.PrimitiveIntHashMap;
 import shortestpath.Transport;
 import shortestpath.WorldPointUtil;
 
@@ -29,7 +30,7 @@ public class PathfinderConfig {
 
     // Copy of transports with packed positions for the hotpath; lists are not copied and are the same reference in both maps
     @Getter
-    private Map<Integer, List<Transport>> transportsPacked;
+    private PrimitiveIntHashMap<List<Transport>> transportsPacked;
 
     private final Client client;
     private final ShortestPathConfig config;
@@ -60,8 +61,8 @@ public class PathfinderConfig {
         this.mapData = mapData;
         this.map = ThreadLocal.withInitial(() -> new CollisionMap(this.mapData));
         this.allTransports = transports;
-        this.transports = new HashMap<>();
-        this.transportsPacked = new HashMap<>();
+        this.transports = new HashMap<>(allTransports.size());
+        this.transportsPacked = new PrimitiveIntHashMap<>((int)(allTransports.size() * 1.5f));
         this.client = client;
         this.config = config;
         refresh();

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -62,7 +62,7 @@ public class PathfinderConfig {
         this.map = ThreadLocal.withInitial(() -> new CollisionMap(this.mapData));
         this.allTransports = transports;
         this.transports = new HashMap<>(allTransports.size());
-        this.transportsPacked = new PrimitiveIntHashMap<>((int)(allTransports.size() * 1.5f));
+        this.transportsPacked = new PrimitiveIntHashMap<>(allTransports.size());
         this.client = client;
         this.config = config;
         refresh();

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -1,5 +1,6 @@
 package shortestpath.pathfinder;
 
+import net.runelite.api.coords.WorldPoint;
 import shortestpath.WorldPointUtil;
 
 import static net.runelite.api.Constants.MAX_Z;
@@ -17,6 +18,10 @@ public class VisitedTiles {
         final int heightInclusive = regionExtents.getHeight() + 1;
 
         visitedRegions = new VisitedRegion[widthInclusive * heightInclusive];
+    }
+
+    public boolean get(WorldPoint point) {
+        return get(point.getX(), point.getY(), point.getPlane());
     }
 
     public boolean get(int packedPoint) {

--- a/src/test/java/pathfinder/PrimitiveIntHashMapTests.java
+++ b/src/test/java/pathfinder/PrimitiveIntHashMapTests.java
@@ -1,0 +1,29 @@
+package pathfinder;
+
+import net.runelite.api.coords.WorldPoint;
+import shortestpath.PrimitiveIntHashMap;
+import shortestpath.Transport;
+import shortestpath.WorldPointUtil;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PrimitiveIntHashMapTests {
+    public static void main(String[] args) {
+        HashMap<WorldPoint, List<Transport>> transports = Transport.loadAllFromResources();
+        PrimitiveIntHashMap<List<Transport>> map = new PrimitiveIntHashMap<>(transports.size());
+        for (Map.Entry<WorldPoint, List<Transport>> entry : transports.entrySet()) {
+            int packedPoint = WorldPointUtil.packWorldPoint(entry.getKey());
+            map.put(packedPoint, entry.getValue());
+        }
+
+        for (Map.Entry<WorldPoint, List<Transport>> entry : transports.entrySet()) {
+            int packedPoint = WorldPointUtil.packWorldPoint(entry.getKey());
+            if (map.get(packedPoint) != entry.getValue()) {
+                System.err.println("Transport entry: " + entry.getKey() + " was not found in map");
+            }
+            assert map.get(packedPoint) == entry.getValue();
+        }
+    }
+}


### PR DESCRIPTION
`CollisionMap.getNeighbors` now checks if a neighbor has already been visited saving a little time while eliminating whole lot of extra allocations. In addition, I've replaced the old `HashMap<Integer, List<Transport>>` with a new `PrimitiveIntHashMap`. This new hashmap only accepts primitive ints as keys. This removes the need to create new `Integer` objects like a generic hashmap would. This new hashmap ends up being faster than the standard Java `HashMap` but only for this specific use-case; it is not a general purpose hashmap nor should it be used as such. I also ran an experiment to find the best hash function for packed WorldPoints that keeps the hashmap buckets as small as possible both for speed and space (though buckets are allowed to grow if needed).

Also included is another test file to check and verify that the `PrimitiveIntHashMap` works as expected using real transport data.

# Results
Same as before, testing the worst case of GE to some point in the top-left of the map in the ocean. Avoid wilderness is _off_ so all nodes are visited.

## Before
**Worst-Case Time:** 175.0368ms
**Allocations:**
<img width="556" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/20b2c6be-ef43-4aec-805b-b12d388c9e41">

## After
**Worst-Case Time:** 133.1026ms
**Allocations:**
<img width="550" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/22290202-f42d-4cd2-ac4c-6c36d9cbf6c3">
