### PR TITLE
Create an interface for external plugins

### DIFF
--- a/src/main/java/shortestpath/DebugOverlayPanel.java
+++ b/src/main/java/shortestpath/DebugOverlayPanel.java
@@ -40,11 +40,18 @@ public class DebugOverlayPanel extends OverlayPanel {
                 .build();
     }
 
+    private LineComponent makeText(String text) {
+        return LineComponent.builder()
+                .left(text)
+                .build();
+    }
+
     @Override
     public Dimension render(Graphics2D graphics) {
+        PathParameters currentParameters = plugin.getPathManager().getCurrentParameters();
         Pathfinder pathfinder = plugin.getPathfinder();
         Pathfinder.PathfinderStats stats;
-        if (pathfinder == null || (stats = pathfinder.getStats()) == null) {
+        if (pathfinder == null || (stats = pathfinder.getStats()) == null || currentParameters == null) {
             return null;
         }
 
@@ -78,6 +85,12 @@ public class DebugOverlayPanel extends OverlayPanel {
         double milliTime = stats.getElapsedTimeNanos() / 1000000.0;
         String time = String.format("%.2fms", milliTime);
         components.add(makeLine("Time:", time));
+
+        components.add(separator);
+
+        components.add(makeText("Path Owner:"));
+        String requester = currentParameters.getRequester().getFullyQualifiedName();
+        components.add(makeText(requester.replaceAll("\\.", " ")));
 
         return super.render(graphics);
     }

--- a/src/main/java/shortestpath/PathParameters.java
+++ b/src/main/java/shortestpath/PathParameters.java
@@ -1,0 +1,51 @@
+package shortestpath;
+
+import lombok.Value;
+import net.runelite.api.coords.WorldPoint;
+
+import java.util.Objects;
+
+@Value
+class PathParameters {
+    private final PluginIdentifier requester;
+    private final WorldPoint start;
+    private final WorldPoint target;
+    private final boolean markerHidden; // Show/hide the target marker on the world map
+    private final boolean visible;
+
+    public PathParameters toggleVisibility() {
+        return new PathParameters(requester, start, target, markerHidden, !visible);
+    }
+
+    public boolean isStartSet() {
+        return start != null;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || !(other instanceof PathParameters)) {
+            return false;
+        }
+
+        PathParameters otherParams = (PathParameters) other;
+        return Objects.equals(requester, otherParams.requester)
+                && Objects.equals(target, otherParams.target)
+                && Objects.equals(start, otherParams.start)
+                && markerHidden == otherParams.markerHidden
+                && visible == otherParams.visible;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 17;
+        hash = hash * 37 + WorldPointUtil.packWorldPoint(start);
+        hash = hash * 37 + WorldPointUtil.packWorldPoint(target);
+        hash = hash * 37 + requester.hashCode();
+        hash = hash * 37 + (markerHidden ? 1 : 0);
+        return hash;
+    }
+}

--- a/src/main/java/shortestpath/PluginIdentifier.java
+++ b/src/main/java/shortestpath/PluginIdentifier.java
@@ -1,0 +1,48 @@
+package shortestpath;
+
+import lombok.Getter;
+import net.runelite.client.plugins.Plugin;
+
+public class PluginIdentifier {
+    @Getter
+    private final String name;
+    @Getter
+    private final String fullyQualifiedName;
+    private final int hashCode;
+
+    public PluginIdentifier(Plugin plugin) {
+        name = plugin.getName();
+        fullyQualifiedName = plugin.getClass().getName();
+        hashCode = fullyQualifiedName.hashCode();
+    }
+
+    PluginIdentifier(String name, String fullyQualifiedName) {
+        this.name = name;
+        this.fullyQualifiedName = fullyQualifiedName;
+        hashCode = fullyQualifiedName.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || !(other instanceof PluginIdentifier)) {
+            return false;
+        }
+
+        // Compare fully-qualified name only in-case plugin name changes
+        return ((PluginIdentifier) other).fullyQualifiedName.equals(fullyQualifiedName);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return name + " [" + fullyQualifiedName + "]";
+    }
+}

