### PR TITLE
fix: barbarian assault teleport requirement

### DIFF
--- a/src/main/resources/transports/teleportation_minigames.tsv
+++ b/src/main/resources/transports/teleportation_minigames.tsv
@@ -1,6 +1,6 @@
 Destination	Skills	Quests	Display info	Duration	Wilderness level	Varbits	VarPlayers
 # Barbarian Assault - Barbarian Outpost							
-2531 3569 0		Barbarian Assault tutorial	Barbarian Assault Minigame Teleport	23	0		888@20
+2531 3569 0		Barbarian Assault tutorial	Barbarian Assault Minigame Teleport	23	3264=11		888@20
 							
 # Blast Furnace - East Keldagrim							
 2894 10214 0		The Giant Dwarf	Blast Furnace Minigame Teleport	23	0		888@20


### PR DESCRIPTION
You must finish the Barbarian Assault minigame tutorial to be able to use the Barbarian Assault minigame teleport

On a new character, I talked to Captain Cain at Barbarian Assault and skipped the tutorial, giving me the following varbit changes:
```
[2025-08-14T19:57:52Z 8823] varbit BARBASSULT_ROLELEVEL_HEAL (3255) 0 -> 1
[2025-08-14T19:57:52Z 8823] varbit BARBASSULT_ROLELEVEL_COL (3254) 0 -> 1
[2025-08-14T19:57:52Z 8823] varbit BARBASSULT_ROLELEVEL_DEF (3253) 0 -> 1
[2025-08-14T19:57:52Z 8823] varbit BARBASSULT_ROLELEVEL_ATT (3251) 0 -> 1
[2025-08-14T19:57:52Z 8823] varbit BARBASSAULT_ARENANEWB (3264) 0 -> 11
```

I suspect it's the BARBASSAULT_ARENANEWB varbit that controls it
