### PR TITLE
Add settings to apply additional artificial cost to individual transport types

### DIFF
--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -405,9 +405,361 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigSection(
+        name = "Transport Thresholds",
+        description = "Set customizable thresholds for how much faster a transportation method must be to be preferred over other methods",
+        position = 33
+    )
+    String sectionThresholds = "sectionThresholds";
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costAgilityShortcuts",
+        name = "Agility shortcut threshold",
+        description = "How many extra tiles an agility shortcut must save to be preferred over walking or other transports",
+        position = 34,
+        section = sectionThresholds
+    )
+    default int costAgilityShortcuts() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costGrappleShortcuts",
+        name = "Grapple shortcut threshold",
+        description = "How many extra tiles a grapple shortcut must save to be preferred over walking or other transports",
+        position = 35,
+        section = sectionThresholds
+    )
+    default int costGrappleShortcuts() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costBoats",
+        name = "Boat threshold",
+        description = "How many extra tiles a small boat must save to be preferred over walking or other transports",
+        position = 36,
+        section = sectionThresholds
+    )
+    default int costBoats() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costCanoes",
+        name = "Canoe threshold",
+        description = "How many extra tiles a canoe must save to be preferred over walking or other transports",
+        position = 373,
+        section = sectionThresholds
+    )
+    default int costCanoes() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costCharterShips",
+        name = "Charter ship threshold",
+        description = "How many extra tiles a charter ship must save to be preferred over walking or other transports",
+        position = 38,
+        section = sectionThresholds
+    )
+    default int costCharterShips() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costShips",
+        name = "Ship threshold",
+        description = "How many extra tiles a passenger ship must save to be preferred over walking or other transports",
+        position = 39,
+        section = sectionThresholds
+    )
+    default int costShips() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costFairyRings",
+        name = "Fairy ring threshold",
+        description = "How many extra tiles a fairy ring must save to be preferred over walking or other transports",
+        position = 40,
+        section = sectionThresholds
+    )
+    default int costFairyRings() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costGnomeGliders",
+        name = "Gnome glider threshold",
+        description = "How many extra tiles a gnome glider must save to be preferred over walking or other transports",
+        position = 41,
+        section = sectionThresholds
+    )
+    default int costGnomeGliders() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costHotAirBalloons",
+        name = "Hot air balloon threshold",
+        description = "How many extra tiles a hot air balloon must save to be preferred over walking or other transports",
+        position = 42,
+        section = sectionThresholds
+    )
+    default int costHotAirBalloons() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costMagicCarpets",
+        name = "Magic carpets threshold",
+        description = "How many extra tiles a magic carpet must save to be preferred over walking or other transports",
+        position = 43,
+        section = sectionThresholds
+    )
+    default int costMagicCarpets() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costMagicMushtrees",
+        name = "Magic mushtrees threshold",
+        description = "How many extra tiles a magic mushtree must save to be preferred over walking or other transports",
+        position = 44,
+        section = sectionThresholds
+    )
+    default int costMagicMushtrees() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costMinecarts",
+        name = "Minecart threshold",
+        description = "How many extra tiles a minecart must save to be preferred over walking or other transports",
+        position = 45,
+        section = sectionThresholds
+    )
+    default int costMinecarts() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costQuetzals",
+        name = "Quetzal threshold",
+        description = "How many extra tiles a quetzal must save to be preferred over walking or other transports",
+        position = 46,
+        section = sectionThresholds
+    )
+    default int costQuetzals() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costSpiritTrees",
+        name = "Spirit tree threshold",
+        description = "How many extra tiles a spirit tree must save to be preferred over walking or other transports",
+        position = 47,
+        section = sectionThresholds
+    )
+    default int costSpiritTrees() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costNonConsumableTeleportationItems",
+        name = "Teleportation item (non-consumable) threshold",
+        description = "How many extra tiles a non-consumable teleportation item must save to be preferred over walking or other transports",
+        position = 48,
+        section = sectionThresholds
+    )
+    default int costNonConsumableTeleportationItems() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costConsumableTeleportationItems",
+        name = "Teleportation item (consumable) threshold",
+        description = "How many extra tiles a consumable teleportation item must save to be preferred over walking or other transports",
+        position = 49,
+        section = sectionThresholds
+    )
+    default int costConsumableTeleportationItems() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costTeleportationBoxes",
+        name = "Teleportation box threshold",
+        description = "How many extra tiles a teleportation box must save to be preferred over walking or other transports",
+        position = 50,
+        section = sectionThresholds
+    )
+    default int costTeleportationBoxes() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costTeleportationLevers",
+        name = "Teleportation lever threshold",
+        description = "How many extra tiles a teleportation lever must save to be preferred over walking or other transports",
+        position = 51,
+        section = sectionThresholds
+    )
+    default int costTeleportationLevers() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costTeleportationPortals",
+        name = "Teleportation portal threshold",
+        description = "How many extra tiles a teleportation portal must save to be preferred over walking or other transports",
+        position = 52,
+        section = sectionThresholds
+    )
+    default int costTeleportationPortals() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costTeleportationSpells",
+        name = "Teleportation spell threshold",
+        description = "How many extra tiles a teleportation spell must save to be preferred over walking or other transports",
+        position = 53,
+        section = sectionThresholds
+    )
+    default int costTeleportationSpells() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costTeleportationMinigames",
+        name = "Teleportation to minigame threshold",
+        description = "How many extra tiles a minigame teleport must save to be preferred over walking or other transports",
+        position = 54,
+        section = sectionThresholds
+    )
+    default int costTeleportationMinigames() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costWildernessObelisks",
+        name = "Wilderness obelisk threshold",
+        description = "How many extra tiles a wilderness obelisk must save to be preferred over walking or other transports",
+        position = 55,
+        section = sectionThresholds
+    )
+    default int costWildernessObelisks() {
+        return 0;
+    }
+
+    @Range(
+        min = 0,
+        max = 10000
+    )
+    @ConfigItem(
+        keyName = "costSeasonalTransports",
+        name = "Seasonal transport threshold",
+        description = "How many extra tiles a seasonal transport must save to be preferred over walking or other transports",
+        position = 56,
+        section = sectionThresholds
+    )
+    default int costSeasonalTransports() {
+        return 0;
+    }
+
+    @ConfigSection(
         name = "Display",
         description = "Options for displaying the path on the world map, minimap and scene tiles",
-        position = 33
+        position = 57
     )
     String sectionDisplay = "sectionDisplay";
 
