### PR TITLE
add 20/08 shortcuts

### DIFF
--- a/src/main/resources/transports/agility_shortcuts.tsv
+++ b/src/main/resources/transports/agility_shortcuts.tsv
@@ -276,14 +276,6 @@
 2888 9823 1	2886 9823 0	Jump-down Rocks 14106	70 Agility				
 3372 2959 0	3373 2955 0	Cross Stepping stone 53241	71 Agility				2
 3373 2955 0	3372 2959 0	Cross Stepping stone 53241	71 Agility				2
-3447 3575 1	3447 3575 2	Climb-up Spikey chain 16537	71 Agility				
-3447 3575 2	3447 3575 1	Climb-down Spikey chain 16538	71 Agility				
-3446 3576 1	3446 3576 2	Climb-up Spikey chain 16537	71 Agility				
-3446 3576 2	3446 3576 1	Climb-down Spikey chain 16538	71 Agility				
-3447 3577 1	3447 3577 2	Climb-up Spikey chain 16537	71 Agility				
-3447 3577 2	3447 3577 1	Climb-down Spikey chain 16538	71 Agility				
-3448 3576 1	3448 3576 2	Climb-up Spikey chain 16537	71 Agility				
-3448 3576 2	3448 3576 1	Climb-down Spikey chain 16538	71 Agility				
 3268 3629 0	3268 3625 0	Cross Stepping stone 53237	72 Agility				2
 3268 3625 0	3268 3629 0	Cross Stepping stone 53237	72 Agility				2
 2429 9807 0	2435 9807 0	Enter Tunnel 30174	72 Agility				
@@ -306,3 +298,26 @@
 2332 3252 0	2338 3253 0	Climb rocks 16514	85 Agility				6
 3500 9510 2	3506 9505 2	Squeeze-through Crevice 16465	86 Agility				
 3506 9505 2	3500 9510 2	Squeeze-through Crevice 16465	86 Agility				
+3765 3883 1	3765 3898 0	Teeth-grip Zip line 17030	74 Agility				10
+
+# Slayer Tower
+3444 3533 0	3442 3531 0	Climb-through Broken window 2173	18 Agility				4	
+3442 3531 0	3444 3533 0	Climb-through Broken window 2173	18 Agility				4	
+3421 3550 0	3421 3550 1	Climb-up Spikey chain 16537	61 Agility						
+3422 3551 0	3422 3551 1	Climb-up Spikey chain 16537	61 Agility						
+3423 3550 0	3423 3550 1	Climb-up Spikey chain 16537	61 Agility						
+3422 3549 0	3422 3549 1	Climb-up Spikey chain 16537	61 Agility						
+3421 3550 1	3421 3550 0	Climb-down Spikey chain 16538	61 Agility						
+3422 3551 1	3422 3551 0	Climb-down Spikey chain 16538	61 Agility						
+3422 3549 1	3422 3549 0	Climb-down Spikey chain 16538	61 Agility						
+3423 3550 1	3423 3550 0	Climb-down Spikey chain 16538	61 Agility						
+3447 3575 1	3447 3575 2	Climb-up Spikey chain 16537	71 Agility				
+3447 3575 2	3447 3575 1	Climb-down Spikey chain 16538	71 Agility				
+3446 3576 1	3446 3576 2	Climb-up Spikey chain 16537	71 Agility				
+3446 3576 2	3446 3576 1	Climb-down Spikey chain 16538	71 Agility				
+3447 3577 1	3447 3577 2	Climb-up Spikey chain 16537	71 Agility				
+3447 3577 2	3447 3577 1	Climb-down Spikey chain 16538	71 Agility				
+3448 3576 1	3448 3576 2	Climb-up Spikey chain 16537	71 Agility				
+3448 3576 2	3448 3576 1	Climb-down Spikey chain 16538	71 Agility				
+3418 3532 0	3420 3534 2	Climb-up Ivy 2176	81 Agility				5	
+3420 3534 2	3418 3532 0	Climb-through Broken window 2173	81 Agility				7	