--- a/src/main/java/shortestpath/PluginPathManager.java
+++ b/src/main/java/shortestpath/PluginPathManager.java
@@ -1,0 +1,91 @@
+package shortestpath;
+
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class PluginPathManager {
+    private List<PluginIdentifier> pluginPriorities;
+    private Map<PluginIdentifier, PathParameters> pluginMap;
+    private PathParameters currentPath;
+
+    PluginPathManager() {
+        pluginPriorities = new ArrayList<>(32);
+        pluginMap = new HashMap<>(32);
+    }
+
+    public PathParameters getCurrentParameters() {
+        return currentPath;
+    }
+
+    public List<PluginIdentifier> getPluginPriorities() {
+        return pluginPriorities;
+    }
+
+    public PathParameters getParameters(PluginIdentifier pluginIdentifier) {
+        return pluginMap.get(pluginIdentifier);
+    }
+
+    public void addPlugin(PluginIdentifier pluginIdentifier) {
+        if (!pluginPriorities.contains(pluginIdentifier)) {
+            pluginPriorities.add(pluginIdentifier);
+        }
+    }
+
+    public void removePlugin(PluginIdentifier pluginIdentifier) {
+        pluginPriorities.remove(pluginIdentifier);
+        pluginMap.remove(pluginIdentifier);
+    }
+
+    // Returns true if the current path was changed
+    public boolean requestPath(PathParameters parameters) {
+        if (Objects.equals(currentPath, parameters)) {
+            return false;
+        }
+
+        int priority = pluginPriorities.indexOf(parameters.getRequester());
+        pluginMap.put(parameters.getRequester(), parameters);
+        if (priority < 0) {
+            pluginPriorities.add(parameters.getRequester());
+        }
+
+        PathParameters oldPath = currentPath;
+        currentPath = getHighestPriorityPath();
+        return !Objects.equals(oldPath, currentPath);
+    }
+
+    // Current path will become stale; the caller is expected to request the newly returned path
+    PathParameters setNewPriorities(@NonNull List<PluginIdentifier> priorities) {
+        if (priorities.size() != pluginPriorities.size()) {
+            throw new IllegalArgumentException("new priorities size must match");
+        }
+
+        pluginPriorities = priorities;
+        return getHighestPriorityPath();
+    }
+
+    // Current path will become stale; the caller is expected to request the newly returned path
+    PathParameters clearPath(PluginIdentifier requester) {
+        pluginMap.remove(requester);
+        return getHighestPriorityPath();
+    }
+
+    private PathParameters getHighestPriorityPath() {
+        for (int i = 0; i < pluginPriorities.size(); ++i) {
+            PathParameters parameters = pluginMap.get(pluginPriorities.get(i));
+            if (parameters != null && parameters.isVisible()) {
+                return parameters;
+            }
+        }
+
+        return null;
+    }
+
+    public void shutDown() {
+        // TODO: save order
+    }
+}

--- a/src/main/java/shortestpath/ShortestPathAPI.java
+++ b/src/main/java/shortestpath/ShortestPathAPI.java
@@ -17,19 +17,20 @@ public class ShortestPathAPI {
 		this.shortestPathPlugin = plugin;
 	}
 
