### PR TITLE
Utility Features & Stability Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 group = 'shortestpath'
 version = '1.11'
-sourceCompatibility = '1.8'
+sourceCompatibility = '1.11'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/shortestpath/DebugOverlayPanel.java
+++ b/src/main/java/shortestpath/DebugOverlayPanel.java
@@ -16,13 +16,10 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.text.NumberFormat;
 import java.util.List;
 
 public class DebugOverlayPanel extends OverlayPanel {
     private final ShortestPathPlugin plugin;
-    private final NumberFormat numberFormatter;
-    private final LineComponent memoryDisclaimer;
     private final SeparatorLine separator;
 
     @Inject
@@ -32,8 +29,6 @@ public class DebugOverlayPanel extends OverlayPanel {
 
         separator = new SeparatorLine();
         separator.setColor(new Color(0, true)); // Invisible color
-        memoryDisclaimer = makeText("Memory usage is a rough approximation", Color.YELLOW);
-        numberFormatter = NumberFormat.getNumberInstance(); // Use user's locale
 
         setPosition(OverlayPosition.TOP_LEFT);
     }
@@ -42,13 +37,6 @@ public class DebugOverlayPanel extends OverlayPanel {
         return LineComponent.builder()
                 .left(left)
                 .right(right)
-                .build();
-    }
-
-    private LineComponent makeText(String text, Color color) {
-        return LineComponent.builder()
-                .left(text)
-                .leftColor(color)
                 .build();
     }
 
@@ -90,20 +78,6 @@ public class DebugOverlayPanel extends OverlayPanel {
         double milliTime = stats.getElapsedTimeNanos() / 1000000.0;
         String time = String.format("%.2fms", milliTime);
         components.add(makeLine("Time:", time));
-
-        // Don't show estimated memory usage if it is obvious GC occurred
-        long estimatedMemory = stats.getEstimatedUsedBytes();
-        if (estimatedMemory <= 0) {
-            components.add(makeLine("Memory:", "N/A"));
-        } else {
-            String memory = numberFormatter.format(stats.getEstimatedUsedBytes() / 1024.0 / 1024.0) + "MB";
-            components.add(makeLine("Memory:", memory));
-        }
-
-        components.add(separator);
-
-        // Warn users that memory usage is not entirely accurate
-        components.add(memoryDisclaimer);
 
         return super.render(graphics);
     }

--- a/src/main/java/shortestpath/DebugOverlayPanel.java
+++ b/src/main/java/shortestpath/DebugOverlayPanel.java
@@ -1,0 +1,140 @@
+package shortestpath;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
+import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+import shortestpath.pathfinder.Pathfinder;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.text.NumberFormat;
+import java.util.List;
+
+public class DebugOverlayPanel extends OverlayPanel {
+    private final ShortestPathPlugin plugin;
+    private final NumberFormat numberFormatter;
+    private final LineComponent memoryDisclaimer;
+    private final SeparatorLine separator;
+
+    @Inject
+    public DebugOverlayPanel(ShortestPathPlugin plugin) {
+        super(plugin);
+        this.plugin = plugin;
+
+        separator = new SeparatorLine();
+        separator.setColor(new Color(0, true)); // Invisible color
+        memoryDisclaimer = makeText("Memory usage is a rough approximation", Color.YELLOW);
+        numberFormatter = NumberFormat.getNumberInstance(); // Use user's locale
+
+        setPosition(OverlayPosition.TOP_LEFT);
+    }
+
+    private LineComponent makeLine(String left, String right) {
+        return LineComponent.builder()
+                .left(left)
+                .right(right)
+                .build();
+    }
+
+    private LineComponent makeText(String text, Color color) {
+        return LineComponent.builder()
+                .left(text)
+                .leftColor(color)
+                .build();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        Pathfinder pathfinder = plugin.getPathfinder();
+        Pathfinder.PathfinderStats stats;
+        if (pathfinder == null || (stats = pathfinder.getStats()) == null) {
+            return null;
+        }
+
+        List<LayoutableRenderableEntity> components = panelComponent.getChildren();
+
+        components.add(
+                TitleComponent.builder()
+                        .text("Shortest Path Debug")
+                        .color(Color.ORANGE)
+                        .build()
+        );
+
+        components.add(separator);
+
+        String pathLength = Integer.toString(pathfinder.getPath().size());
+        components.add(makeLine("Path Length:", pathLength));
+
+        components.add(separator);
+
+        String nodes = Integer.toString(stats.getNodesChecked());
+        components.add(makeLine("Nodes:", nodes));
+
+        String transports = Integer.toString(stats.getTransportsChecked());
+        components.add(makeLine("Transports:", transports));
+
+        String totalNodes = Integer.toString(stats.getTotalNodesChecked());
+        components.add(makeLine("Total:", totalNodes));
+
+        components.add(separator);
+
+        double milliTime = stats.getElapsedTimeNanos() / 1000000.0;
+        String time = String.format("%.2fms", milliTime);
+        components.add(makeLine("Time:", time));
+
+        // Don't show estimated memory usage if it is obvious GC occurred
+        long estimatedMemory = stats.getEstimatedUsedBytes();
+        if (estimatedMemory <= 0) {
+            components.add(makeLine("Memory:", "N/A"));
+        } else {
+            String memory = numberFormatter.format(stats.getEstimatedUsedBytes() / 1024.0 / 1024.0) + "MB";
+            components.add(makeLine("Memory:", memory));
+        }
+
+        components.add(separator);
+
+        // Warn users that memory usage is not entirely accurate
+        components.add(memoryDisclaimer);
+
+        return super.render(graphics);
+    }
+
+    @Setter
+    private static class SeparatorLine implements LayoutableRenderableEntity {
+        private Color color = Color.GRAY;
+        private Point preferredLocation = new Point();
+        private Dimension preferredSize = new Dimension(ComponentConstants.STANDARD_WIDTH, 4);
+
+        @Getter
+        private final Rectangle bounds = new Rectangle();
+
+        @Override
+        public Dimension render(Graphics2D graphics) {
+            final int separatorX = preferredLocation.x;
+            final int separatorY = preferredLocation.y + 4;
+            final int width = preferredSize.width;
+            final int height = Math.max(preferredSize.height, 2);
+
+            // Draw bar
+            if (color != null && color.getAlpha() != 0) {
+                graphics.setColor(color);
+                graphics.fillRect(separatorX, separatorY, width, height);
+            }
+
+            final Dimension dimension = new Dimension(width, height + 4);
+            bounds.setLocation(preferredLocation);
+            bounds.setSize(dimension);
+
+            return dimension;
+        }
+    }
+}

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -77,7 +77,7 @@ public interface ShortestPathConfig extends Config {
 
     @ConfigItem(
         keyName = "useCharterShips",
-        name = "Use charter chips",
+        name = "Use charter ships",
         description = "Whether to include charter ships in the path",
         position = 6,
         section = sectionSettings
@@ -302,7 +302,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigItem(
         keyName = "drawDebugPanel",
         name = "Show debug panel",
-        description = "Toggle displaying a pathfinding debug stats panel",
+        description = "Toggles displaying the pathfinding debug stats panel",
         position = 25,
         section = sectionDisplay
     )

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -301,8 +301,8 @@ public interface ShortestPathConfig extends Config {
 
     @ConfigItem(
         keyName = "drawDebugPanel",
-        name = "Show Debug Stats",
-        description = "Toggle displaying Pathfinding debug info",
+        name = "Show debug panel",
+        description = "Toggle displaying a pathfinding debug stats panel",
         position = 25,
         section = sectionDisplay
     )

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -300,21 +300,10 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
-        keyName = "drawDebugPanel",
-        name = "Show debug panel",
-        description = "Toggles displaying the pathfinding debug stats panel",
-        position = 25,
-        section = sectionDisplay
-    )
-    default boolean drawDebugPanel() {
-        return false;
-    }
-
-    @ConfigItem(
         keyName = "pathStyle",
         name = "Path style",
         description = "Whether to display the path as tiles or a segmented line",
-        position = 26,
+        position = 25,
         section = sectionDisplay
     )
     default TileStyle pathStyle() {
@@ -324,7 +313,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Colours",
         description = "Colours for the path map, minimap and scene tiles",
-        position = 27
+        position = 26
     )
     String sectionColours = "sectionColours";
 
@@ -333,7 +322,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPath",
         name = "Path",
         description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 28,
+        position = 27,
         section = sectionColours
     )
     default Color colourPath() {
@@ -345,7 +334,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPathCalculating",
         name = "Calculating",
         description = "Colour of the path tiles while the pathfinding calculation is in progress",
-        position = 29,
+        position = 28,
         section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -357,7 +346,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 30,
+        position = 29,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -369,7 +358,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 31,
+        position = 30,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -381,10 +370,28 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 32,
+        position = 31,
         section = sectionColours
     )
     default Color colourText() {
         return Color.WHITE;
+    }
+
+    @ConfigSection(
+            name = "Debug Options",
+            description = "Various options for debugging",
+            position = 32
+    )
+    String sectionDebug = "sectionDebug";
+
+    @ConfigItem(
+            keyName = "drawDebugPanel",
+            name = "Show debug panel",
+            description = "Toggles displaying the pathfinding debug stats panel",
+            position = 33,
+            section = sectionDebug
+    )
+    default boolean drawDebugPanel() {
+        return false;
     }
 }

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -300,10 +300,21 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "drawDebugPanel",
+        name = "Show Debug Stats",
+        description = "Toggle displaying Pathfinding debug info",
+        position = 25,
+        section = sectionDisplay
+    )
+    default boolean drawDebugPanel() {
+        return false;
+    }
+
+    @ConfigItem(
         keyName = "pathStyle",
         name = "Path style",
         description = "Whether to display the path as tiles or a segmented line",
-        position = 25,
+        position = 26,
         section = sectionDisplay
     )
     default TileStyle pathStyle() {
@@ -313,7 +324,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Colours",
         description = "Colours for the path map, minimap and scene tiles",
-        position = 26
+        position = 27
     )
     String sectionColours = "sectionColours";
 