@@ -415,7 +767,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawMap",
         name = "Draw path on world map",
         description = "Whether the path should be drawn on the world map",
-        position = 34,
+        position = 58,
         section = sectionDisplay
     )
     default boolean drawMap() {
@@ -426,7 +778,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawMinimap",
         name = "Draw path on minimap",
         description = "Whether the path should be drawn on the minimap",
-        position = 35,
+        position = 59,
         section = sectionDisplay
     )
     default boolean drawMinimap() {
@@ -437,7 +789,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTiles",
         name = "Draw path on tiles",
         description = "Whether the path should be drawn on the game tiles",
-        position = 36,
+        position = 60,
         section = sectionDisplay
     )
     default boolean drawTiles() {
@@ -448,7 +800,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "pathStyle",
         name = "Path style",
         description = "Whether to display the path as tiles or a segmented line",
-        position = 37,
+        position = 61,
         section = sectionDisplay
     )
     default TileStyle pathStyle() {
@@ -458,7 +810,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Colours",
         description = "Colours for the path map, minimap and scene tiles",
-        position = 38
+        position = 62
     )
     String sectionColours = "sectionColours";
 
@@ -467,7 +819,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPath",
         name = "Path",
         description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 39,
+        position = 63,
         section = sectionColours
     )
     default Color colourPath() {
@@ -480,7 +832,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculating",
         description = "Colour of the path tiles while the pathfinding calculation is in progress," +
             "<br>and the colour of unused targets if there are more than a single target",
-        position = 40,
+        position = 64,
         section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -492,7 +844,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 41,
+        position = 65,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -504,7 +856,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 42,
+        position = 66,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -516,7 +868,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 43,
+        position = 67,
         section = sectionColours
     )
     default Color colourText() {
@@ -526,7 +878,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Debug Options",
         description = "Various options for debugging",
-        position = 44,
+        position = 68,
         closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
@@ -535,7 +887,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTransports",
         name = "Draw transports",
         description = "Whether transports should be drawn",
-        position = 45,
+        position = 69,
         section = sectionDebug
     )
     default boolean drawTransports() {
@@ -546,7 +898,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawCollisionMap",
         name = "Draw collision map",
         description = "Whether the collision map should be drawn",
-        position = 46,
+        position = 70,
         section = sectionDebug
     )
     default boolean drawCollisionMap() {
@@ -557,7 +909,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawDebugPanel",
         name = "Show debug panel",
         description = "Toggles displaying the pathfinding debug stats panel",
-        position = 47,
+        position = 71,
         section = sectionDebug
     )
     default boolean drawDebugPanel() {
@@ -568,7 +920,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "postTransports",
         name = "Post transports",
         description = "Whether to post the transports used in the current path as a PluginMessage event",
-        position = 48,
+        position = 72,
         section = sectionDebug
     )
     default boolean postTransports() {

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -92,7 +92,7 @@ public class CollisionMap {
         // Thus any transports in the list are guaranteed to be valid per the user's settings
         for (Transport transport : transports) {
             if (visited.get(transport.getDestination())) continue;
-            neighbors.add(new TransportNode(transport.getDestination(), node, transport.getDuration()));
+            neighbors.add(new TransportNode(transport.getDestination(), node, transport.getDuration(), config.getAdditionalTransportCost(transport)));
         }
 
         if (isBlocked(x, y, z)) {

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -1,5 +1,6 @@
 package shortestpath.pathfinder;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -131,6 +132,8 @@ public class PathfinderConfig {
         useWildernessObelisks,
         includeBankPath;
     private TeleportationItem useTeleportationItems;
+    private Map<TransportType, Integer> artificialTransportCosts = new EnumMap<>(TransportType.class);
+    private int costConsumableTeleportationItems;
     private int currencyThreshold;
     private final int[] boostedSkillLevelsAndMore = new int[Skill.values().length + 3];
     private Map<Quest, QuestState> questStates = new HashMap<>();
@@ -193,6 +196,30 @@ public class PathfinderConfig {
         currencyThreshold = ShortestPathPlugin.override("currencyThreshold", config.currencyThreshold());
         includeBankPath = ShortestPathPlugin.override("includeBankPath", config.includeBankPath());
         bankVisited = !includeBankPath;
+        artificialTransportCosts = new EnumMap<>(TransportType.class);
+        artificialTransportCosts.put(TransportType.AGILITY_SHORTCUT, ShortestPathPlugin.override("costAgilityShortcuts", config.costAgilityShortcuts()));
+        artificialTransportCosts.put(TransportType.GRAPPLE_SHORTCUT, ShortestPathPlugin.override("costGrappleShortcuts", config.costGrappleShortcuts()));
+        artificialTransportCosts.put(TransportType.BOAT, ShortestPathPlugin.override("costBoats", config.costBoats()));
+        artificialTransportCosts.put(TransportType.CANOE, ShortestPathPlugin.override("costCanoes", config.costCanoes()));
+        artificialTransportCosts.put(TransportType.CHARTER_SHIP, ShortestPathPlugin.override("costCharterShips", config.costCharterShips()));
+        artificialTransportCosts.put(TransportType.SHIP, ShortestPathPlugin.override("costShips", config.costShips()));
+        artificialTransportCosts.put(TransportType.FAIRY_RING, ShortestPathPlugin.override("costFairyRings", config.costFairyRings()));
+        artificialTransportCosts.put(TransportType.GNOME_GLIDER, ShortestPathPlugin.override("costGnomeGliders", config.costGnomeGliders()));
+        artificialTransportCosts.put(TransportType.HOT_AIR_BALLOON, ShortestPathPlugin.override("costHotAirBalloons", config.costHotAirBalloons()));
+        artificialTransportCosts.put(TransportType.MAGIC_CARPET, ShortestPathPlugin.override("costMagicCarpets", config.costMagicCarpets()));
+        artificialTransportCosts.put(TransportType.MAGIC_MUSHTREE, ShortestPathPlugin.override("costMagicMushtrees", config.costMagicMushtrees()));
+        artificialTransportCosts.put(TransportType.MINECART, ShortestPathPlugin.override("costMinecarts", config.costMinecarts()));
+        artificialTransportCosts.put(TransportType.QUETZAL, ShortestPathPlugin.override("costQuetzals", config.costQuetzals()));
+        artificialTransportCosts.put(TransportType.SEASONAL_TRANSPORTS, ShortestPathPlugin.override("costSeasonalTransports", config.costSeasonalTransports()));
+        artificialTransportCosts.put(TransportType.SPIRIT_TREE, ShortestPathPlugin.override("costSpiritTrees", config.costSpiritTrees()));
+        artificialTransportCosts.put(TransportType.TELEPORTATION_ITEM, ShortestPathPlugin.override("costNonConsumableTeleportationItems", config.costNonConsumableTeleportationItems()));
+        artificialTransportCosts.put(TransportType.TELEPORTATION_BOX, ShortestPathPlugin.override("costTeleportationBoxes", config.costTeleportationBoxes()));
+        artificialTransportCosts.put(TransportType.TELEPORTATION_LEVER, ShortestPathPlugin.override("costTeleportationLevers", config.costTeleportationLevers()));
+        artificialTransportCosts.put(TransportType.TELEPORTATION_MINIGAME, ShortestPathPlugin.override("costTeleportationMinigames", config.costTeleportationMinigames()));
+        artificialTransportCosts.put(TransportType.TELEPORTATION_PORTAL, ShortestPathPlugin.override("costTeleportationPortals", config.costTeleportationPortals()));
+        artificialTransportCosts.put(TransportType.TELEPORTATION_SPELL, ShortestPathPlugin.override("costTeleportationSpells", config.costTeleportationSpells()));
+        artificialTransportCosts.put(TransportType.WILDERNESS_OBELISK, ShortestPathPlugin.override("costWildernessObelisks", config.costWildernessObelisks()));
+        costConsumableTeleportationItems = ShortestPathPlugin.override("costConsumableTeleportationItems", config.costConsumableTeleportationItems());
 
         if (GameState.LOGGED_IN.equals(client.getGameState())) {
             int i = 0;
@@ -250,6 +277,14 @@ public class PathfinderConfig {
             locations.addAll(filteredTargets);
             filteredTargets.clear();
         }
+    }
+
+    /** Returns the user-configured additional cost for a given transport */
+    public int getAdditionalTransportCost(Transport transport) {
+        if (transport.isConsumable() && TransportType.TELEPORTATION_ITEM.equals(transport.getType())) {
+            return costConsumableTeleportationItems;
+        }
+        return artificialTransportCosts.getOrDefault(transport.getType(), 0);
     }
 
     private Map<String, Set<Integer>> filterDestinations(Map<String, Set<Integer>> allDestinations) {

--- a/src/main/java/shortestpath/pathfinder/TransportNode.java
+++ b/src/main/java/shortestpath/pathfinder/TransportNode.java
@@ -1,8 +1,8 @@
 package shortestpath.pathfinder;
 
 public class TransportNode extends Node implements Comparable<TransportNode> {
-    public TransportNode(int packedPosition, Node previous, int travelTime) {
-        super(packedPosition, previous, cost(previous, travelTime));
+    public TransportNode(int packedPosition, Node previous, int travelTime, int additionalCost) {
+        super(packedPosition, previous, cost(previous, travelTime + additionalCost));
     }
 
     private static int cost(Node previous, int travelTime) {


### PR DESCRIPTION
This fairly minimal PR adds the ability to specify an artificial overhead cost to different transport types (see https://github.com/Skretzo/shortest-path/issues/268)

- Adds configs to specify a threshold value for each transport type
- Threshold is added directly to cost when generating `TransportNode`s in `getNeighbors()` from each defined `Transport`. This simply artificially inflates the cost of the node by the threshold value, making it less desirable over just walking or any lower-cost transport node.
- Additional config added to differentiate costs for consumable and non-consumable teleport items to improve the non-`(perm)` teleportation item options
  - _(Should this consumable/non-consumable distinction also be added to seasonal transports?)_

---

A further improvement could be to add an option for threshold costs for transports that require banked items when "Inventory and Bank" is selected. This would require an update to the `hasRequiredItems()` function to return not just a boolean but also whether that boolean requires banking, and somehow add that to the cost as well. A further consideration here would be whether to count each transport that requires a banked item as adding the artificial cost again, or whether it should only add the cost once to the total path.

It would be great to be able to calculate cost to nearest bank instead of using a fixed cost, but that would be quite expensive to calculate so it's probably not reasonable at this time. However, if this were implemented in a reasonable fashion, this would allow for even more efficient pathing by including banking in the route, and possibly even showing required banked items in an overlay so you only need to visit the bank once to grab everything for the path.
