### PR TITLE
Show tiles saved when offering teleports & option to show a walkable path aswell

### DIFF
--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -93,10 +93,32 @@ public class PathMapOverlay extends Overlay {
             }
         }
 
-        if (plugin.getPathfinder() != null) {
+        Point cursorPos = client.getMouseCanvasPosition();
+        
+        // Draw walking-only path first if showBothPaths is enabled
+        if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && plugin.getWalkingPathfinder().getPath() != null) {
+            Color walkingColour = plugin.getWalkingPathfinder().isDone() 
+                ? new Color(plugin.colourWalkingPath.getRed(), plugin.colourWalkingPath.getGreen(),
+                           plugin.colourWalkingPath.getBlue(), plugin.colourWalkingPath.getAlpha() / 2)
+                : new Color(plugin.colourPathCalculating.getRed(), plugin.colourPathCalculating.getGreen(),
+                           plugin.colourPathCalculating.getBlue(), plugin.colourPathCalculating.getAlpha() / 2);
+            List<Integer> walkingPath = plugin.getWalkingPathfinder().getPath();
+            
+            for (int i = 0; i < walkingPath.size(); i++) {
+                graphics.setColor(walkingColour);
+                int point = walkingPath.get(i);
+                int lastPoint = (i > 0) ? walkingPath.get(i - 1) : point;
+                if (WorldPointUtil.distanceBetween(point, lastPoint) > 1) {
+                    drawOnMap(graphics, lastPoint, point, false, cursorPos);
+                }
+                drawOnMap(graphics, point, false, cursorPos);
+            }
+        }
+        
+        // Draw main path
+        if (plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
             Color colour = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
             List<Integer> path = plugin.getPathfinder().getPath();
-            Point cursorPos = client.getMouseCanvasPosition();
             for (int i = 0; i < path.size(); i++) {
                 graphics.setColor(colour);
                 int point = path.get(i);

--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -1,6 +1,7 @@
 package shortestpath;
 
 import com.google.inject.Inject;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -9,6 +10,7 @@ import java.awt.Rectangle;
 import java.awt.geom.Area;
 import java.util.HashSet;
 import java.util.List;
+
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.widgets.ComponentID;
@@ -94,16 +96,16 @@ public class PathMapOverlay extends Overlay {
         }
 
         Point cursorPos = client.getMouseCanvasPosition();
-        
+
         // Draw walking-only path first if showBothPaths is enabled
         if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && plugin.getWalkingPathfinder().getPath() != null) {
-            Color walkingColour = plugin.getWalkingPathfinder().isDone() 
-                ? new Color(plugin.colourWalkingPath.getRed(), plugin.colourWalkingPath.getGreen(),
-                           plugin.colourWalkingPath.getBlue(), plugin.colourWalkingPath.getAlpha() / 2)
-                : new Color(plugin.colourPathCalculating.getRed(), plugin.colourPathCalculating.getGreen(),
-                           plugin.colourPathCalculating.getBlue(), plugin.colourPathCalculating.getAlpha() / 2);
+            Color walkingColour = plugin.getWalkingPathfinder().isDone()
+                    ? new Color(plugin.colourWalkingPath.getRed(), plugin.colourWalkingPath.getGreen(),
+                    plugin.colourWalkingPath.getBlue(), plugin.colourWalkingPath.getAlpha() / 2)
+                    : new Color(plugin.colourPathCalculating.getRed(), plugin.colourPathCalculating.getGreen(),
+                    plugin.colourPathCalculating.getBlue(), plugin.colourPathCalculating.getAlpha() / 2);
             List<Integer> walkingPath = plugin.getWalkingPathfinder().getPath();
-            
+
             for (int i = 0; i < walkingPath.size(); i++) {
                 graphics.setColor(walkingColour);
                 int point = walkingPath.get(i);
@@ -114,7 +116,7 @@ public class PathMapOverlay extends Overlay {
                 drawOnMap(graphics, point, false, cursorPos);
             }
         }
-        
+
         // Draw main path
         if (plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
             Color colour = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
@@ -150,7 +152,7 @@ public class PathMapOverlay extends Overlay {
         int endY = plugin.mapWorldPointToGraphicsPointY(offsetPoint);
 
         if (startX == Integer.MIN_VALUE || startY == Integer.MIN_VALUE ||
-            endX == Integer.MIN_VALUE || endY == Integer.MIN_VALUE) {
+                endX == Integer.MIN_VALUE || endY == Integer.MIN_VALUE) {
             return;
         }
 
@@ -166,8 +168,8 @@ public class PathMapOverlay extends Overlay {
             graphics.drawLine(startX, startY, endX, endY);
         } else {
             if (checkHover && cursorPos != null &&
-                cursorPos.getX() >= x && cursorPos.getX() <= (endX - width / 2) &&
-                cursorPos.getY() >= y && cursorPos.getY() <= (endY - width / 2)) {
+                    cursorPos.getX() >= x && cursorPos.getX() <= (endX - width / 2) &&
+                    cursorPos.getY() >= y && cursorPos.getY() <= (endY - width / 2)) {
                 graphics.setColor(graphics.getColor().darker());
             }
             graphics.fillRect(x, y, width, height);
@@ -193,25 +195,25 @@ public class PathMapOverlay extends Overlay {
 
     private int getWorldMapExtentWidth(Rectangle baseRectangle) {
         return (
-            WorldPointUtil.unpackWorldX(
-                plugin.calculateMapPoint(
-                    baseRectangle.x + baseRectangle.width,
-                    baseRectangle.y + baseRectangle.height)) -
-            WorldPointUtil.unpackWorldX(
-                plugin.calculateMapPoint(
-                    baseRectangle.x,
-                    baseRectangle.y)));
+                WorldPointUtil.unpackWorldX(
+                        plugin.calculateMapPoint(
+                                baseRectangle.x + baseRectangle.width,
+                                baseRectangle.y + baseRectangle.height)) -
+                        WorldPointUtil.unpackWorldX(
+                                plugin.calculateMapPoint(
+                                        baseRectangle.x,
+                                        baseRectangle.y)));
     }
 
     private int getWorldMapExtentHeight(Rectangle baseRectangle) {
         return (
-            WorldPointUtil.unpackWorldY(
-                plugin.calculateMapPoint(
-                    baseRectangle.x,
-                    baseRectangle.y)) -
-            WorldPointUtil.unpackWorldY(
-                plugin.calculateMapPoint(
-                    baseRectangle.x + baseRectangle.width,
-                    baseRectangle.y + baseRectangle.height)));
+                WorldPointUtil.unpackWorldY(
+                        plugin.calculateMapPoint(
+                                baseRectangle.x,
+                                baseRectangle.y)) -
+                        WorldPointUtil.unpackWorldY(
+                                plugin.calculateMapPoint(
+                                        baseRectangle.x + baseRectangle.width,
+                                        baseRectangle.y + baseRectangle.height)));
     }
 }

--- a/src/main/java/shortestpath/PathMapTooltipOverlay.java
+++ b/src/main/java/shortestpath/PathMapTooltipOverlay.java
@@ -1,6 +1,7 @@
 package shortestpath;
 
 import com.google.inject.Inject;
+
 import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+
 import net.runelite.api.Client;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
@@ -77,37 +79,37 @@ public class PathMapTooltipOverlay extends Overlay {
         int endY = plugin.mapWorldPointToGraphicsPointY(offsetPoint);
 
         if (startX == Integer.MIN_VALUE || startY == Integer.MIN_VALUE ||
-            endX == Integer.MIN_VALUE || endY == Integer.MIN_VALUE) {
+                endX == Integer.MIN_VALUE || endY == Integer.MIN_VALUE) {
             return false;
         }
 
         int width = endX - startX;
 
         if (cursorPos.getX() < (startX - width / 2) || cursorPos.getX() > (endX - width / 2) ||
-            cursorPos.getY() < (startY - width / 2) || cursorPos.getY() > (endY - width / 2)) {
+                cursorPos.getY() < (startY - width / 2) || cursorPos.getY() > (endY - width / 2)) {
             return false;
         }
 
         List<String> rows = new ArrayList<>(Arrays.asList("Shortest path:",
-            n < 0 ? "Unused target" : ("Step " + n + " of " + plugin.getPathfinder().getPath().size())));
+                n < 0 ? "Unused target" : ("Step " + n + " of " + plugin.getPathfinder().getPath().size())));
         if (nextPoint != WorldPointUtil.UNDEFINED) {
             for (Transport transport : plugin.getTransports().getOrDefault(point, new HashSet<>())) {
                 if (nextPoint == transport.getDestination()
-                    && transport.getDisplayInfo() != null && !transport.getDisplayInfo().isEmpty()) {
+                        && transport.getDisplayInfo() != null && !transport.getDisplayInfo().isEmpty()) {
                     String transportText = transport.getDisplayInfo();
-                    
-                    
+
+
                     if (plugin.showTilesSaved && TransportType.isResourceMovement(transport.getType())) {
                         Player localPlayer = client.getLocalPlayer();
                         if (localPlayer != null) {
                             int currentLocation = WorldPointUtil.fromLocalInstance(client, localPlayer.getLocalLocation());
                             List<Integer> path = plugin.getPathfinder().getPath();
-                            
+
                             int remainingPathDistance = calculatePathDistance(path, transport.getDestination(), finalDestination);
-                            
+
                             int walkingDistance;
-                            if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && 
-                                plugin.getWalkingPathfinder().isDone() && plugin.getWalkingPathfinder().getPath() != null) {
+                            if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null &&
+                                    plugin.getWalkingPathfinder().isDone() && plugin.getWalkingPathfinder().getPath() != null) {
                                 // Use actual walking path distance
                                 List<Integer> walkingPath = plugin.getWalkingPathfinder().getPath();
                                 walkingDistance = calculatePathDistance(walkingPath, currentLocation, finalDestination);
@@ -119,7 +121,7 @@ public class PathMapTooltipOverlay extends Overlay {
                                 // Use straight-line distance as approximation
                                 walkingDistance = WorldPointUtil.distanceBetween(currentLocation, finalDestination);
                             }
-                            
+
                             if (remainingPathDistance != -1 && walkingDistance > remainingPathDistance) {
                                 int tilesSaved = walkingDistance - remainingPathDistance;
                                 if (tilesSaved > 0) {
@@ -128,7 +130,7 @@ public class PathMapTooltipOverlay extends Overlay {
                             }
                         }
                     }
-                    
+
                     rows.add(transportText);
                     break;
                 }
@@ -173,11 +175,11 @@ public class PathMapTooltipOverlay extends Overlay {
 
         return true;
     }
-    
+
     private int calculatePathDistance(List<Integer> path, int startPoint, int endPoint) {
         int startIndex = -1;
         int endIndex = -1;
-        
+
         for (int i = 0; i < path.size(); i++) {
             if (path.get(i) == startPoint) {
                 startIndex = i;
@@ -186,16 +188,16 @@ public class PathMapTooltipOverlay extends Overlay {
                 endIndex = i;
             }
         }
-        
+
         if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
             return -1;
         }
-        
+
         int totalDistance = 0;
         for (int i = startIndex + 1; i <= endIndex; i++) {
             totalDistance += WorldPointUtil.distanceBetween(path.get(i - 1), path.get(i));
         }
-        
+
         return totalDistance;
     }
 }

--- a/src/main/java/shortestpath/PathMinimapOverlay.java
+++ b/src/main/java/shortestpath/PathMinimapOverlay.java
@@ -1,12 +1,14 @@
 package shortestpath;
 
 import com.google.inject.Inject;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.util.List;
+
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
@@ -42,15 +44,15 @@ public class PathMinimapOverlay extends Overlay {
         }
         graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 
-        
+
         if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && plugin.getWalkingPathfinder().getPath() != null) {
             List<Integer> walkingPathPoints = plugin.getWalkingPathfinder().getPath();
-            Color walkingPathColor = plugin.getWalkingPathfinder().isDone() 
-                ? new Color(plugin.colourWalkingPath.getRed(), plugin.colourWalkingPath.getGreen(), 
-                           plugin.colourWalkingPath.getBlue(), plugin.colourWalkingPath.getAlpha() / 2)
-                : new Color(plugin.colourPathCalculating.getRed(), plugin.colourPathCalculating.getGreen(),
-                           plugin.colourPathCalculating.getBlue(), plugin.colourPathCalculating.getAlpha() / 2);
-            
+            Color walkingPathColor = plugin.getWalkingPathfinder().isDone()
+                    ? new Color(plugin.colourWalkingPath.getRed(), plugin.colourWalkingPath.getGreen(),
+                    plugin.colourWalkingPath.getBlue(), plugin.colourWalkingPath.getAlpha() / 2)
+                    : new Color(plugin.colourPathCalculating.getRed(), plugin.colourPathCalculating.getGreen(),
+                    plugin.colourPathCalculating.getBlue(), plugin.colourPathCalculating.getAlpha() / 2);
+
             for (int pathPoint : walkingPathPoints) {
                 if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {
                     continue;

--- a/src/main/java/shortestpath/PathMinimapOverlay.java
+++ b/src/main/java/shortestpath/PathMinimapOverlay.java
@@ -30,7 +30,7 @@ public class PathMinimapOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
-        if (!plugin.drawMinimap || plugin.getPathfinder() == null) {
+        if (!plugin.drawMinimap) {
             return null;
         }
 
@@ -42,18 +42,38 @@ public class PathMinimapOverlay extends Overlay {
         }
         graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 
-        List<Integer> pathPoints = plugin.getPathfinder().getPath();
-        Color pathColor = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
-        for (int pathPoint : pathPoints) {
-            if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {
-                continue;
+        
+        if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && plugin.getWalkingPathfinder().getPath() != null) {
+            List<Integer> walkingPathPoints = plugin.getWalkingPathfinder().getPath();
+            Color walkingPathColor = plugin.getWalkingPathfinder().isDone() 
+                ? new Color(plugin.colourWalkingPath.getRed(), plugin.colourWalkingPath.getGreen(), 
+                           plugin.colourWalkingPath.getBlue(), plugin.colourWalkingPath.getAlpha() / 2)
+                : new Color(plugin.colourPathCalculating.getRed(), plugin.colourPathCalculating.getGreen(),
+                           plugin.colourPathCalculating.getBlue(), plugin.colourPathCalculating.getAlpha() / 2);
+            
+            for (int pathPoint : walkingPathPoints) {
+                if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {
+                    continue;
+                }
+                drawOnMinimap(graphics, pathPoint, walkingPathColor);
             }
-
-            drawOnMinimap(graphics, pathPoint, pathColor);
         }
-        for (int target : plugin.getPathfinder().getTargets()) {
-            if (pathPoints.size() > 0 && target != pathPoints.get(pathPoints.size() - 1)) {
-                drawOnMinimap(graphics, target, plugin.colourPathCalculating);
+
+        // Draw main path
+        if (plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
+            List<Integer> pathPoints = plugin.getPathfinder().getPath();
+            Color pathColor = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
+            for (int pathPoint : pathPoints) {
+                if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {
+                    continue;
+                }
+
+                drawOnMinimap(graphics, pathPoint, pathColor);
+            }
+            for (int target : plugin.getPathfinder().getTargets()) {
+                if (pathPoints.size() > 0 && target != pathPoints.get(pathPoints.size() - 1)) {
+                    drawOnMinimap(graphics, target, plugin.colourPathCalculating);
+                }
             }
         }
 

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -1,6 +1,7 @@
 package shortestpath;
 
 import com.google.inject.Inject;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -11,6 +12,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
@@ -134,17 +136,17 @@ public class PathTileOverlay extends Overlay {
         if (plugin.drawTiles) {
             if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && plugin.getWalkingPathfinder().getPath() != null) {
                 Color walkingColorCalculating = new Color(
-                    plugin.colourPathCalculating.getRed(),
-                    plugin.colourPathCalculating.getGreen(),
-                    plugin.colourPathCalculating.getBlue(),
-                    plugin.colourPathCalculating.getAlpha() / 4); 
+                        plugin.colourPathCalculating.getRed(),
+                        plugin.colourPathCalculating.getGreen(),
+                        plugin.colourPathCalculating.getBlue(),
+                        plugin.colourPathCalculating.getAlpha() / 4);
                 Color walkingColor = plugin.getWalkingPathfinder().isDone()
-                    ? new Color(
+                        ? new Color(
                         plugin.colourWalkingPath.getRed(),
                         plugin.colourWalkingPath.getGreen(),
                         plugin.colourWalkingPath.getBlue(),
-                        plugin.colourWalkingPath.getAlpha() / 4) 
-                    : walkingColorCalculating;
+                        plugin.colourWalkingPath.getAlpha() / 4)
+                        : walkingColorCalculating;
 
                 List<Integer> walkingPath = plugin.getWalkingPathfinder().getPath();
                 if (TileStyle.LINES.equals(plugin.pathStyle)) {
@@ -158,21 +160,21 @@ public class PathTileOverlay extends Overlay {
                     }
                 }
             }
-            
-            
+
+
             if (plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
                 Color colorCalculating = new Color(
-                    plugin.colourPathCalculating.getRed(),
-                    plugin.colourPathCalculating.getGreen(),
-                    plugin.colourPathCalculating.getBlue(),
-                    plugin.colourPathCalculating.getAlpha() / 2);
+                        plugin.colourPathCalculating.getRed(),
+                        plugin.colourPathCalculating.getGreen(),
+                        plugin.colourPathCalculating.getBlue(),
+                        plugin.colourPathCalculating.getAlpha() / 2);
                 Color color = plugin.getPathfinder().isDone()
-                    ? new Color(
+                        ? new Color(
                         plugin.colourPath.getRed(),
                         plugin.colourPath.getGreen(),
                         plugin.colourPath.getBlue(),
                         plugin.colourPath.getAlpha() / 2)
-                    : colorCalculating;
+                        : colorCalculating;
 
                 List<Integer> path = plugin.getPathfinder().getPath();
                 int counter = 0;
@@ -315,15 +317,15 @@ public class PathTileOverlay extends Overlay {
             String counterText = Integer.toString(counter);
             graphics.setColor(plugin.colourText);
             graphics.drawString(
-                counterText,
-                (int) (x - graphics.getFontMetrics().getStringBounds(counterText, graphics).getWidth() / 2), (int) y);
+                    counterText,
+                    (int) (x - graphics.getFontMetrics().getStringBounds(counterText, graphics).getWidth() / 2), (int) y);
         }
     }
 
     private int calculatePathDistance(List<Integer> path, int startPoint, int endPoint) {
         int startIndex = -1;
         int endIndex = -1;
-        
+
         for (int i = 0; i < path.size(); i++) {
             if (path.get(i) == startPoint) {
                 startIndex = i;
@@ -332,16 +334,16 @@ public class PathTileOverlay extends Overlay {
                 endIndex = i;
             }
         }
-        
+
         if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
             return -1;
         }
-        
+
         int totalDistance = 0;
         for (int i = startIndex + 1; i <= endIndex; i++) {
             totalDistance += WorldPointUtil.distanceBetween(path.get(i - 1), path.get(i));
         }
-        
+
         return totalDistance;
     }
 
@@ -350,8 +352,7 @@ public class PathTileOverlay extends Overlay {
             return;
         }
         for (int point : WorldPointUtil.toLocalInstance(client, location)) {
-            for (int pointEnd : WorldPointUtil.toLocalInstance(client, locationEnd))
-            {
+            for (int pointEnd : WorldPointUtil.toLocalInstance(client, locationEnd)) {
                 if (WorldPointUtil.unpackWorldPlane(point) != client.getPlane()) {
                     continue;
                 }
@@ -371,12 +372,12 @@ public class PathTileOverlay extends Overlay {
                         Player localPlayer = client.getLocalPlayer();
                         if (localPlayer != null) {
                             int currentLocation = WorldPointUtil.fromLocalInstance(client, localPlayer.getLocalLocation());
-                            
+
                             int remainingPathDistance = calculatePathDistance(path, transport.getDestination(), finalDestination);
-                            
+
                             int walkingDistance;
-                            if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null && 
-                                plugin.getWalkingPathfinder().isDone() && plugin.getWalkingPathfinder().getPath() != null) {
+                            if (plugin.showBothPaths && plugin.getWalkingPathfinder() != null &&
+                                    plugin.getWalkingPathfinder().isDone() && plugin.getWalkingPathfinder().getPath() != null) {
                                 List<Integer> walkingPath = plugin.getWalkingPathfinder().getPath();
                                 walkingDistance = calculatePathDistance(walkingPath, currentLocation, finalDestination);
                                 if (walkingDistance == -1) {
@@ -385,7 +386,7 @@ public class PathTileOverlay extends Overlay {
                             } else {
                                 walkingDistance = WorldPointUtil.distanceBetween(currentLocation, finalDestination);
                             }
-                            
+
                             if (remainingPathDistance != -1 && walkingDistance > remainingPathDistance) {
                                 int tilesSaved = walkingDistance - remainingPathDistance;
                                 if (tilesSaved > 0) {

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -397,10 +397,32 @@ public interface ShortestPathConfig extends Config {
         return TileStyle.TILES;
     }
 
+    @ConfigItem(
+        keyName = "showTilesSaved",
+        name = "Show tiles saved",
+        description = "Whether to display tiles saved when using teleports",
+        position = 33,
+        section = sectionDisplay
+    )
+    default boolean showTilesSaved() {
+        return true;
+    }
+
+    @ConfigItem(
+        keyName = "showBothPaths",
+        name = "Show both teleport and walking paths",
+        description = "Whether to display both the teleport path and walking-only path when a teleport option is available",
+        position = 34,
+        section = sectionDisplay
+    )
+    default boolean showBothPaths() {
+        return false;
+    }
+
     @ConfigSection(
         name = "Colours",
         description = "Colours for the path map, minimap and scene tiles",
-        position = 33
+        position = 35
     )
     String sectionColours = "sectionColours";
 
@@ -409,7 +431,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPath",
         name = "Path",
         description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 34,
+        position = 36,
         section = sectionColours
     )
     default Color colourPath() {
@@ -418,11 +440,23 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
+        keyName = "colourWalkingPath",
+        name = "Walking-only path",
+        description = "Colour of the walking-only path tiles when both paths are shown",
+        position = 37,
+        section = sectionColours
+    )
+    default Color colourWalkingPath() {
+        return new Color(255, 165, 0); // Orange color
+    }
+
+    @Alpha
+    @ConfigItem(
         keyName = "colourPathCalculating",
         name = "Calculating",
         description = "Colour of the path tiles while the pathfinding calculation is in progress," +
             "<br>and the colour of unused targets if there are more than a single target",
-        position = 35,
+        position = 38,
         section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -434,7 +468,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 36,
+        position = 39,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -446,7 +480,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 37,
+        position = 40,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -458,7 +492,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 38,
+        position = 41,
         section = sectionColours
     )
     default Color colourText() {
@@ -468,7 +502,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Debug Options",
         description = "Various options for debugging",
-        position = 39,
+        position = 42,
         closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
@@ -477,7 +511,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTransports",
         name = "Draw transports",
         description = "Whether transports should be drawn",
-        position = 40,
+        position = 43,
         section = sectionDebug
     )
     default boolean drawTransports() {
@@ -488,7 +522,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawCollisionMap",
         name = "Draw collision map",
         description = "Whether the collision map should be drawn",
-        position = 41,
+        position = 44,
         section = sectionDebug
     )
     default boolean drawCollisionMap() {
@@ -499,7 +533,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawDebugPanel",
         name = "Show debug panel",
         description = "Toggles displaying the pathfinding debug stats panel",
-        position = 42,
+        position = 45,
         section = sectionDebug
     )
     default boolean drawDebugPanel() {

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -1,6 +1,7 @@
 package shortestpath;
 
 import java.awt.Color;
+
 import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
@@ -12,427 +13,425 @@ import net.runelite.client.config.Units;
 @ConfigGroup(ShortestPathPlugin.CONFIG_GROUP)
 public interface ShortestPathConfig extends Config {
     @ConfigSection(
-        name = "Settings",
-        description = "Options for the pathfinding",
-        position = 0
+            name = "Settings",
+            description = "Options for the pathfinding",
+            position = 0
     )
     String sectionSettings = "sectionSettings";
 
     @ConfigItem(
-        keyName = "avoidWilderness",
-        name = "Avoid wilderness",
-        description = "Whether the wilderness should be avoided if possible<br>" +
-            "(otherwise, will e.g. use wilderness lever from Edgeville to Ardougne)",
-        position = 1,
-        section = sectionSettings
+            keyName = "avoidWilderness",
+            name = "Avoid wilderness",
+            description = "Whether the wilderness should be avoided if possible<br>" +
+                    "(otherwise, will e.g. use wilderness lever from Edgeville to Ardougne)",
+            position = 1,
+            section = sectionSettings
     )
     default boolean avoidWilderness() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useAgilityShortcuts",
-        name = "Use agility shortcuts",
-        description = "Whether to include agility shortcuts in the path.<br>" +
-            "You must also have the required agility level",
-        position = 2,
-        section = sectionSettings
+            keyName = "useAgilityShortcuts",
+            name = "Use agility shortcuts",
+            description = "Whether to include agility shortcuts in the path.<br>" +
+                    "You must also have the required agility level",
+            position = 2,
+            section = sectionSettings
     )
     default boolean useAgilityShortcuts() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useGrappleShortcuts",
-        name = "Use grapple shortcuts",
-        description = "Whether to include crossbow grapple agility shortcuts in the path.<br>" +
-            "You must also have the required agility, ranged and strength levels",
-        position = 3,
-        section = sectionSettings
+            keyName = "useGrappleShortcuts",
+            name = "Use grapple shortcuts",
+            description = "Whether to include crossbow grapple agility shortcuts in the path.<br>" +
+                    "You must also have the required agility, ranged and strength levels",
+            position = 3,
+            section = sectionSettings
     )
     default boolean useGrappleShortcuts() {
         return false;
     }
 
     @ConfigItem(
-        keyName = "useBoats",
-        name = "Use boats",
-        description = "Whether to include small boats in the path<br>" +
-            "(e.g. the boat to Fishing Platform)",
-        position = 4,
-        section = sectionSettings
+            keyName = "useBoats",
+            name = "Use boats",
+            description = "Whether to include small boats in the path<br>" +
+                    "(e.g. the boat to Fishing Platform)",
+            position = 4,
+            section = sectionSettings
     )
     default boolean useBoats() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useCanoes",
-        name = "Use canoes",
-        description = "Whether to include canoes in the path",
-        position = 5,
-        section = sectionSettings
+            keyName = "useCanoes",
+            name = "Use canoes",
+            description = "Whether to include canoes in the path",
+            position = 5,
+            section = sectionSettings
     )
     default boolean useCanoes() {
         return false;
     }
 
     @ConfigItem(
-        keyName = "useCharterShips",
-        name = "Use charter ships",
-        description = "Whether to include charter ships in the path",
-        position = 6,
-        section = sectionSettings
+            keyName = "useCharterShips",
+            name = "Use charter ships",
+            description = "Whether to include charter ships in the path",
+            position = 6,
+            section = sectionSettings
     )
     default boolean useCharterShips() {
         return false;
     }
 
     @ConfigItem(
-        keyName = "useShips",
-        name = "Use ships",
-        description = "Whether to include passenger ships in the path<br>" +
-            "(e.g. the customs ships to Karamja)",
-        position = 7,
-        section = sectionSettings
+            keyName = "useShips",
+            name = "Use ships",
+            description = "Whether to include passenger ships in the path<br>" +
+                    "(e.g. the customs ships to Karamja)",
+            position = 7,
+            section = sectionSettings
     )
     default boolean useShips() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useFairyRings",
-        name = "Use fairy rings",
-        description = "Whether to include fairy rings in the path.<br>" +
-            "You must also have completed the required quests or miniquests",
-        position = 8,
-        section = sectionSettings
+            keyName = "useFairyRings",
+            name = "Use fairy rings",
+            description = "Whether to include fairy rings in the path.<br>" +
+                    "You must also have completed the required quests or miniquests",
+            position = 8,
+            section = sectionSettings
     )
     default boolean useFairyRings() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useGnomeGliders",
-        name = "Use gnome gliders",
-        description = "Whether to include gnome gliders in the path",
-        position = 9,
-        section = sectionSettings
+            keyName = "useGnomeGliders",
+            name = "Use gnome gliders",
+            description = "Whether to include gnome gliders in the path",
+            position = 9,
+            section = sectionSettings
     )
     default boolean useGnomeGliders() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useHotAirBalloons",
-        name = "Use hot air balloons",
-        description = "Whether to include hot air balloons in the path",
-        position = 10,
-        section = sectionSettings
+            keyName = "useHotAirBalloons",
+            name = "Use hot air balloons",
+            description = "Whether to include hot air balloons in the path",
+            position = 10,
+            section = sectionSettings
     )
     default boolean useHotAirBalloons() {
         return false;
     }
 
     @ConfigItem(
-        keyName = "useMinecarts",
-        name = "Use minecarts",
-        description = "Whether to include minecarts in the path<br>" +
-            "(e.g. the Keldagrim and Lovakengj minecart networks)",
-        position = 11,
-        section = sectionSettings
+            keyName = "useMinecarts",
+            name = "Use minecarts",
+            description = "Whether to include minecarts in the path<br>" +
+                    "(e.g. the Keldagrim and Lovakengj minecart networks)",
+            position = 11,
+            section = sectionSettings
     )
     default boolean useMinecarts() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useQuetzals",
-        name = "Use quetzals",
-        description = "Whether to include quetzals in the path",
-        position = 12,
-        section = sectionSettings
+            keyName = "useQuetzals",
+            name = "Use quetzals",
+            description = "Whether to include quetzals in the path",
+            position = 12,
+            section = sectionSettings
     )
     default boolean useQuetzals() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useSpiritTrees",
-        name = "Use spirit trees",
-        description = "Whether to include spirit trees in the path",
-        position = 13,
-        section = sectionSettings
+            keyName = "useSpiritTrees",
+            name = "Use spirit trees",
+            description = "Whether to include spirit trees in the path",
+            position = 13,
+            section = sectionSettings
     )
     default boolean useSpiritTrees() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useTeleportationItems",
-        name = "Use teleportation items",
-        description = "Whether to include teleportation items from the player's inventory and equipment.<br>" +
-            "Options labelled (perm) only use permanent non-charge items.",
-        position = 14,
-        section = sectionSettings
+            keyName = "useTeleportationItems",
+            name = "Use teleportation items",
+            description = "Whether to include teleportation items from the player's inventory and equipment.<br>" +
+                    "Options labelled (perm) only use permanent non-charge items.",
+            position = 14,
+            section = sectionSettings
     )
     default TeleportationItem useTeleportationItems() {
         return TeleportationItem.INVENTORY_NON_CONSUMABLE;
     }
 
     @ConfigItem(
-        keyName = "useTeleportationLevers",
-        name = "Use teleportation levers",
-        description = "Whether to include teleportation levers in the path<br>" +
-            "(e.g. the lever from Edgeville to Wilderness)",
-        position = 15,
-        section = sectionSettings
+            keyName = "useTeleportationLevers",
+            name = "Use teleportation levers",
+            description = "Whether to include teleportation levers in the path<br>" +
+                    "(e.g. the lever from Edgeville to Wilderness)",
+            position = 15,
+            section = sectionSettings
     )
     default boolean useTeleportationLevers() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useTeleportationPortals",
-        name = "Use teleportation portals",
-        description = "Whether to include teleportation portals in the path<br>" +
-            "(e.g. the portal from Ferox Enclave to Castle Wars)",
-        position = 16,
-        section = sectionSettings
+            keyName = "useTeleportationPortals",
+            name = "Use teleportation portals",
+            description = "Whether to include teleportation portals in the path<br>" +
+                    "(e.g. the portal from Ferox Enclave to Castle Wars)",
+            position = 16,
+            section = sectionSettings
     )
     default boolean useTeleportationPortals() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useTeleportationSpells",
-        name = "Use teleportation spells",
-        description = "Whether to include teleportation spells in the path",
-        position = 17,
-        section = sectionSettings
+            keyName = "useTeleportationSpells",
+            name = "Use teleportation spells",
+            description = "Whether to include teleportation spells in the path",
+            position = 17,
+            section = sectionSettings
     )
     default boolean useTeleportationSpells() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useTeleportationMinigames",
-        name = "Use teleportation to minigames",
-        description = "Whether to include teleportation to minigames/activities/grouping in the path<br>" +
-            "(e.g. the Nightmare Zone minigame teleport). These teleports share a 20 minute cooldown.",
-        position = 18,
-        section = sectionSettings
+            keyName = "useTeleportationMinigames",
+            name = "Use teleportation to minigames",
+            description = "Whether to include teleportation to minigames/activities/grouping in the path<br>" +
+                    "(e.g. the Nightmare Zone minigame teleport). These teleports share a 20 minute cooldown.",
+            position = 18,
+            section = sectionSettings
     )
     default boolean useTeleportationMinigames() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "useWildernessObelisks",
-        name = "Use wilderness obelisks",
-        description = "Whether to include wilderness obelisks in the path",
-        position = 19,
-        section = sectionSettings
+            keyName = "useWildernessObelisks",
+            name = "Use wilderness obelisks",
+            description = "Whether to include wilderness obelisks in the path",
+            position = 19,
+            section = sectionSettings
     )
     default boolean useWildernessObelisks() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "currencyThreshold",
-        name = "Currency threshold",
-        description = "The maximum amount of currency to use on a single transportation method." +
-            "<br>The currencies affected by the threshold are coins, trading sticks, ecto-tokens and warrior guild tokens.",
-        position = 20,
-        section = sectionSettings
+            keyName = "currencyThreshold",
+            name = "Currency threshold",
+            description = "The maximum amount of currency to use on a single transportation method." +
+                    "<br>The currencies affected by the threshold are coins, trading sticks, ecto-tokens and warrior guild tokens.",
+            position = 20,
+            section = sectionSettings
     )
     default int currencyThreshold() {
         return 100000;
     }
 
     @ConfigItem(
-        keyName = "cancelInstead",
-        name = "Cancel instead of recalculating",
-        description = "Whether the path should be cancelled rather than recalculated " +
-            "when the recalculate distance limit is exceeded",
-        position = 21,
-        section = sectionSettings
+            keyName = "cancelInstead",
+            name = "Cancel instead of recalculating",
+            description = "Whether the path should be cancelled rather than recalculated " +
+                    "when the recalculate distance limit is exceeded",
+            position = 21,
+            section = sectionSettings
     )
     default boolean cancelInstead() {
         return false;
     }
 
     @Range(
-        min = -1,
-        max = 20000
+            min = -1,
+            max = 20000
     )
     @ConfigItem(
-        keyName = "recalculateDistance",
-        name = "Recalculate distance",
-        description = "Distance from the path the player should be for it to be recalculated (-1 for never)",
-        position = 22,
-        section = sectionSettings
+            keyName = "recalculateDistance",
+            name = "Recalculate distance",
+            description = "Distance from the path the player should be for it to be recalculated (-1 for never)",
+            position = 22,
+            section = sectionSettings
     )
     default int recalculateDistance() {
         return 10;
     }
 
     @Range(
-        min = -1,
-        max = 50
+            min = -1,
+            max = 50
     )
     @ConfigItem(
-        keyName = "finishDistance",
-        name = "Finish distance",
-        description = "Distance from the target tile at which the path should be ended (-1 for never)",
-        position = 23,
-        section = sectionSettings
+            keyName = "finishDistance",
+            name = "Finish distance",
+            description = "Distance from the target tile at which the path should be ended (-1 for never)",
+            position = 23,
+            section = sectionSettings
     )
     default int reachedDistance() {
         return 5;
     }
 
     @ConfigItem(
-        keyName = "showTileCounter",
-        name = "Show tile counter",
-        description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-        position = 24,
-        section = sectionSettings
+            keyName = "showTileCounter",
+            name = "Show tile counter",
+            description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
+            position = 24,
+            section = sectionSettings
     )
     default TileCounter showTileCounter() {
         return TileCounter.DISABLED;
     }
 
     @ConfigItem(
-        keyName = "tileCounterStep",
-        name = "Tile counter step",
-        description = "The number of tiles between the displayed tile counter numbers",
-        position = 25,
-        section = sectionSettings
+            keyName = "tileCounterStep",
+            name = "Tile counter step",
+            description = "The number of tiles between the displayed tile counter numbers",
+            position = 25,
+            section = sectionSettings
     )
-    default int tileCounterStep()
-    {
+    default int tileCounterStep() {
         return 1;
     }
 
     @Units(
-        value = Units.TICKS
+            value = Units.TICKS
     )
     @Range(
-        min = 1,
-        max = 30
+            min = 1,
+            max = 30
     )
     @ConfigItem(
-        keyName = "calculationCutoff",
-        name = "Calculation cutoff",
-        description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
-            "made towards the path target before the calculation will be stopped",
-        position = 26,
-        section = sectionSettings
+            keyName = "calculationCutoff",
+            name = "Calculation cutoff",
+            description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
+                    "made towards the path target before the calculation will be stopped",
+            position = 26,
+            section = sectionSettings
     )
-    default int calculationCutoff()
-    {
+    default int calculationCutoff() {
         return 5;
     }
 
     @ConfigItem(
-        keyName = "showTransportInfo",
-        name = "Show transport info",
-        description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-        position = 27,
-        section = sectionSettings
+            keyName = "showTransportInfo",
+            name = "Show transport info",
+            description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
+            position = 27,
+            section = sectionSettings
     )
     default boolean showTransportInfo() {
         return true;
     }
 
     @ConfigSection(
-        name = "Display",
-        description = "Options for displaying the path on the world map, minimap and scene tiles",
-        position = 28
+            name = "Display",
+            description = "Options for displaying the path on the world map, minimap and scene tiles",
+            position = 28
     )
     String sectionDisplay = "sectionDisplay";
 
     @ConfigItem(
-        keyName = "drawMap",
-        name = "Draw path on world map",
-        description = "Whether the path should be drawn on the world map",
-        position = 29,
-        section = sectionDisplay
+            keyName = "drawMap",
+            name = "Draw path on world map",
+            description = "Whether the path should be drawn on the world map",
+            position = 29,
+            section = sectionDisplay
     )
     default boolean drawMap() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "drawMinimap",
-        name = "Draw path on minimap",
-        description = "Whether the path should be drawn on the minimap",
-        position = 30,
-        section = sectionDisplay
+            keyName = "drawMinimap",
+            name = "Draw path on minimap",
+            description = "Whether the path should be drawn on the minimap",
+            position = 30,
+            section = sectionDisplay
     )
     default boolean drawMinimap() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "drawTiles",
-        name = "Draw path on tiles",
-        description = "Whether the path should be drawn on the game tiles",
-        position = 31,
-        section = sectionDisplay
+            keyName = "drawTiles",
+            name = "Draw path on tiles",
+            description = "Whether the path should be drawn on the game tiles",
+            position = 31,
+            section = sectionDisplay
     )
     default boolean drawTiles() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "pathStyle",
-        name = "Path style",
-        description = "Whether to display the path as tiles or a segmented line",
-        position = 32,
-        section = sectionDisplay
+            keyName = "pathStyle",
+            name = "Path style",
+            description = "Whether to display the path as tiles or a segmented line",
+            position = 32,
+            section = sectionDisplay
     )
     default TileStyle pathStyle() {
         return TileStyle.TILES;
     }
 
     @ConfigItem(
-        keyName = "showTilesSaved",
-        name = "Show tiles saved",
-        description = "Whether to display tiles saved when using teleports",
-        position = 33,
-        section = sectionDisplay
+            keyName = "showTilesSaved",
+            name = "Show tiles saved",
+            description = "Whether to display tiles saved when using teleports",
+            position = 33,
+            section = sectionDisplay
     )
     default boolean showTilesSaved() {
         return true;
     }
 
     @ConfigItem(
-        keyName = "showBothPaths",
-        name = "Show both teleport and walking paths",
-        description = "Whether to display both the teleport path and walking-only path when a teleport option is available",
-        position = 34,
-        section = sectionDisplay
+            keyName = "showBothPaths",
+            name = "Show both teleport and walking paths",
+            description = "Whether to display both the teleport path and walking-only path when a teleport option is available",
+            position = 34,
+            section = sectionDisplay
     )
     default boolean showBothPaths() {
         return false;
     }
 
     @ConfigSection(
-        name = "Colours",
-        description = "Colours for the path map, minimap and scene tiles",
-        position = 35
+            name = "Colours",
+            description = "Colours for the path map, minimap and scene tiles",
+            position = 35
     )
     String sectionColours = "sectionColours";
 
     @Alpha
     @ConfigItem(
-        keyName = "colourPath",
-        name = "Path",
-        description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 36,
-        section = sectionColours
+            keyName = "colourPath",
+            name = "Path",
+            description = "Colour of the path tiles on the world map, minimap and in the game scene",
+            position = 36,
+            section = sectionColours
     )
     default Color colourPath() {
         return new Color(255, 0, 0);
@@ -440,11 +439,11 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
-        keyName = "colourWalkingPath",
-        name = "Walking-only path",
-        description = "Colour of the walking-only path tiles when both paths are shown",
-        position = 37,
-        section = sectionColours
+            keyName = "colourWalkingPath",
+            name = "Walking-only path",
+            description = "Colour of the walking-only path tiles when both paths are shown",
+            position = 37,
+            section = sectionColours
     )
     default Color colourWalkingPath() {
         return new Color(255, 165, 0); // Orange color
@@ -452,12 +451,12 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
-        keyName = "colourPathCalculating",
-        name = "Calculating",
-        description = "Colour of the path tiles while the pathfinding calculation is in progress," +
-            "<br>and the colour of unused targets if there are more than a single target",
-        position = 38,
-        section = sectionColours
+            keyName = "colourPathCalculating",
+            name = "Calculating",
+            description = "Colour of the path tiles while the pathfinding calculation is in progress," +
+                    "<br>and the colour of unused targets if there are more than a single target",
+            position = 38,
+            section = sectionColours
     )
     default Color colourPathCalculating() {
         return new Color(0, 0, 255);
@@ -465,11 +464,11 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
-        keyName = "colourTransports",
-        name = "Transports",
-        description = "Colour of the transport tiles",
-        position = 39,
-        section = sectionColours
+            keyName = "colourTransports",
+            name = "Transports",
+            description = "Colour of the transport tiles",
+            position = 39,
+            section = sectionColours
     )
     default Color colourTransports() {
         return new Color(0, 255, 0, 128);
@@ -477,11 +476,11 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
-        keyName = "colourCollisionMap",
-        name = "Collision map",
-        description = "Colour of the collision map tiles",
-        position = 40,
-        section = sectionColours
+            keyName = "colourCollisionMap",
+            name = "Collision map",
+            description = "Colour of the collision map tiles",
+            position = 40,
+            section = sectionColours
     )
     default Color colourCollisionMap() {
         return new Color(0, 128, 255, 128);
@@ -489,52 +488,52 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
-        keyName = "colourText",
-        name = "Text",
-        description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 41,
-        section = sectionColours
+            keyName = "colourText",
+            name = "Text",
+            description = "Colour of the text of the tile counter and fairy ring codes",
+            position = 41,
+            section = sectionColours
     )
     default Color colourText() {
         return Color.WHITE;
     }
 
     @ConfigSection(
-        name = "Debug Options",
-        description = "Various options for debugging",
-        position = 42,
-        closedByDefault = true
+            name = "Debug Options",
+            description = "Various options for debugging",
+            position = 42,
+            closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
 
     @ConfigItem(
-        keyName = "drawTransports",
-        name = "Draw transports",
-        description = "Whether transports should be drawn",
-        position = 43,
-        section = sectionDebug
+            keyName = "drawTransports",
+            name = "Draw transports",
+            description = "Whether transports should be drawn",
+            position = 43,
+            section = sectionDebug
     )
     default boolean drawTransports() {
         return false;
     }
 
     @ConfigItem(
-        keyName = "drawCollisionMap",
-        name = "Draw collision map",
-        description = "Whether the collision map should be drawn",
-        position = 44,
-        section = sectionDebug
+            keyName = "drawCollisionMap",
+            name = "Draw collision map",
+            description = "Whether the collision map should be drawn",
+            position = 44,
+            section = sectionDebug
     )
     default boolean drawCollisionMap() {
         return false;
     }
 
     @ConfigItem(
-        keyName = "drawDebugPanel",
-        name = "Show debug panel",
-        description = "Toggles displaying the pathfinding debug stats panel",
-        position = 45,
-        section = sectionDebug
+            keyName = "drawDebugPanel",
+            name = "Show debug panel",
+            description = "Toggles displaying the pathfinding debug stats panel",
+            position = 45,
+            section = sectionDebug
     )
     default boolean drawDebugPanel() {
         return false;

--- a/src/main/java/shortestpath/TransportType.java
+++ b/src/main/java/shortestpath/TransportType.java
@@ -41,4 +41,36 @@ public enum TransportType {
                 return false;
         }
     }
+
+    /*
+    * Indicates whether a TransportType is a resource movement.
+    * Resource movements are any transport that is not walking.
+    */
+    public static boolean isResourceMovement(TransportType transportType) {
+        if (transportType == null) {
+            return false;
+        }
+        if(isTeleport(transportType)) {
+            return true;
+        }
+        switch (transportType) {
+            case FAIRY_RING:
+            case GNOME_GLIDER:
+            case HOT_AIR_BALLOON:
+            case BOAT:
+            case CANOE:
+            case CHARTER_SHIP:
+            case SHIP:
+            case MINECART:
+            case QUETZAL:
+            case SPIRIT_TREE:
+            case TELEPORTATION_LEVER:
+            case TELEPORTATION_PORTAL:
+            case TELEPORTATION_SPELL:
+            case WILDERNESS_OBELISK:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/src/main/java/shortestpath/TransportType.java
+++ b/src/main/java/shortestpath/TransportType.java
@@ -43,14 +43,14 @@ public enum TransportType {
     }
 
     /*
-    * Indicates whether a TransportType is a resource movement.
-    * Resource movements are any transport that is not walking.
-    */
+     * Indicates whether a TransportType is a resource movement.
+     * Resource movements are any transport that is not walking.
+     */
     public static boolean isResourceMovement(TransportType transportType) {
         if (transportType == null) {
             return false;
         }
-        if(isTeleport(transportType)) {
+        if (isTeleport(transportType)) {
             return true;
         }
         switch (transportType) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
+
 import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
@@ -34,6 +35,7 @@ import shortestpath.TransportType;
 import shortestpath.TransportVarbit;
 import shortestpath.TransportVarPlayer;
 import shortestpath.WorldPointUtil;
+
 import static shortestpath.TransportType.AGILITY_SHORTCUT;
 import static shortestpath.TransportType.GRAPPLE_SHORTCUT;
 import static shortestpath.TransportType.BOAT;
@@ -70,23 +72,25 @@ public class PathfinderConfig {
     private static final WorldArea NOT_WILDERNESS_3 = new WorldArea(3000, 3534, 5, 5, 0);
     private static final WorldArea NOT_WILDERNESS_4 = new WorldArea(3031, 3525, 2, 2, 0);
     private static final List<Integer> RUNE_POUCHES = Arrays.asList(
-        ItemID.RUNE_POUCH, ItemID.RUNE_POUCH_L,
-        ItemID.DIVINE_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH_L
+            ItemID.RUNE_POUCH, ItemID.RUNE_POUCH_L,
+            ItemID.DIVINE_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH_L
     );
     private static final int[] RUNE_POUCH_RUNE_VARBITS = {
-        Varbits.RUNE_POUCH_RUNE1, Varbits.RUNE_POUCH_RUNE2, Varbits.RUNE_POUCH_RUNE3, Varbits.RUNE_POUCH_RUNE4,
-        Varbits.RUNE_POUCH_RUNE5, Varbits.RUNE_POUCH_RUNE6
-	};
+            Varbits.RUNE_POUCH_RUNE1, Varbits.RUNE_POUCH_RUNE2, Varbits.RUNE_POUCH_RUNE3, Varbits.RUNE_POUCH_RUNE4,
+            Varbits.RUNE_POUCH_RUNE5, Varbits.RUNE_POUCH_RUNE6
+    };
     private static final int[] RUNE_POUCH_AMOUNT_VARBITS = {
-        Varbits.RUNE_POUCH_AMOUNT1, Varbits.RUNE_POUCH_AMOUNT2, Varbits.RUNE_POUCH_AMOUNT3, Varbits.RUNE_POUCH_AMOUNT4,
-        Varbits.RUNE_POUCH_AMOUNT5, Varbits.RUNE_POUCH_AMOUNT6
-	};
+            Varbits.RUNE_POUCH_AMOUNT1, Varbits.RUNE_POUCH_AMOUNT2, Varbits.RUNE_POUCH_AMOUNT3, Varbits.RUNE_POUCH_AMOUNT4,
+            Varbits.RUNE_POUCH_AMOUNT5, Varbits.RUNE_POUCH_AMOUNT6
+    };
     private static final Set<Integer> CURRENCIES = Set.of(
-        ItemID.COINS_995, ItemID.TRADING_STICKS, ItemID.ECTOTOKEN, ItemID.WARRIOR_GUILD_TOKEN);
+            ItemID.COINS_995, ItemID.TRADING_STICKS, ItemID.ECTOTOKEN, ItemID.WARRIOR_GUILD_TOKEN);
 
     private final SplitFlagMap mapData;
     private final ThreadLocal<CollisionMap> map;
-    /** All transports by origin. The WorldPointUtil.UNDEFINED key is used for transports centered on the player. */
+    /**
+     * All transports by origin. The WorldPointUtil.UNDEFINED key is used for transports centered on the player.
+     */
     private final Map<Integer, Set<Transport>> allTransports;
     private final Set<Transport> usableTeleports;
     private final Map<String, Set<Integer>> allDestinations;
@@ -99,7 +103,9 @@ public class PathfinderConfig {
     // Copy of transports with packed positions for the hotpath; lists are not copied and are the same reference in both maps
     @Getter
     private final PrimitiveIntHashMap<Set<Transport>> transportsPacked;
-    /** Reference that points to either allDestinations or filteredDestinations */
+    /**
+     * Reference that points to either allDestinations or filteredDestinations
+     */
     private Map<String, Set<Integer>> destinations;
 
     private final Client client;
@@ -110,22 +116,22 @@ public class PathfinderConfig {
     @Getter
     private boolean avoidWilderness;
     private boolean useAgilityShortcuts,
-        useGrappleShortcuts,
-        useBoats,
-        useCanoes,
-        useCharterShips,
-        useShips,
-        useFairyRings,
-        useGnomeGliders,
-        useHotAirBalloons,
-        useMinecarts,
-        useQuetzals,
-        useSpiritTrees,
-        useTeleportationLevers,
-        useTeleportationMinigames,
-        useTeleportationPortals,
-        useTeleportationSpells,
-        useWildernessObelisks;
+            useGrappleShortcuts,
+            useBoats,
+            useCanoes,
+            useCharterShips,
+            useShips,
+            useFairyRings,
+            useGnomeGliders,
+            useHotAirBalloons,
+            useMinecarts,
+            useQuetzals,
+            useSpiritTrees,
+            useTeleportationLevers,
+            useTeleportationMinigames,
+            useTeleportationPortals,
+            useTeleportationSpells,
+            useWildernessObelisks;
     private TeleportationItem useTeleportationItems;
     private int currencyThreshold;
     private final int[] boostedLevels = new int[Skill.values().length];
@@ -193,7 +199,9 @@ public class PathfinderConfig {
         refreshDestinations();
     }
 
-    /** Specialized method for only updating player-held item and spell transports */
+    /**
+     * Specialized method for only updating player-held item and spell transports
+     */
     public void refreshTeleports(int packedLocation, int wildernessLevel) {
         Set<Transport> usableWildyTeleports = new HashSet<>(usableTeleports.size());
 
@@ -213,7 +221,9 @@ public class PathfinderConfig {
         destinations = avoidWilderness ? filteredDestinations : allDestinations;
     }
 
-    /** Changes to the config might have invalidated some locations, e.g. those in the wilderness */
+    /**
+     * Changes to the config might have invalidated some locations, e.g. those in the wilderness
+     */
     public void filterLocations(Set<Integer> locations, boolean canReviveFiltered) {
         if (avoidWilderness) {
             locations.removeIf(location -> {
@@ -304,30 +314,30 @@ public class PathfinderConfig {
 
     public static boolean isInWilderness(WorldPoint p) {
         return WILDERNESS_ABOVE_GROUND.distanceTo2D(p) == 0
-            && FEROX_ENCLAVE_1.distanceTo2D(p) != 0
-            && FEROX_ENCLAVE_2.distanceTo2D(p) != 0
-            && FEROX_ENCLAVE_3.distanceTo2D(p) != 0
-            && FEROX_ENCLAVE_4.distanceTo2D(p) != 0
-            && FEROX_ENCLAVE_5.distanceTo2D(p) != 0
-            && NOT_WILDERNESS_1.distanceTo2D(p) != 0
-            && NOT_WILDERNESS_2.distanceTo2D(p) != 0
-            && NOT_WILDERNESS_3.distanceTo2D(p) != 0
-            && NOT_WILDERNESS_4.distanceTo2D(p) != 0
-            || WILDERNESS_UNDERGROUND.distanceTo2D(p) == 0;
+                && FEROX_ENCLAVE_1.distanceTo2D(p) != 0
+                && FEROX_ENCLAVE_2.distanceTo2D(p) != 0
+                && FEROX_ENCLAVE_3.distanceTo2D(p) != 0
+                && FEROX_ENCLAVE_4.distanceTo2D(p) != 0
+                && FEROX_ENCLAVE_5.distanceTo2D(p) != 0
+                && NOT_WILDERNESS_1.distanceTo2D(p) != 0
+                && NOT_WILDERNESS_2.distanceTo2D(p) != 0
+                && NOT_WILDERNESS_3.distanceTo2D(p) != 0
+                && NOT_WILDERNESS_4.distanceTo2D(p) != 0
+                || WILDERNESS_UNDERGROUND.distanceTo2D(p) == 0;
     }
 
     public static boolean isInWilderness(int packedPoint) {
         return WorldPointUtil.distanceToArea2D(packedPoint, WILDERNESS_ABOVE_GROUND) == 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_1) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_2) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_3) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_4) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_5) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_1) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_2) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_3) != 0
-            && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_4) != 0
-            || WorldPointUtil.distanceToArea2D(packedPoint, WILDERNESS_UNDERGROUND) == 0;
+                && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_1) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_2) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_3) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_4) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, FEROX_ENCLAVE_5) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_1) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_2) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_3) != 0
+                && WorldPointUtil.distanceToArea2D(packedPoint, NOT_WILDERNESS_4) != 0
+                || WorldPointUtil.distanceToArea2D(packedPoint, WILDERNESS_UNDERGROUND) == 0;
     }
 
     public static boolean isInWilderness(Set<Integer> packedPoints) {
@@ -341,18 +351,18 @@ public class PathfinderConfig {
 
     public static boolean isInLevel20Wilderness(int packedPoint) {
         return WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_ABOVE_GROUND_LEVEL_20) == 0
-            || WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_UNDERGROUND_LEVEL_20) == 0;
+                || WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_UNDERGROUND_LEVEL_20) == 0;
     }
 
