### PR TITLE
Add new agility shortcut: Climb Rocks at coordinates (1465, 3128)

### DIFF
--- a/src/main/resources/transports/agility_shortcuts.tsv
+++ b/src/main/resources/transports/agility_shortcuts.tsv
@@ -236,6 +236,8 @@
 2903 3680 0	2900 3680 0	Climb Rocks 16524	47 Agility				
 2901 3679 0	2903 3680 0	Climb Rocks 16524	47 Agility				
 2902 3681 0	2900 3680 0	Climb Rocks 16524	47 Agility				
+1465 3128 0	1455 3128 0	Climb Rocks 51931	47 Agility				8
+1455 3128 0	1465 3128 0	Climb Rocks 51931	47 Agility				8
 2722 3592 0	2722 3596 0	Walk-across Log balance 16542	48 Agility				4
 2722 3596 0	2722 3592 0	Walk-across Log balance 16540	48 Agility				4
 1776 3884 0	1776 3880 0	Jump Boulder 27990	49 Agility				4


### PR DESCRIPTION
<img width="2219" height="1351" alt="image" src="https://github.com/user-attachments/assets/2262071e-6ff2-409e-b2c1-60e4e502014f" />

solves https://github.com/Skretzo/shortest-path/issues/72