### PR TITLE
add Isafdar and Arandar transports (closes #66)

### DIFF
--- a/src/main/resources/transports/agility_shortcuts.tsv
+++ b/src/main/resources/transports/agility_shortcuts.tsv
@@ -212,3 +212,101 @@
 2832 3252 0	2832 3247 0	Climb Rocks 53236	84 Agility				6
 3500 9510 2	3506 9505 2	Squeeze-through Crevice 16465	86 Agility				
 3506 9505 2	3500 9510 2	Squeeze-through Crevice 16465	86 Agility				
+
+# Isafdar
+2188 3162 0	2188 3165 0	Enter Dense forest 3999	56 Agility				4
+2188 3165 0	2188 3162 0	Enter Dense forest 3999	56 Agility				4
+2188 3165 0	2188 3168 0	Enter Dense forest 3939	56 Agility				4
+2188 3168 0	2188 3165 0	Enter Dense forest 3939	56 Agility				4
+2188 3168 0	2188 3171 0	Enter Dense forest 3998	56 Agility				4
+2188 3171 0	2188 3168 0	Enter Dense forest 3998	56 Agility				4
+2217 3169 0	2217 3166 0	Enter Dense forest 3939	56 Agility				4
+2217 3166 0	2217 3169 0	Enter Dense forest 3939	56 Agility				4
+2217 3166 0	2217 3163 0	Enter Dense forest 3938	56 Agility				4
+2217 3163 0	2217 3166 0	Enter Dense forest 3938	56 Agility				4
+2217 3163 0	2217 3160 0	Enter Dense forest 3939	56 Agility				4
+2217 3160 0	2217 3163 0	Enter Dense forest 3939	56 Agility				4
+2231 3149 0	2234 3149 0	Enter Dense forest 3937	56 Agility				4
+2234 3149 0	2231 3149 0	Enter Dense forest 3937	56 Agility				4
+2234 3149 0	2237 3149 0	Enter Dense forest 3938	56 Agility				4
+2237 3149 0	2234 3149 0	Enter Dense forest 3938	56 Agility				4
+2237 3149 0	2240 3149 0	Enter Dense forest 3939	56 Agility				4
+2240 3149 0	2237 3149 0	Enter Dense forest 3939	56 Agility				4
+2226 3219 0	2229 3219 0	Enter Dense forest 3938	56 Agility				4
+2229 3219 0	2226 3219 0	Enter Dense forest 3938	56 Agility				4
+2229 3219 0	2232 3219 0	Enter Dense forest 3939	56 Agility				4
+2232 3219 0	2229 3219 0	Enter Dense forest 3939	56 Agility				4
+2232 3219 0	2235 3219 0	Enter Dense forest 3937	56 Agility				4
+2235 3219 0	2232 3219 0	Enter Dense forest 3937	56 Agility				4
+2235 3219 0	2238 3219 0	Enter Dense forest 3939	56 Agility				4
+2238 3219 0	2235 3219 0	Enter Dense forest 3939	56 Agility				4
+2230 3249 0	2233 3249 0	Enter Dense forest 3938	56 Agility				4
+2233 3249 0	2230 3249 0	Enter Dense forest 3938	56 Agility				4
+2233 3249 0	2236 3249 0	Enter Dense forest 3939	56 Agility				4
+2236 3249 0	2233 3249 0	Enter Dense forest 3939	56 Agility				4
+2236 3249 0	2239 3249 0	Enter Dense forest 3937	56 Agility				4
+2239 3249 0	2236 3249 0	Enter Dense forest 3937	56 Agility				4
+2279 3231 0	2279 3228 0	Enter Dense forest 3939	56 Agility				4
+2279 3228 0	2279 3231 0	Enter Dense forest 3939	56 Agility				4
+2279 3228 0	2279 3225 0	Enter Dense forest 3937	56 Agility				4
+2279 3225 0	2279 3228 0	Enter Dense forest 3937	56 Agility				4
+2279 3225 0	2279 3222 0	Enter Dense forest 3938	56 Agility				4
+2279 3222 0	2279 3225 0	Enter Dense forest 3938	56 Agility				4
+2265 3192 0	2268 3192 0	Enter Dense forest 3938	56 Agility				4
+2268 3192 0	2265 3192 0	Enter Dense forest 3938	56 Agility				4
+2268 3192 0	2271 3192 0	Enter Dense forest 3939	56 Agility				4
+2271 3192 0	2268 3192 0	Enter Dense forest 3939	56 Agility				4
+2271 3192 0	2274 3192 0	Enter Dense forest 3937	56 Agility				4
+2274 3192 0	2271 3192 0	Enter Dense forest 3937	56 Agility				4
+2303 3213 0	2303 3216 0	Enter Dense forest 3937	56 Agility				4
+2303 3216 0	2303 3213 0	Enter Dense forest 3937	56 Agility				4
+2303 3216 0	2303 3219 0	Enter Dense forest 3938	56 Agility				4
+2303 3219 0	2303 3216 0	Enter Dense forest 3938	56 Agility				4
+2303 3219 0	2303 3222 0	Enter Dense forest 3939	56 Agility				4
+2303 3222 0	2303 3219 0	Enter Dense forest 3939	56 Agility				4
+2303 3222 0	2303 3225 0	Enter Dense forest 3938	56 Agility				4
+2303 3225 0	2303 3222 0	Enter Dense forest 3938	56 Agility				4
+2220 3155 0	2220 3152 0	Step-over Tripwire 3921					8
+2220 3152 0	2220 3155 0	Step-over Tripwire 3921					8
+2215 3156 0	2215 3153 0	Step-over Tripwire 3921					8
+2215 3153 0	2215 3156 0	Step-over Tripwire 3921					8
+2250 3168 0	2253 3168 0	Step-over Tripwire 3921					8
+2253 3168 0	2250 3168 0	Step-over Tripwire 3921					8
+2284 3188 0	2287 3188 0	Step-over Tripwire 3921					8
+2287 3188 0	2284 3188 0	Step-over Tripwire 3921					8
+2294 3242 0	2294 3245 0	Step-over Tripwire 3921					8
+2294 3245 0	2294 3242 0	Step-over Tripwire 3921					8
+2202 3237 0	2196 3237 0	Cross Log balance 3931	45 Agility				8
+2196 3237 0	2202 3237 0	Cross Log balance 3931	45 Agility				8
+2258 3250 0	2264 3250 0	Cross Log balance 3932	45 Agility				8
+2264 3250 0	2258 3250 0	Cross Log balance 3932	45 Agility				8
+2290 3232 0	2290 3239 0	Cross Log balance 3933	45 Agility				9
+2290 3239 0	2290 3232 0	Cross Log balance 3933	45 Agility				9
+2199 3169 0	2202 3169 0	Pass Sticks 3922					6
+2202 3169 0	2199 3169 0	Pass Sticks 3922					6
+2234 3181 0	2238 3181 0	Pass Sticks 3922					6
+2238 3181 0	2234 3181 0	Pass Sticks 3922					6
+2181 3212 0	2181 3208 0	Pass Sticks 3922					6
+2181 3208 0	2181 3212 0	Pass Sticks 3922					6
+2256 3227 0	2260 3227 0	Pass Sticks 3922					6
+2260 3227 0	2256 3227 0	Pass Sticks 3922					6
+2274 3163 0	2277 3163 0	Pass Sticks 3922					6
+2277 3163 0	2274 3163 0	Pass Sticks 3922					6
+2295 3217 0	2295 3213 0	Pass Sticks 3922					6
+2295 3213 0	2295 3217 0	Pass Sticks 3922					6
+2209 3201 0	2209 3205 0	Jump Leaves 3925					4
+2209 3205 0	2209 3201 0	Jump Leaves 3925					4
+2275 3262 0	2279 3262 0	Jump Leaves 3925					4
+2279 3262 0	2275 3262 0	Jump Leaves 3925					4
+2267 3205 0	2267 3201 0	Jump Leaves 3925					4
+2267 3201 0	2267 3205 0	Jump Leaves 3925					4
+2274 3176 0	2274 3172 0	Jump Leaves 3925					4
+2274 3172 0	2274 3176 0	Jump Leaves 3925					4
+
+# Arandar
+2346 3300 0	2344 3294 0	Climb rocks 16515	59 Agility				6
+2344 3294 0	2346 3300 0	Climb rocks 16514	59 Agility				8
+2338 3286 0	2338 3281 0	Climb rocks 16515	68 Agility				8
+2338 3281 0	2338 3286 0	Climb rocks 16514	68 Agility				4
+2338 3253 0	2332 3252 0	Climb rocks 16515	85 Agility				
+2332 3252 0	2338 3253 0	Climb rocks 16514	85 Agility				

--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -4539,3 +4539,11 @@
 1795 3107 0	1799 9506 0	Enter Colosseum entrance 50749						
 1799 9506 0	1795 3106 0	Exit Stairs 50750						
 1799 9507 0	1795 3106 0	Exit Stairs 50750						
+
+# Arandar Gates
+2386 3333 0	2386 3335 0	Enter Huge Gate 3944			Regicide			2
+2386 3335 0	2386 3333 0	Enter Huge Gate 3944			Regicide			2
+
+# Lletya Entrance
+2304 3194 0	2306 3194 0	Pass Tree 8742			Mourning's End Part I			
+2306 3194 0	2304 3194 0	Pass Tree 8742			Mourning's End Part I			


### PR DESCRIPTION
I couldn't test the duration of Arandar's highest agi shortcut and Lletya's entrance because I lack the level/quest to do it.

<img width="1220" height="1046" alt="{9EFDAC3A-3286-412C-8B61-B71B391CA1FA}" src="https://github.com/user-attachments/assets/bd67c4de-b41f-4337-975c-d62f538cea4d" />