--- a/src/main/resources/transports/boats.tsv
+++ b/src/main/resources/transports/boats.tsv
@@ -78,8 +78,8 @@
 # Fossil Island, Underwater								
 3724 3807 0	3734 3893 0	Travel Rowboat 30914					4	
 3734 3893 0	3724 3807 0	Travel Rowboat 30915					3	
-3734 3893 0	3768 3898 0	Travel Rowboat 30915					3	
-3768 3898 0	3734 3893 0	Travel Rowboat 30919					3	
+3734 3893 0	3764 3899 0	Travel Rowboat 30915					3	
+3763 3899 0	3733 3893 0	Travel Rowboat 30919					3	
 								
 # Hosidius, Crabclaw Isle								
 1783 3458 0	1778 3417 0	Travel Sandicrahb 7483					5	

--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -2110,12 +2110,14 @@
 3613 3342 1	3613 3338 0	Climb-down Staircase 39492							
 3599 3317 0	3603 3317 1	Climb-up Staircase 39491							
 3603 3317 1	3599 3317 0	Climb-down Staircase 39492							
-3667 3375 0	3670 3375 0	Climb Wall 39542							
-3670 3375 0	3667 3375 0	Climb Wall 39542							
-3670 3375 0	3673 3375 0	Climb Wall 39541							
-3673 3375 0	3670 3375 0	Climb Wall 39541							
-3672 3376 0	3670 3375 0	Climb Wall 39541							
-3672 3374 0	3670 3375 0	Climb Wall 39541							
+3667 3375 0	3670 3375 0	Climb Wall 39542	63 Agility			10449=1			
+3670 3375 0	3667 3375 0	Climb Wall 39542	63 Agility			10449=1			
+3670 3375 0	3673 3375 0	Climb Wall 39541	63 Agility			10450=1			
+3673 3375 0	3670 3375 0	Climb Wall 39541	63 Agility			10450=1			
+3672 3376 0	3670 3375 0	Climb Wall 39541	63 Agility			10450=1			
+3672 3374 0	3670 3375 0	Climb Wall 39541	63 Agility			10450=1			
+3565 3379 0	3562 3379 0	Jump-over Rocks 57666	69 Agility		Sins of the Father				
+3562 3379 0	3565 3379 0	Jump-over Inconspicuous rocks (master) 29044	69 Agility		Sins of the Father				
 									
 # The Hollows									
 3480 9837 0	3480 9836 0	Search Wall 5052							
@@ -2324,14 +2326,6 @@
 # Slayer Tower									
 3417 3536 0	3412 9932 3	Climb-down Ladder 30191							
 3412 9932 3	3417 3536 0	Climb-up Ladder 30192							
-3421 3550 0	3421 3550 1	Climb-up Spikey chain 16537							
-3422 3551 0	3422 3551 1	Climb-up Spikey chain 16537							
-3423 3550 0	3423 3550 1	Climb-up Spikey chain 16537							
-3422 3549 0	3422 3549 1	Climb-up Spikey chain 16537							
-3421 3550 1	3421 3550 0	Climb-down Spikey chain 16538							
-3422 3551 1	3422 3551 0	Climb-down Spikey chain 16538							
-3422 3549 1	3422 3549 0	Climb-down Spikey chain 16538							
-3423 3550 1	3423 3550 0	Climb-down Spikey chain 16538							
 3427 3555 1	3427 3556 1	Open Door 2104							
 3427 3556 1	3427 3555 1	Open Door 2104							
 3426 3555 1	3426 3556 1	Open Door 2102							


### PR DESCRIPTION
Adds the shortcuts introduced in the [latest blog post](https://secure.runescape.com/m=news/more-doom-tweaks-poll-84--summer-sweep-up-changes?oldschool=true). Also fixes requirements for the Darkmeyer wall shortcut, as well as location for some fossil island boats and requirements for slayer tower shortcuts