### PR TITLE
Add transport in Isafdar

### DIFF
--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -4547,3 +4547,93 @@
 # Lletya Entrance								
 2304 3194 0	2306 3194 0	Pass Tree 8742			Mourning's End Part I			2
 2306 3194 0	2304 3194 0	Pass Tree 8742			Mourning's End Part I			2
+								
+# Isafdar								
+2267 3201 0	2267 3205 0	Jump Leaves 3925						3
+2267 3205 0	2267 3201 0	Jump Leaves 3925						3
+2265 3192 0	2268 3192 0	Enter Dense forest 3938						4
+2268 3192 0	2265 3192 0	Enter Dense forest 3938						4
+2268 3192 0	2271 3192 0	Enter Dense forest 3939						4
+2271 3192 0	2268 3192 0	Enter Dense forest 3939						4
+2271 3192 0	2274 3192 0	Enter Dense forest 3937						4
+2274 3192 0	2271 3192 0	Enter Dense forest 3937						4
+2238 3181 0	2234 3181 0	Pass Sticks 3922						6
+2234 3181 0	2238 3181 0	Pass Sticks 3922						6
+2240 3149 0	2237 3149 0	Enter Dense forest 3939						4
+2237 3149 0	2240 3149 0	Enter Dense forest 3939						4
+2237 3149 0	2234 3149 0	Enter Dense forest 3938						4
+2234 3149 0	2237 3149 0	Enter Dense forest 3938						4
+2234 3149 0	2231 3149 0	Enter Dense forest 3937						4
+2231 3149 0	2234 3149 0	Enter Dense forest 3937						4
+2220 3152 0	2220 3155 0	Step-over Tripwire 3921						7
+2220 3155 0	2220 3152 0	Step-over Tripwire 3921						7
+2215 3153 0	2215 3156 0	Step-over Tripwire 3921						7
+2215 3156 0	2215 3153 0	Step-over Tripwire 3921						7
+2217 3160 0	2217 3163 0	Enter Dense forest 3939						4
+2217 3163 0	2217 3160 0	Enter Dense forest 3939						4
+2217 3163 0	2217 3166 0	Enter Dense forest 3938						4
+2217 3166 0	2217 3163 0	Enter Dense forest 3938						4
+2217 3166 0	2217 3169 0	Enter Dense forest 3939						4
+2217 3169 0	2217 3166 0	Enter Dense forest 3939						4
+2188 3171 0	2188 3168 0	Enter Dense forest 3998						4
+2188 3168 0	2188 3171 0	Enter Dense forest 3998						4
+2188 3168 0	2188 3165 0	Enter Dense forest 3939						4
+2188 3165 0	2188 3168 0	Enter Dense forest 3939						4
+2188 3165 0	2188 3162 0	Enter Dense forest 3999						4
+2188 3162 0	2188 3165 0	Enter Dense forest 3999						4
+2209 3201 0	2209 3205 0	Jump Leaves 3925						3
+2209 3205 0	2209 3201 0	Jump Leaves 3925						3
+2202 3237 0	2196 3237 0	Cross Log balance						8
+2196 3237 0	2202 3237 0	Cross Log balance						8
+2230 3249 0	2233 3249 0	Enter Dense forest 3938						4
+2233 3249 0	2230 3249 0	Enter Dense forest 3938						4
+2233 3249 0	2236 3249 0	Enter Dense forest 3939						4
+2236 3249 0	2233 3249 0	Enter Dense forest 3939						4
+2236 3249 0	2239 3249 0	Enter Dense forest 3937						4
+2239 3249 0	2236 3249 0	Enter Dense forest 3937						4
+2258 3250 0	2264 3250 0	Cross Log balance						8
+2264 3250 0	2258 3250 0	Cross Log balance						8
+2275 3262 0	2279 3262 0	Jump Leaves 3925						3
+2279 3262 0	2275 3262 0	Jump Leaves 3925						3
+2279 3231 0	2279 3228 0	Enter Dense forest 3939						4
+2279 3228 0	2279 3231 0	Enter Dense forest 3939						4
+2279 3228 0	2279 3225 0	Enter Dense forest 3937						4
+2279 3225 0	2279 3228 0	Enter Dense forest 3937						4
+2279 3225 0	2279 3222 0	Enter Dense forest 3938						4
+2279 3222 0	2279 3225 0	Enter Dense forest 3938						4
+2295 3213 0	2295 3217 0	Pass Sticks 3922						6
+2295 3217 0	2295 3213 0	Pass Sticks 3922						6
+2303 3213 0	2303 3216 0	Enter Dense forest 3937						4
+2303 3216 0	2303 3213 0	Enter Dense forest 3937						4
+2303 3216 0	2303 3219 0	Enter Dense forest 3938						4
+2303 3219 0	2303 3216 0	Enter Dense forest 3938						4
+2303 3219 0	2303 3222 0	Enter Dense forest 3939						4
+2303 3222 0	2303 3219 0	Enter Dense forest 3939						4
+2303 3222 0	2303 3225 0	Enter Dense forest 3938						4
+2303 3225 0	2303 3222 0	Enter Dense forest 3938						4
+2290 3232 0	2290 3239 0	Cross Log balance						9
+2290 3239 0	2290 3232 0	Cross Log balance						9
+2294 3242 0	2294 3245 0	Step-over Tripwire 3921						7
+2294 3245 0	2294 3242 0	Step-over Tripwire 3921						7
+2284 3188 0	2287 3188 0	Step-over Tripwire 3921						7
+2287 3188 0	2284 3188 0	Step-over Tripwire 3921						7
+2199 3169 0	2202 3169 0	Pass Sticks 3922						5
+2202 3169 0	2199 3169 0	Pass Sticks 3922						5
+2274 3176 0	2274 3172 0	Jump Leaves 3925						3
+2274 3172 0	2274 3176 0	Jump Leaves 3925						3
+2274 3163 0	2277 3163 0	Pass Sticks 3922						5
+2277 3163 0	2274 3163 0	Pass Sticks 3922						5
+2250 3168 0	2253 3168 0	Step-over Tripwire 3921						7
+2253 3168 0	2250 3168 0	Step-over Tripwire 3921						7
+2181 3212 0	2181 3208 0	Pass Sticks 3922						6
+2181 3208 0	2181 3212 0	Pass Sticks 3922						6
+2226 3219 0	2229 3219 0	Enter Dense forest 3938						4
+2229 3219 0	2226 3219 0	Enter Dense forest 3938						4
+2229 3219 0	2232 3219 0	Enter Dense forest 3939						4
+2232 3219 0	2229 3219 0	Enter Dense forest 3939						4
+2232 3219 0	2235 3219 0	Enter Dense forest 3937						4
+2235 3219 0	2232 3219 0	Enter Dense forest 3937						4
+2235 3219 0	2238 3219 0	Enter Dense forest 3939						4
+2238 3219 0	2235 3219 0	Enter Dense forest 3939						4
+2256 3227 0	2260 3227 0	Pass Sticks 3922						6
+2260 3227 0	2256 3227 0	Pass Sticks 3922						6


### PR DESCRIPTION
Add transport in Isafdar

- Add all the traps shown on the map at
    https://oldschool.runescape.wiki/w/Regicide

The duration is approximate for "Pass Sticks", but definitely wrong, as the trap is faster in 1 direction than the other. For 2 instances of this trap, there is not enough room for your character to walk fully past the trap, so I've set the duration of these to 5 not 6.

Here is the map of the added transport, with debug options on: (ignore the entrance to Lletya)

<img width="1268" height="1004" alt="image" src="https://github.com/user-attachments/assets/e0d2dc08-c964-4ca3-abea-e233ac43067f" />

