### PR TITLE
Add Giantsoul amulet teleports

### DIFF
--- a/src/main/resources/transports/teleportation_items.tsv
+++ b/src/main/resources/transports/teleportation_items.tsv
@@ -245,6 +245,10 @@
 3144 3772 0			13280=1||13342=1		4	Max cape: Other Teleports: Black chinchompa	T	20	
 1558 3046 0			13280=1||13342=1		4	Max cape: Other Teleports: Hunter Guild	F	20	
 1248 3725 0			13280=1||13342=1		4	Max cape: Other Teleports: Farming Guild	F	20	
+# Giantsoul amulet									
+3174 9898 0			30638=1		4	Giantsoul amulet: 1. Bryophyta	T	20	
+3096 9833 0			30638=1		4	Giantsoul amulet: 2. Obor	T	20	
+2952 9574 0			30638=1		4	Giantsoul amulet: 3. Brand & Eldtrich	T	20	
 2729 3348 0			9813=1||13068=1		4	Quest point cape: Teleport	F	20	
 2689 3547 0			13221=1||13222=1		4	Music cape: Teleport	F	20	
 2574 3323 0			13069=1||19476=1		4	Achievement diary cape: 1. Two-pints	F	20	


### PR DESCRIPTION
Add teleport destinations for the Giantsoul amulet:
- Bryophyta's lair (3174, 9898, 0)
- Obor's lair (3096, 9833, 0)
- Brand & Eldtrich's lair (2952, 9574, 0)