### PR TITLE
fix: remove varbit requirement for MTA teleport

### DIFF
--- a/src/main/resources/transports/teleportation_minigames.tsv
+++ b/src/main/resources/transports/teleportation_minigames.tsv
@@ -27,7 +27,7 @@ Destination	Skills	Quests	Display info	Duration	Wilderness level	Varbits	VarPlay
 3150 3635 0			Last Man Standing Minigame Teleport	23	0		888@20
 							
 # Mage Training Arena							
-3363 3295 0			Mage Training Arena Minigame Teleport	23	0	10670=1	888@20
+3363 3295 0			Mage Training Arena Minigame Teleport	23	0		888@20
 							
 # Nightmare Zone - North of Yanille							
 2609 3114 0			Nightmare Zone Minigame Teleport	23	0		888@20


### PR DESCRIPTION
The varbit previously specified (10670) is actually `CHATMODAL_UNCLAMP`

The requirement is to have spoken to the Entrance Guardian far enough to have received the Progress hat, but there's no transmitted varbit or varplayer that controls this.
