### PR TITLE
add almera's house ladder transport

### DIFF
--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -4991,3 +4991,9 @@
 2936 2938 0	2936 2940 0	Chop-down Jungle Bush 2893		MACHETE=1			139>49	2	
 2936 2938 0	2936 2936 0	Chop-down Jungle tree 2889		AXE=1			139>49	10	
 2936 2936 0	2936 2938 0	Chop-down Jungle tree 2889		AXE=1			139>49	10	
+
+# Almera's House in Baxtorian Falls
+2521 3494 0	2521 3494 1	Climb-up Ladder 16683						2	
+2522 3493 0	2522 3493 1	Climb-up Ladder 16683						2	
+2521 3494 1	2521 3494 0	Climb-down Ladder 16679						2	
+2522 3493 1	2522 3493 0	Climb-down Ladder 16679						2	


### PR DESCRIPTION
This adds transport data for the ladder that goes to the upper floor of Almera's house. This is the location of the a hard clue step.

<img width="1235" height="892" alt="{3951ED6F-FB70-4ECC-9D70-4E0D0617EA51}" src="https://github.com/user-attachments/assets/9d52c025-1901-455a-8c17-3c6fa977ecf3" />
<img width="987" height="730" alt="{89131AEE-3890-4EB5-B1B6-08152976F3C9}" src="https://github.com/user-attachments/assets/b2ec3756-d0ca-488c-acbf-9357565d9615" />
