### PR TITLE
Tests for WorldPointUtil and PrimitiveIntHashMap

### DIFF
--- a/src/main/java/shortestpath/PrimitiveIntHashMap.java
+++ b/src/main/java/shortestpath/PrimitiveIntHashMap.java
@@ -37,10 +37,18 @@ public class PrimitiveIntHashMap<V> {
     }
 
     public PrimitiveIntHashMap(int initialSize, float loadFactor) {
+        if (loadFactor < 0.0f || loadFactor > 1.0f) {
+            throw new IllegalArgumentException("Load factor must be between 0 and 1");
+        }
+
         this.loadFactor = loadFactor;
         size = 0;
         setNewSize(initialSize);
         recreateArrays();
+    }
+
+    public int size() {
+        return size;
     }
 
     public V get(int key) {
@@ -57,6 +65,10 @@ public class PrimitiveIntHashMap<V> {
     }
 
     public V put(int key, V value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Cannot insert a null value");
+        }
+
         int bucketIndex = getBucket(key);
         IntNode<V>[] bucket = buckets[bucketIndex];
 
@@ -138,7 +150,7 @@ public class PrimitiveIntHashMap<V> {
 
     private void setNewSize(int size) {
         if (size < MINIMUM_SIZE) {
-            size = MINIMUM_SIZE;
+            size = MINIMUM_SIZE - 1;
         }
 
         maxSize = getNewMaxSize(size);

--- a/src/main/java/shortestpath/WorldPointUtil.java
+++ b/src/main/java/shortestpath/WorldPointUtil.java
@@ -55,7 +55,7 @@ public class WorldPointUtil {
     }
 
     public static int distanceBetween(WorldPoint previous, WorldPoint current) {
-        return distanceBetween(WorldPointUtil.packWorldPoint(previous), WorldPointUtil.packWorldPoint(current), 1);
+        return distanceBetween(previous, current, 1);
     }
 
     public static int distanceBetween(WorldPoint previous, WorldPoint current, int diagonal) {

--- a/src/main/java/shortestpath/WorldPointUtil.java
+++ b/src/main/java/shortestpath/WorldPointUtil.java
@@ -33,6 +33,10 @@ public class WorldPointUtil {
         return (packedPoint >> 30) & 0x3;
     }
 
+    public static int distanceBetween(int previousPacked, int currentPacked) {
+        return distanceBetween(previousPacked, currentPacked, 1);
+    }
+
     public static int distanceBetween(int previousPacked, int currentPacked, int diagonal) {
         final int previousX = WorldPointUtil.unpackWorldX(previousPacked);
         final int previousY = WorldPointUtil.unpackWorldY(previousPacked);
@@ -50,16 +54,21 @@ public class WorldPointUtil {
         return Integer.MAX_VALUE;
     }
 
-    public static int distanceBetween(int previousPacked, int currentPacked) {
-        return distanceBetween(previousPacked, currentPacked, 1);
-    }
-
     public static int distanceBetween(WorldPoint previous, WorldPoint current) {
         return distanceBetween(WorldPointUtil.packWorldPoint(previous), WorldPointUtil.packWorldPoint(current), 1);
     }
 
     public static int distanceBetween(WorldPoint previous, WorldPoint current, int diagonal) {
-        return distanceBetween(WorldPointUtil.packWorldPoint(previous), WorldPointUtil.packWorldPoint(current), diagonal);
+        final int dx = Math.abs(previous.getX() - current.getX());
+        final int dy = Math.abs(previous.getY() - current.getY());
+
+        if (diagonal == 1) {
+            return Math.max(dx, dy);
+        } else if (diagonal == 2) {
+            return dx + dy;
+        }
+
+        return Integer.MAX_VALUE;
     }
 
     // Matches WorldArea.distanceTo

--- a/src/test/java/pathfinder/PrimitiveIntHashMapTests.java
+++ b/src/test/java/pathfinder/PrimitiveIntHashMapTests.java
@@ -1,6 +1,8 @@
 package pathfinder;
 
 import net.runelite.api.coords.WorldPoint;
+import org.junit.Assert;
+import org.junit.Test;
 import shortestpath.PrimitiveIntHashMap;
 import shortestpath.Transport;
 import shortestpath.WorldPointUtil;
@@ -10,9 +12,17 @@ import java.util.List;
 import java.util.Map;
 
 public class PrimitiveIntHashMapTests {
-    public static void main(String[] args) {
+    @Test(expected=IllegalArgumentException.class)
+    public void checkNullValueProhibited() {
+        PrimitiveIntHashMap<Boolean> map = new PrimitiveIntHashMap<>(8);
+        map.put(0, null);
+    }
+
+    @Test
+    public void tryInsertTransports() {
         HashMap<WorldPoint, List<Transport>> transports = Transport.loadAllFromResources();
         PrimitiveIntHashMap<List<Transport>> map = new PrimitiveIntHashMap<>(transports.size());
+
         for (Map.Entry<WorldPoint, List<Transport>> entry : transports.entrySet()) {
             int packedPoint = WorldPointUtil.packWorldPoint(entry.getKey());
             map.put(packedPoint, entry.getValue());
@@ -20,10 +30,77 @@ public class PrimitiveIntHashMapTests {
 
         for (Map.Entry<WorldPoint, List<Transport>> entry : transports.entrySet()) {
             int packedPoint = WorldPointUtil.packWorldPoint(entry.getKey());
-            if (map.get(packedPoint) != entry.getValue()) {
-                System.err.println("Transport entry: " + entry.getKey() + " was not found in map");
-            }
-            assert map.get(packedPoint) == entry.getValue();
+            Assert.assertEquals("World Point " + entry.getKey() + " did not map to the correct value", entry.getValue(), map.get(packedPoint));
+        }
+    }
+
+    @Test
+    public void tryGrowMap() {
+        PrimitiveIntHashMap<Integer> map = new PrimitiveIntHashMap<>(8);
+        for (int i = 0; i < 1024; ++i) {
+            map.put(i, i);
+        }
+
+        Assert.assertEquals(1024, map.size());
+
+        for (int i = 0; i < 1024; ++i) {
+            Assert.assertEquals(i, map.get(i).intValue());
+        }
+    }
+
+    @Test
+    public void checkNonexistentEntries() {
+        PrimitiveIntHashMap<Integer> map = new PrimitiveIntHashMap<>(8);
+        Assert.assertNull(map.get(667215));
+    }
+
+    @Test
+    public void tryOverwriteValues() {
+        final int keyStart = 9875643; // Use keys that aren't 0 or all low bits
+
+        PrimitiveIntHashMap<Integer> map = new PrimitiveIntHashMap<>(2048);
+        for (int i = 0; i < 1024; ++i) {
+            map.put(i + keyStart, i);
+        }
+
+        // Overwrite values
+        for (int i = 0; i < 1024; ++i) {
+            map.put(i + keyStart, i + 1);
+        }
+
+        // Now check overwritten values stuck
+        for (int i = 0; i < 1024; ++i) {
+            Assert.assertEquals(i + 1, map.get(i + keyStart).intValue());
+        }
+    }
+
+    @Test
+    public void checkClearMap() {
+        PrimitiveIntHashMap<Integer> map = new PrimitiveIntHashMap<>(8);
+        for (int i = 0; i < 1024; ++i) {
+            map.put(i, i);
+        }
+
+        Assert.assertEquals(1024, map.size());
+        Assert.assertEquals(364, map.get(364).intValue());
+
+        map.clear();
+        Assert.assertEquals(0, map.size());
+        Assert.assertNull(map.get(364));
+    }
+
+    @Test
+    public void checkInsertOrderIrrelevant() {
+        final int keyStart = 9875643; // Use keys that aren't 0 or all low bits
+        PrimitiveIntHashMap<Integer> mapForward = new PrimitiveIntHashMap<>(8);
+        PrimitiveIntHashMap<Integer> mapReversed = new PrimitiveIntHashMap<>(8);
+        for (int i = 0; i < 1024; ++i) {
+            mapForward.put(i + keyStart, i);
+            mapReversed.put(1023 - i + keyStart, 1023 - i);
+        }
+
+        for (int i = 0; i < 1024; ++i) {
+            Assert.assertEquals(mapForward.get(i + keyStart), mapReversed.get(i + keyStart));
         }
     }
 }

--- a/src/test/java/pathfinder/WorldPointTests.java
+++ b/src/test/java/pathfinder/WorldPointTests.java
@@ -2,15 +2,25 @@ package pathfinder;
 
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
-import shortestpath.WorldPointUtil;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static shortestpath.WorldPointUtil.distanceBetween;
+import static shortestpath.WorldPointUtil.distanceToArea;
+import static shortestpath.WorldPointUtil.packWorldPoint;
+import static shortestpath.WorldPointUtil.unpackWorldPlane;
+import static shortestpath.WorldPointUtil.unpackWorldPoint;
+import static shortestpath.WorldPointUtil.unpackWorldX;
+import static shortestpath.WorldPointUtil.unpackWorldY;
+
 public class WorldPointTests {
     private static final WorldArea WILDERNESS_ABOVE_GROUND = new WorldArea(2944, 3523, 448, 448, 0);
 
-    public static void main(String[] args) {
+    @Test
+    public void testDistanceToArea() {
         List<WorldPoint> testPoints = new ArrayList<>(10);
         testPoints.add(new WorldPoint(2900, 3500, 0));
         testPoints.add(new WorldPoint(3000, 3500, 0));
@@ -25,13 +35,68 @@ public class WorldPointTests {
 
         for (WorldPoint point : testPoints) {
             final int areaDistance = WILDERNESS_ABOVE_GROUND.distanceTo(point);
-            final int packedPoint = WorldPointUtil.packWorldPoint(point);
-            final int worldUtilDistance = WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_ABOVE_GROUND);
-            if (areaDistance == worldUtilDistance) {
-                System.out.println(areaDistance + " == " + worldUtilDistance);
-            } else {
-                System.out.println(String.format("Error: %d != %d; Point: [%d,%d,%d]", areaDistance, worldUtilDistance, point.getX(), point.getY(), point.getPlane()));
-            }
+            final int packedPoint = packWorldPoint(point);
+            final int worldUtilDistance = distanceToArea(packedPoint, WILDERNESS_ABOVE_GROUND);
+            Assert.assertEquals("Calculating distance to " + point + " failed", areaDistance, worldUtilDistance);
         }
+    }
+
+    @Test
+    public void testWorldPointPacking() {
+        WorldPoint point = new WorldPoint(13, 24685, 1);
+
+        final int packedPoint = packWorldPoint(point);
+        Assert.assertEquals(0x7036800D, packedPoint); // Manually verified
+
+        final int unpackedX = unpackWorldX(packedPoint);
+        Assert.assertEquals(point.getX(), unpackedX);
+
+        final int unpackedY = unpackWorldY(packedPoint);
+        Assert.assertEquals(point.getY(), unpackedY);
+
+        final int unpackedPlane = unpackWorldPlane(packedPoint);
+        Assert.assertEquals(point.getPlane(), unpackedPlane);
+
+        WorldPoint unpackedPoint = unpackWorldPoint(packedPoint);
+        Assert.assertEquals(point, unpackedPoint);
+    }
+
+    @Test
+    public void testDistanceBetween() {
+        WorldPoint pointA = new WorldPoint(13, 24685, 1);
+        WorldPoint pointB = new WorldPoint(29241, 3384, 1);
+        WorldPoint pointC = new WorldPoint(292, 3384, 0); // Test point on different plane
+
+        Assert.assertEquals(0, distanceBetween(pointA, pointA));
+        Assert.assertEquals(29228, distanceBetween(pointA, pointB));
+        Assert.assertEquals(29228, distanceBetween(pointB, pointA));
+        Assert.assertEquals(21301, distanceBetween(pointA, pointC));
+
+        // with diagonal = 2
+        Assert.assertEquals(0, distanceBetween(pointA, pointA, 2));
+        Assert.assertEquals(50529, distanceBetween(pointA, pointB, 2));
+        Assert.assertEquals(50529, distanceBetween(pointB, pointA, 2));
+        Assert.assertEquals(28949, distanceBetween(pointB, pointC, 2));
+    }
+
+    @Test
+    public void testPackedDistanceBetween() {
+        WorldPoint pointA = new WorldPoint(13, 24685, 1);
+        WorldPoint pointB = new WorldPoint(29241, 3384, 1);
+        WorldPoint pointC = new WorldPoint(292, 3384, 0); // Test point on different plane
+        final int packedPointA = packWorldPoint(pointA);
+        final int packedPointB = packWorldPoint(pointB);
+        final int packedPointC = packWorldPoint(pointC);
+
+        Assert.assertEquals(0, distanceBetween(packedPointA, packedPointA));
+        Assert.assertEquals(29228, distanceBetween(packedPointA, packedPointB));
+        Assert.assertEquals(29228, distanceBetween(packedPointB, packedPointA));
+        Assert.assertEquals(21301, distanceBetween(packedPointA, packedPointC));
+
+        // with diagonal = 2
+        Assert.assertEquals(0, distanceBetween(packedPointA, packedPointA, 2));
+        Assert.assertEquals(50529, distanceBetween(packedPointA, packedPointB, 2));
+        Assert.assertEquals(50529, distanceBetween(packedPointB, packedPointA, 2));
+        Assert.assertEquals(28949, distanceBetween(packedPointB, packedPointC, 2));
     }
 }


### PR DESCRIPTION
Added proper tests for `WorldPointUtil` and `PrimitiveIntHashMap`. No impactful logic changes have been made, but I have reorganized a few methods and fixed an issue with inserting null values into the `PrimitiveIntHashMap`.