### PR TITLE
Transports update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 out/
 bin/
 
+.vscode/
+
 # For the Collision Map build
 runelite/
 cache/

--- a/build.gradle
+++ b/build.gradle
@@ -29,3 +29,13 @@ sourceCompatibility = '1.11'
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
+
+// Convenience task to start the RuneLite client with the ShortestPathPlugin
+tasks.register('runelite', JavaExec) {
+    group = 'application'
+    description = 'Runs pathfinder.ShortestPathPluginTest with assertions enabled'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass.set('pathfinder.ShortestPathPluginTest')
+    jvmArgs '-ea'
+    args '--developer-mode'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,3 @@ sourceCompatibility = '1.11'
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
-
-// Convenience task to start the RuneLite client with the ShortestPathPlugin
-tasks.register('runelite', JavaExec) {
-    group = 'application'
-    description = 'Runs pathfinder.ShortestPathPluginTest with assertions enabled'
-    classpath = sourceSets.test.runtimeClasspath
-    mainClass.set('pathfinder.ShortestPathPluginTest')
-    jvmArgs '-ea'
-    args '--developer-mode'
-}

--- a/src/main/resources/transports/agility_shortcuts.tsv
+++ b/src/main/resources/transports/agility_shortcuts.tsv
@@ -104,8 +104,8 @@
 2556 3075 0	2556 3074 1	Grapple Wall 17047	39 Agility;21 Ranged;38 Strength	CROSSBOW=1&MITH_GRAPPLE=1			
 1614 3570 0	1610 3570 0	Cross Stepping stone 29729	40 Agility				2
 1610 3570 0	1614 3570 0	Cross Stepping stone 29729	40 Agility				2
-1603 3571	1607 3571 0	Cross Stepping stone 29730	40 Agility				2
-1607 3571 0	1603 3571	Cross Stepping stone 29730	40 Agility				2
+1603 3571 0	1607 3571 0	Cross Stepping stone 29730	40 Agility				2
+1607 3571 0	1603 3571 0	Cross Stepping stone 29730	40 Agility				2
 2580 9520 0	2580 9512 0	Walk-across Balancing ledge 23548	40 Agility				9
 2580 9512 0	2580 9520 0	Walk-across Balancing ledge 23548	40 Agility				9
 2872 3671 0	2869 3671 0	Climb Rocks 16521	41 Agility				

--- a/src/main/resources/transports/boats.tsv
+++ b/src/main/resources/transports/boats.tsv
@@ -82,8 +82,8 @@
 3768 3898 0	3734 3893 0	Travel Rowboat 30919					3	
 								
 # Hosidius, Crabclaw Isle								
-1783 3458 0	1779 3417 0	Travel Sandicrahb 7483					5	
-1779 3417 0	1783 3458 0	Travel Sandicrahb 7484					5	
+1783 3458 0	1778 3417 0	Travel Sandicrahb 7483					5	
+1779 3417 0	1784 3458 0	Travel Sandicrahb 7484					5	
 								
 # Crash Island, Ape Atoll								
 2892 2724 0	2803 2706 0	Travel Lumdo 1454					5	

--- a/src/main/resources/transports/teleportation_minigames.tsv
+++ b/src/main/resources/transports/teleportation_minigames.tsv
@@ -37,9 +37,9 @@ Destination	Skills	Quests	Display info	Duration	Wilderness level	Varbits	VarPlay
 							
 # Rat Pits - East Ardougne, Keldagrim, Port Sarim, Varrock							
 2561 3319 0		Ratcatchers	Rat Pits Minigame Teleport: 1. Ardougne	23	0		888@20
+3262 3405 0		Ratcatchers	Rat Pits Minigame Teleport: 2. Varrock	23	0		888@20
 2914 10193 0		Ratcatchers	Rat Pits Minigame Teleport: 3. Keldagrim	23	0		888@20
 3018 3231 0		Ratcatchers	Rat Pits Minigame Teleport: 4. Port Sarim	23	0		888@20
-3267 3399 0		Ratcatchers	Rat Pits Minigame Teleport: 2. Varrock	23	0		888@20
 							
 # Shades of Mort'ton							
 3506 3304 0		Shades of Mort'ton	Shades of Mort'ton Minigame Teleport	23	0		888@20

--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -4677,6 +4677,7 @@
 1361 3309 0	1486 3232 0	Follow Mountain Guide 14529				17226=1		5	
 									
 # Entrance to the Brimhaven Dungeon									
+# TODO If you pay 1 milion GP you get permanent access									
 2745 3152 0	2713 9564 0	Pay Dungeon entrance 20877		COINS=875				2	
 2744 3152 0	2713 9564 0	Pay Dungeon entrance 20877		COINS=875				2	
 									
@@ -4684,3 +4685,8 @@
 									
 # Second Brimhaven Dungeon entrance									
 # TODO if you pay 5000 trading sticks you can enter the dungeon down south									
+									
+# Brimhaven Dungeon Vines									
+# TODO you need a axe you can use									
+2691 9512 0	2689 9512 0	Chop-down Vines 29731						2	
+2689 9512 0	2691 9512 0	Chop-down Vines 29731						2	

--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -4675,3 +4675,12 @@
 # Mountain Guide between Nemus Retreat and Quetzacalli Gorge									
 1486 3232 0	1361 3309 0	Follow Mountain Guide 14529				17226=1		5	
 1361 3309 0	1486 3232 0	Follow Mountain Guide 14529				17226=1		5	
+									
+# Entrance to the Brimhaven Dungeon									
+2745 3152 0	2713 9564 0	Pay Dungeon entrance 20877		COINS=875				2	
+2744 3152 0	2713 9564 0	Pay Dungeon entrance 20877		COINS=875				2	
+									
+2713 9564 0	2745 3152 0	Leave exit 20878						2	
+									
+# Second Brimhaven Dungeon entrance									
+# TODO if you pay 5000 trading sticks you can enter the dungeon down south									


### PR DESCRIPTION
I've extracted some of the edits to the transports out of the CI/CD pipeline.

I've tested the Varrock rat pit teleport multiple times, and it always puts me around this coordinate.

I need some more help with the Brimhaven dungeon.
What I'm mostly missing is documentation on what they put in the columns and info on how to find the information more easily.