-    public static boolean isInLevel30Wilderness(int packedPoint){
+    public static boolean isInLevel30Wilderness(int packedPoint) {
         return WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_ABOVE_GROUND_LEVEL_30) == 0
-            || WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_UNDERGROUND_LEVEL_30) == 0;
+                || WorldPointUtil.distanceToArea(packedPoint, WILDERNESS_UNDERGROUND_LEVEL_30) == 0;
 
     }
 
     public boolean avoidWilderness(int packedPosition, int packedNeightborPosition, boolean targetInWilderness) {
         return avoidWilderness && !targetInWilderness
-            && !isInWilderness(packedPosition) && isInWilderness(packedNeightborPosition);
+                && !isInWilderness(packedPosition) && isInWilderness(packedNeightborPosition);
     }
 
     public QuestState getQuestState(Quest quest) {
@@ -427,7 +437,7 @@ public class PathfinderConfig {
             useTeleportationSpells = ShortestPathPlugin.override("useTeleportationSpells", config.useTeleportationSpells());
             useWildernessObelisks = ShortestPathPlugin.override("useWildernessObelisks", config.useWildernessObelisks());
         }
-        
+
         // Refresh transports to apply the changes
         if (GameState.LOGGED_IN.equals(client.getGameState())) {
             refreshTransports();
@@ -508,7 +518,9 @@ public class PathfinderConfig {
         return true;
     }
 
-    /** Checks if the player has all the required skill levels for the transport */
+    /**
+     * Checks if the player has all the required skill levels for the transport
+     */
     private boolean hasRequiredLevels(Transport transport) {
         int[] requiredLevels = transport.getSkillLevels();
         for (int i = 0; i < boostedLevels.length; i++) {
@@ -521,15 +533,17 @@ public class PathfinderConfig {
         return true;
     }
 
-    /** Checks if the player has all the required equipment and inventory items for the transport */
+    /**
+     * Checks if the player has all the required equipment and inventory items for the transport
+     */
     private boolean hasRequiredItems(Transport transport) {
         if ((TeleportationItem.ALL.equals(useTeleportationItems) ||
-            TeleportationItem.ALL_NON_CONSUMABLE.equals(useTeleportationItems)) &&
-            TransportType.TELEPORTATION_ITEM.equals(transport.getType())) {
+                TeleportationItem.ALL_NON_CONSUMABLE.equals(useTeleportationItems)) &&
+                TransportType.TELEPORTATION_ITEM.equals(transport.getType())) {
             return true;
         }
         if (TeleportationItem.NONE.equals(useTeleportationItems) &&
-            TransportType.TELEPORTATION_ITEM.equals(transport.getType())) {
+                TransportType.TELEPORTATION_ITEM.equals(transport.getType())) {
             return false;
         }
         itemsAndQuantities.clear();

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -386,6 +386,54 @@ public class PathfinderConfig {
         return true;
     }
 
+    public void setWalkingOnly(boolean walkingOnly) {
+        if (walkingOnly) {
+            useAgilityShortcuts = false;
+            useGrappleShortcuts = false;
+            useBoats = false;
+            useCanoes = false;
+            useCharterShips = false;
+            useShips = false;
+            useFairyRings = false;
+            useGnomeGliders = false;
+            useHotAirBalloons = false;
+            useMinecarts = false;
+            useQuetzals = false;
+            useSpiritTrees = false;
+            useTeleportationItems = TeleportationItem.NONE;
+            useTeleportationLevers = false;
+            useTeleportationMinigames = false;
+            useTeleportationPortals = false;
+            useTeleportationSpells = false;
+            useWildernessObelisks = false;
+        } else {
+            // Restore original settings from config
+            useAgilityShortcuts = ShortestPathPlugin.override("useAgilityShortcuts", config.useAgilityShortcuts());
+            useGrappleShortcuts = ShortestPathPlugin.override("useGrappleShortcuts", config.useGrappleShortcuts());
+            useBoats = ShortestPathPlugin.override("useBoats", config.useBoats());
+            useCanoes = ShortestPathPlugin.override("useCanoes", config.useCanoes());
+            useCharterShips = ShortestPathPlugin.override("useCharterShips", config.useCharterShips());
+            useShips = ShortestPathPlugin.override("useShips", config.useShips());
+            useFairyRings = ShortestPathPlugin.override("useFairyRings", config.useFairyRings());
+            useGnomeGliders = ShortestPathPlugin.override("useGnomeGliders", config.useGnomeGliders());
+            useHotAirBalloons = ShortestPathPlugin.override("useHotAirBalloons", config.useHotAirBalloons());
+            useMinecarts = ShortestPathPlugin.override("useMinecarts", config.useMinecarts());
+            useQuetzals = ShortestPathPlugin.override("useQuetzals", config.useQuetzals());
+            useSpiritTrees = ShortestPathPlugin.override("useSpiritTrees", config.useSpiritTrees());
+            useTeleportationItems = ShortestPathPlugin.override("useTeleportationItems", config.useTeleportationItems());
+            useTeleportationLevers = ShortestPathPlugin.override("useTeleportationLevers", config.useTeleportationLevers());
+            useTeleportationMinigames = ShortestPathPlugin.override("useTeleportationMinigames", config.useTeleportationMinigames());
+            useTeleportationPortals = ShortestPathPlugin.override("useTeleportationPortals", config.useTeleportationPortals());
+            useTeleportationSpells = ShortestPathPlugin.override("useTeleportationSpells", config.useTeleportationSpells());
+            useWildernessObelisks = ShortestPathPlugin.override("useWildernessObelisks", config.useWildernessObelisks());
+        }
+        
+        // Refresh transports to apply the changes
+        if (GameState.LOGGED_IN.equals(client.getGameState())) {
+            refreshTransports();
+        }
+    }
+
     private boolean useTransport(Transport transport) {
         final boolean isQuestLocked = transport.isQuestLocked();
 


### PR DESCRIPTION
This introduces two new toggle options to improve QOL when the shortest path includes a teleport:

1. **"Show tiles saved" toggle** – Displays how many tiles are saved by using the teleport path compared to walking.
2. **"Show walkable path" toggle** – Optionally shows the full walkable path even when a teleport is offered, giving users visibility into the alternative route.