@@ -322,7 +333,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPath",
         name = "Path",
         description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 27,
+        position = 28,
         section = sectionColours
     )
     default Color colourPath() {
@@ -334,7 +345,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPathCalculating",
         name = "Calculating",
         description = "Colour of the path tiles while the pathfinding calculation is in progress",
-        position = 28,
+        position = 29,
         section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -346,7 +357,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 29,
+        position = 30,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -358,7 +369,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 30,
+        position = 31,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -370,7 +381,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 31,
+        position = 32,
         section = sectionColours
     )
     default Color colourText() {

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -206,7 +206,7 @@ public class ShortestPathPlugin extends Plugin {
         return false;
     }
 
-    private final Pattern TRANSPORT_OPTIONS = Pattern.compile("avoidWilderness|useAgilityShortcuts|useGrappleShortcuts|useBoats|useCanoes|useCharterShips|useShips|useFairyRings|useGnomeGliders|useSpiritTrees|useTeleportationLevers|useTeleportationPortals");
+    private final Pattern TRANSPORT_OPTIONS_REGEX = Pattern.compile("^(avoidWilderness|use\\w+)$");
 
     @Subscribe
     public void onConfigChanged(ConfigChanged event) {
@@ -224,7 +224,7 @@ public class ShortestPathPlugin extends Plugin {
         }
 
         // Transport option changed; rerun pathfinding
-        if (TRANSPORT_OPTIONS.matcher(event.getKey()).find()) {
+        if (TRANSPORT_OPTIONS_REGEX.matcher(event.getKey()).find()) {
             if (pathfinder != null) {
                 restartPathfinding(pathfinder.getStart(), pathfinder.getTarget());
             }

--- a/src/main/java/shortestpath/Transport.java
+++ b/src/main/java/shortestpath/Transport.java
@@ -224,6 +224,8 @@ public class Transport {
 
     public static HashMap<WorldPoint, List<Transport>> loadAllFromResources() {
         HashMap<WorldPoint, List<Transport>> transports = new HashMap<>();
+        fairyRings.clear();
+        fairyRingCodes.clear();
 
         addTransports(transports, "/transports.txt", TransportType.TRANSPORT);
         addTransports(transports, "/agility_shortcuts.txt", TransportType.AGILITY_SHORTCUT);

--- a/src/main/java/shortestpath/Util.java
+++ b/src/main/java/shortestpath/Util.java
@@ -19,4 +19,9 @@ public class Util {
             result.write(buffer, 0, read);
         }
     }
+
+    public static long getUsedHeapBytes() {
+        Runtime runtime = Runtime.getRuntime();
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
 }

--- a/src/main/java/shortestpath/Util.java
+++ b/src/main/java/shortestpath/Util.java
@@ -19,9 +19,4 @@ public class Util {
             result.write(buffer, 0, read);
         }
     }
-
-    public static long getUsedHeapBytes() {
-        Runtime runtime = Runtime.getRuntime();
-        return runtime.totalMemory() - runtime.freeMemory();
-    }
 }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -156,7 +156,6 @@ public class Pathfinder implements Runnable {
         @Getter
         private int nodesChecked = 0, transportsChecked = 0;
         private long startNanos, endNanos;
-        private long startHeapBytes, endHeapBytes;
         private volatile boolean started = false, ended = false;
 
         public int getTotalNodesChecked() {
@@ -167,27 +166,14 @@ public class Pathfinder implements Runnable {
             return endNanos - startNanos;
         }
 
-        // This is not technically correct as GC could happen during pathfinding
-        // However it's close enough to the actual value most of the time to not matter too much
-        public long getEstimatedUsedBytes() {
-            if (endHeapBytes <= startHeapBytes) {
-                // GC definitely occurred; cannot accurately estimate memory usage
-                return -1;
-            }
-
-            return endHeapBytes - startHeapBytes;
-        }
-
         private void start() {
             started = true;
             nodesChecked = 0;
             transportsChecked = 0;
-            startHeapBytes = Util.getUsedHeapBytes();
             startNanos = System.nanoTime();
         }
 
         private void end() {
-            endHeapBytes = Util.getUsedHeapBytes();
             endNanos = System.nanoTime();
             ended = true;
         }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -80,10 +80,14 @@ public class Pathfinder implements Runnable {
         return path;
     }
 
-    private void addNeighbors(Node node) {
+    private Node addNeighbors(Node node) {
         List<Node> nodes = map.getNeighbors(node, visited, config);
         for (int i = 0; i < nodes.size(); ++i) {
             Node neighbor = nodes.get(i);
+            if (neighbor.packedPosition == targetPacked) {
+                return neighbor;
+            }
+
             if (config.isAvoidWilderness() && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness)) {
                 continue;
             }
@@ -97,6 +101,8 @@ public class Pathfinder implements Runnable {
                 ++stats.nodesChecked;
             }
         }
+
+        return null;
     }
 
     @Override
@@ -140,7 +146,12 @@ public class Pathfinder implements Runnable {
                 break;
             }
 
-            addNeighbors(node);
+            // Check if target was found without processing the queue to find it
+            if ((p = addNeighbors(node)) != null) {
+                bestLastNode = p;
+                pathNeedsUpdate = true;
+                break;
+            }
         }
 
         done = !cancelled;

--- a/src/test/java/pathfinder/PathfinderTest.java
+++ b/src/test/java/pathfinder/PathfinderTest.java
@@ -157,6 +157,8 @@ public class PathfinderTest {
             pathfinderConfig,
             new WorldPoint(startX, startY, startZ),
             new WorldPoint(endX, endY, endZ));
-        return pathfinder.getCompletedPath().size();
+
+        pathfinder.run();
+        return pathfinder.getPath().size();
     }
 }


### PR DESCRIPTION
Stress tested plugin stability by spam-clicking options on/off and turning the plugin itself on/off quickly. After a fixing a few breaks/exceptions, the plugin seems to be fully stable.

## Debug Panel
* Added a toggleable `DebugOverlayPanel` with basic stats about path finding
* Shows info about how many nodes were checked, time taken, and ~~rough approximation of memory used~~
* ~~Added a warning for users that memory usage is not 100% accurate and may be off by ±5MB in the worst case~~
* ~~Memory info will show "N/A" when it's obvious that Garbage Collection occurred (i.e. less memory used than when pathfinding started)~~

Edit: Removed memory usage display, see comment below.

<img width="103" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/b5623f5f-3b26-4568-bb66-83b797273dbe">

<details><summary>Old Screenshot</summary><img width="106" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/3aea62db-4fdf-46b7-a2aa-0122f3712f07"></details>

## Additional Changes
* Pathfinding is restarted when the user changes an option related to transports
* Turning the plugin off & back on would hit an exception due to fairy ring transport code
* Moved `ExecutorService` to main plugin and teardown/rebuild the executor as needed
* Pathfinding thread is appropriately named
* `PathfindingTests` doesn't need to run pathfinding on a separate thread
* `AtomicBoolean` was unnecessary in this context and can be replaced with `volatile boolean`
* Set gradle source compatibility to Java 11 due to usage of `String.isBlank` in `Transport.java`
* Avoid processing the entire boundary queue if the target was found