### PR TITLE
Update entrance to Lletya

### DIFF
--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -4545,8 +4545,8 @@
 2386 3335 0	2386 3333 0	Enter Huge Gate 3944			Regicide			2
 								
 # Lletya Entrance								
-2304 3194 0	2306 3194 0	Pass Tree 8742			Mourning's End Part I			2
-2306 3194 0	2304 3194 0	Pass Tree 8742			Mourning's End Part I			2
+2304 3194 0	2306 3194 0	Pass Tree 8742					517>1	5
+2306 3194 0	2304 3194 0	Pass Tree 8742					517>1	5
 								
 # Isafdar								
 2265 3192 0	2268 3192 0	Enter Dense forest 3938						4


### PR DESCRIPTION
- The entrance to Lletya can be used near the start of the `Mourning's End Part I` quest.
- The duration of walking through the tree is 5 ticks.

The relevant `VarPlayer` is 517 (`MOURNING_QUEST`), which takes the following values:
- 1 after you start the quest
- 2 after you are teleported to Lletya and given a teleport crystal
- 3 after speaking to Arianwyn in Lletya

You can definitely use the entrance when it is set to 3, but I think it probably also works when it is set to 2. So I set the condition as `517 > 1`.