+	@SuppressWarnings("unchecked")
 	private static <T> T getValidatedObject(Object object, Class<T> expectedType) {
-		if (object == null || !expectedType.isInstance(object)) {
+		if (!expectedType.isInstance(object)) {
 			return null;
 		}
 		return (T) object;
 	}
 
-	public void parseDataMap(Map data) {
+	public void parseDataMap(Map<?, ?> data) {
 		Plugin plugin;
 		if (data.containsKey("plugin")) {
 			plugin = getValidatedObject(data.get("plugin"), Plugin.class);
 			if (plugin == null) {
-				log.debug("Received data without a valid Plugin object");
+				log.debug("Received data without a valid 'plugin' object type");
 				return;
 			}
 		} else {
@@ -40,7 +41,7 @@ public class ShortestPathAPI {
 
 		String command = getValidatedObject(data.get("command"), String.class);
 		if (command == null) {
-			log.debug("{} - Received data without a valid command object", requester);
+			log.debug("{} - Received data without a valid 'command' object", requester);
 			return;
 		}
 
@@ -53,14 +54,14 @@ public class ShortestPathAPI {
 		switch (command) {
 			case "request-path": handleRequestPath(requester, data); break;
 			case "clear-path": handleClearPath(requester); break;
-			default: log.debug("{} - Invalid command: ", requester, command);
+			default: log.debug("{} - Invalid command: {}", requester, command);
 		}
 	}
 
-	private void handleRequestPath(PluginIdentifier requester, Map data) {
+	private void handleRequestPath(PluginIdentifier requester, Map<?, ?> data) {
 		WorldPoint target = getValidatedObject(data.get("target"), WorldPoint.class);
 		if (target == null) {
-			log.debug("{} - Target is either not set or contains an invalid object", requester);
+			log.debug("{} - 'target' is either not set or contains an invalid object type", requester);
 			return;
 		}
 
@@ -68,13 +69,21 @@ public class ShortestPathAPI {
 		if (data.containsKey("start")) {
 			Object startObj = data.get("start");
 			if (startObj != null && !(startObj instanceof WorldPoint)) {
-				log.debug("{} - Start contained an invalid object", requester);
+				log.debug("{} - 'start' contained an invalid object type", requester);
 				return;
 			}
 			start = getValidatedObject(startObj, WorldPoint.class);
 		}
 
-		boolean hideMarker = data.containsKey("hide-marker");
+		boolean hideMarker = false;
+		if (data.containsKey("hide-marker")) {
+			Boolean hideMarkerObj = getValidatedObject(data.get("hide-marker"), Boolean.class);
+			if (hideMarkerObj == null) {
+				log.debug("{} - 'hide-marker' contained an invalid object type", requester);
+				return;
+			}
+			hideMarker = Boolean.TRUE.equals(hideMarkerObj);
+		}
 
 		PathParameters parameters = new PathParameters(requester, start, target, hideMarker, true);
 		shortestPathPlugin.requestPath(parameters);

--- a/src/main/java/shortestpath/ShortestPathAPI.java
+++ b/src/main/java/shortestpath/ShortestPathAPI.java
@@ -1,0 +1,86 @@
+package shortestpath;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.Plugin;
+
+import java.util.Map;
+
+// This class forms the outward-facing "API" to be used by other plugins
+@Slf4j
+public class ShortestPathAPI {
+	private static final String COMMAND_PREFIX = "shortestpath:";
+
+	private final ShortestPathPlugin shortestPathPlugin;
+
+	ShortestPathAPI(ShortestPathPlugin plugin) {
+		this.shortestPathPlugin = plugin;
+	}
+
+	private static <T> T getValidatedObject(Object object, Class<T> expectedType) {
+		if (object == null || !expectedType.isInstance(object)) {
+			return null;
+		}
+		return (T) object;
+	}
+
+	public void parseDataMap(Map data) {
+		Plugin plugin;
+		if (data.containsKey("plugin")) {
+			plugin = getValidatedObject(data.get("plugin"), Plugin.class);
+			if (plugin == null) {
+				log.debug("Received data without a valid Plugin object");
+				return;
+			}
+		} else {
+			log.trace("Received data not containing a 'plugin' key; ignoring");
+			return;
+		}
+		PluginIdentifier requester = new PluginIdentifier(plugin);
+
+		String command = getValidatedObject(data.get("command"), String.class);
+		if (command == null) {
+			log.debug("{} - Received data without a valid command object", requester);
+			return;
+		}
+
+		if (!command.startsWith(COMMAND_PREFIX)) {
+			log.debug("{} - Command uses an invalid prefix: {}", requester, command);
+			return;
+		}
+
+		command = command.substring(command.indexOf(':') + 1);
+		switch (command) {
+			case "request-path": handleRequestPath(requester, data); break;
+			case "clear-path": handleClearPath(requester); break;
+			default: log.debug("{} - Invalid command: ", requester, command);
+		}
+	}
+
+	private void handleRequestPath(PluginIdentifier requester, Map data) {
+		WorldPoint target = getValidatedObject(data.get("target"), WorldPoint.class);
+		if (target == null) {
+			log.debug("{} - Target is either not set or contains an invalid object", requester);
+			return;
+		}
+
+		WorldPoint start = null;
+		if (data.containsKey("start")) {
+			Object startObj = data.get("start");
+			if (startObj != null && !(startObj instanceof WorldPoint)) {
+				log.debug("{} - Start contained an invalid object", requester);
+				return;
+			}
+			start = getValidatedObject(startObj, WorldPoint.class);
+		}
+
+		boolean hideMarker = data.containsKey("hide-marker");
+
+		PathParameters parameters = new PathParameters(requester, start, target, hideMarker, true);
+		shortestPathPlugin.requestPath(parameters);
+	}
+
+	private void handleClearPath(PluginIdentifier requester) {
+		shortestPathPlugin.clearPath(requester);
+	}
+}

--- a/src/main/java/shortestpath/ShortestPathPluginPanel.java
+++ b/src/main/java/shortestpath/ShortestPathPluginPanel.java
@@ -1,0 +1,131 @@
+package shortestpath;
+
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.components.DragAndDropReorderPane;
+import net.runelite.client.ui.components.MouseDragEventForwarder;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShortestPathPluginPanel extends PluginPanel {
+    private ShortestPathPlugin plugin;
+
+    private final DragAndDropReorderPane pluginListPanel;
+
+    public ShortestPathPluginPanel(ShortestPathPlugin plugin) {
+        this.plugin = plugin;
+
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(10, 10, 10, 10));
+
+        JPanel northPanel = new JPanel(new BorderLayout());
+        northPanel.setBorder(new EmptyBorder(1,1,10,0));
+
+        JPanel titlePanel = new JPanel(new BorderLayout());
+        titlePanel.setBorder(new EmptyBorder(1, 3, 10, 7));
+
+        JLabel title = new JLabel();
+        title.setText("Shortest Path");
+        title.setForeground(Color.WHITE);
+        titlePanel.add(title, BorderLayout.WEST);
+
+        pluginListPanel = new DragAndDropReorderPane();
+        pluginListPanel.addDragListener(component -> {
+            Component[] components = component.getParent().getComponents();
+            List<PluginIdentifier> plugins = new ArrayList<>(plugin.getPathManager().getPluginPriorities().size());
+            for (Component c : components) {
+                if (c instanceof PluginPathPanel) {
+                    PluginPathPanel pathPanel = (PluginPathPanel)c;
+                    plugins.add(pathPanel.ownerPlugin);
+                }
+            }
+            plugin.setNewPriorities(plugins);
+        });
+
+        pluginListPanel.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+
+        JPanel centerPanel = new JPanel(new BorderLayout());
+        centerPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+        centerPanel.add(pluginListPanel, BorderLayout.NORTH);
+
+        add(titlePanel, BorderLayout.NORTH);
+        add(centerPanel, BorderLayout.CENTER);
+
+        repaintAsync();
+    }
+
+    void repaintAsync() {
+        SwingUtilities.invokeLater(() -> {
+            pluginListPanel.removeAll();
+            PluginPathManager pm = plugin.getPathManager();
+            List<PluginIdentifier> pluginIdentifiers = pm.getPluginPriorities();
+
+            for (PluginIdentifier pi : pluginIdentifiers) {
+                pluginListPanel.add(new PluginPathPanel(pi, pm.getParameters(pi), pluginListPanel));
+            }
+
+            pluginListPanel.revalidate();
+            revalidate();
+            repaint();
+        });
+    }
+
+    private class PluginPathPanel extends JPanel {
+        private final String VISIBLE_ICON = "\uD83D\uDC41";
+        private final String HIDDEN_ICON = "⬭";
+        private final JLabel pluginName;
+
+        private final PluginIdentifier ownerPlugin;
+
+        PluginPathPanel(PluginIdentifier ownerPlugin, PathParameters parameters, JComponent panel) {
+            this.ownerPlugin = ownerPlugin;
+
+            setLayout(new BorderLayout());
+            setBorder(new EmptyBorder(5, 0, 0, 0));
+
+            JPanel mainLayout = new JPanel();
+            mainLayout.setLayout(new BorderLayout());
+            mainLayout.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+            mainLayout.setBorder(new EmptyBorder(4, 4, 4, 4));
+
+            pluginName = new JLabel();
+            pluginName.setText(ownerPlugin.getName());
+
+            JLabel visiblityPath = new JLabel();
+            if (parameters != null) {
+                visiblityPath.setText(parameters.isVisible() ? VISIBLE_ICON : HIDDEN_ICON);
+                visiblityPath.addMouseListener(new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        plugin.requestPath(parameters.toggleVisibility());
+                    }
+                });
+            }
+
+            MouseDragEventForwarder mouseDragEventForwarder = new MouseDragEventForwarder(panel);
+            addMouseMotionListener(mouseDragEventForwarder);
+            addMouseListener(mouseDragEventForwarder);
+            pluginName.addMouseMotionListener(mouseDragEventForwarder);
+            pluginName.addMouseListener(mouseDragEventForwarder);
+
+            mainLayout.add(pluginName, BorderLayout.CENTER);
+
+            if (parameters != null) {
+                mainLayout.add(visiblityPath, BorderLayout.LINE_END);
+            }
+
+            add(mainLayout, BorderLayout.CENTER);
+        }
+    }
+}


### PR DESCRIPTION
This PR is incomplete, namely UI and API is not finalized. I'm publishing it to receive feedback from others.

## Overview 
A common request I see from other plugin developers is wanting some way to interface with shortest path but there currently doesn't exist a way to do so. This PR proposes a potential API that can be exposed to external plugins to allow them to make requests while also allowing users to control which paths are visible and prioritize which plugin paths should override other paths.

* Plugins may now use an API over the event bus to request paths
  * Currently uses a `HashMap` to transfer data until some form of Plugin Messaging event is added to RuneLite, a la: https://github.com/runelite/runelite/pull/16863
  * Plugins can only modify their own requested paths; they cannot clear/change paths for other plugins.
  * For now, plugins can only request one path at a time. Any new requests overwrite the old one.
  * Similarly, Shortest Path currently only displays one path at a time determined by the priority list and visibility.
  * Shortest Path still processes requests for bookkeeping even if the shortest path plugin is disabled, it just won't do the actual pathfinding unless it's enabled.
  * Shortest Path attempts to respect other plugins requests and provides no option to cancel/clear plugin paths directly, only toggle visibility.
* Refactored how shortest path handles path finding requests internally; all internal requests for pathfinding go through the same `requestPath` code path as external plugins.
* Optimized the `startUp` and `shutDown` functions to avoid redundantly loading data in-case the user toggles the plugin on/off.
* Plugin Panel shows a drag-and-drop list of plugins. Plugins higher-up have a higher priority.
  <img width="200" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/8caa8be0-6c42-4adb-81d2-f9b8271695e5">
* Debug Overlay now shows the path owner:
  <img width="200" alt="image" src="https://github.com/Skretzo/shortest-path/assets/2230152/1990fb9c-16b6-41e5-840a-1224181f48ad">

### Notes
* Priority list order is not yet saved. Was wondering if it should be saved at all or reset each time the client starts up
* All icons for UI are placeholders until I can either make new assets or find some with an agreeable license.
* Navigation Button currently uses [marker.png](https://github.com/Skretzo/shortest-path/blob/74a8f15d19c4b1138a0c09bfdb089cd93982f8c7/src/main/resources/marker.png) as the plugin's icon; open to ideas for something better to use.

### Video Demo
Video demonstrates that shortest-path's normal functions still work as expected, but also that other plugins (e.x. Quest Helper) can interface with it. Plugins can be re-ordered and paths hidden via the side panel. Shortest Path still tracks request/clear commands even if it's disabled so that the data remains current the next time it's enabled.

https://github.com/Skretzo/shortest-path/assets/2230152/33622cee-eed8-49d2-9b52-a416f0a0bee7

## API

This initial proposal is meant to implement the bare minimum feature-set most people want and that can be easily maintained going forward. Additional features like changing pathfinding options, drawing multiple paths, changing path colors, etc., are out of the intended scope of this PR.

Plugins interface over the `EventBus` by passing a hashmap of type `HashMap<String, Object>` containing the required parameters. Any invalid requests or requests with invalid/missing parameters are ignored and a debug message printed. For simplicity, the API is entirely one-way communication and Shortest Path does not send responses or acknowledgements back to requesters. Here is a [working example class](https://gist.github.com/jocopa3/c3260fd3443ec2c07d9a61b915f4a3ff) that external plugins can use directly to interface with shortest path or use as a reference.

Internally, the API side is handled by `ShortestPathAPI.java`. It validates that the objects received are the correct types and prints debug messages when it receives invalid requests or parameters; these messages can be seen in logs or when RuneLite is run with the `--debug` argument.

### Required Parameters 

There are a few parameters that are required in all events:
Key | Type | Description
| --- | --- | --- |
`plugin` | Plugin | Required. A reference to the plugin making the path requests.
`command` | String | Required. Must start with `shortestpath:` followed by the command.

### Commands
* `request-path`: Asks shortest path to try and draw a path from the player's position or start point to the target point. The requested path will only be drawn if no other plugin has an active path or the requesting plugin is higher on the user's priority list than other plugins with active paths.
* `clear-path`: Clears any paths set by the requesting plugin; does not affect other plugins paths.

Some commands may have additional parameters as listed below.

**`request-path` Command:**
Key | Type | Description
| --- | --- | --- |
`target` | WorldPoint | Required. The world point for where the path ends.
`start` | WorldPoint | Optional. The world point that marks where the path should start. If missing or `null`, then the player's position is used as the start point.
`hide-marker` | Boolean | Optional. If the key exists and value is `true`, shortest path won't draw the target "marker" overlay on the world map. This is useful to plugins like Quest Helper that already draw their own world map marker.