### PR TITLE
Add Fossil Island Mushtree transport system

### DIFF
--- a/src/main/java/shortestpath/Transport.java
+++ b/src/main/java/shortestpath/Transport.java
@@ -435,6 +435,7 @@ public class Transport {
         addTransports(transports, "/transports/minecarts.tsv", TransportType.MINECART);
         addTransports(transports, "/transports/quetzals.tsv", TransportType.QUETZAL);
         addTransports(transports, "/transports/spirit_trees.tsv", TransportType.SPIRIT_TREE, 5);
+        addTransports(transports, "/transports/magic_mushtrees.tsv", TransportType.SPIRIT_TREE, 5);
         addTransports(transports, "/transports/teleportation_items.tsv", TransportType.TELEPORTATION_ITEM);
         addTransports(transports, "/transports/teleportation_boxes.tsv", TransportType.TELEPORTATION_BOX);
         addTransports(transports, "/transports/teleportation_levers.tsv", TransportType.TELEPORTATION_LEVER);

--- a/src/main/resources/transports/magic_mushtrees.tsv
+++ b/src/main/resources/transports/magic_mushtrees.tsv
@@ -1,0 +1,17 @@
+# Origin	Destination	menuOption menuTarget objectID	Duration	Display info	Quests
+# House on the Hill					
+3764 3879 1		Use Magic Mushtree 30920			Bone Voyage
+3766 3879 1		Use Magic Mushtree 30920			Bone Voyage
+	3764 3879 1		6	1. House on the Hill	
+# Verdant Valley					
+3757 3757 0		Use Magic Mushtree 30924			Bone Voyage
+3757 3756 0		Use Magic Mushtree 30924			Bone Voyage
+	3760 3758 0		6	2. Verdant Valley	
+# Sticky Swamp					
+3676 3755 0		Use Magic Mushtree 30924			Bone Voyage
+3676 3756 0		Use Magic Mushtree 30924			Bone Voyage
+	3676 3755 0		6	3. Sticky Swamp	
+# Mushroom Meadow					
+3676 3871 0		Use Magic Mushtree 30924			Bone Voyage
+3676 3872 0		Use Magic Mushtree 30924			Bone Voyage
+	3676 3871 0		6	4. Mushroom Meadow	


### PR DESCRIPTION
Added the [Fossil Island Mushtree](https://oldschool.runescape.wiki/w/Mycelium_Transportation_System) transportation system.

Note: Mushtrees have to be initially unlocked by visiting them for the first time and using them. Unfortunately, I'm unable to find the associated Varbit/VarPlayer and I don't have an account to find that out. So as long as someone has completed Bone Voyage which is required to visit Fossil Island, currently, it'll make all the Mushtrees accessible.