### PR TITLE
Option to include path to bank for teleports

### DIFF
--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -286,11 +286,22 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "includeBankPath",
+        name = "Include path to bank",
+        description = "Whether to include the path to the closest bank when suggesting teleports from the bank",
+        position = 24,
+        section = sectionSettings
+    )
+    default boolean includeBankPath() {
+        return false;
+    }
+
+    @ConfigItem(
         keyName = "currencyThreshold",
         name = "Currency threshold",
         description = "The maximum amount of currency to use on a single transportation method." +
             "<br>The currencies affected by the threshold are coins, trading sticks, ecto-tokens and warrior guild tokens.",
-        position = 24,
+        position = 25,
         section = sectionSettings
     )
     default int currencyThreshold() {
@@ -302,7 +313,7 @@ public interface ShortestPathConfig extends Config {
         name = "Cancel instead of recalculating",
         description = "Whether the path should be cancelled rather than recalculated " +
             "when the recalculate distance limit is exceeded",
-        position = 25,
+        position = 26,
         section = sectionSettings
     )
     default boolean cancelInstead() {
@@ -317,7 +328,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "recalculateDistance",
         name = "Recalculate distance",
         description = "Distance from the path the player should be for it to be recalculated (-1 for never)",
-        position = 26,
+        position = 27,
         section = sectionSettings
     )
     default int recalculateDistance() {
@@ -332,7 +343,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "finishDistance",
         name = "Finish distance",
         description = "Distance from the target tile at which the path should be ended (-1 for never)",
-        position = 27,
+        position = 28,
         section = sectionSettings
     )
     default int reachedDistance() {
@@ -343,7 +354,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "showTileCounter",
         name = "Show tile counter",
         description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-        position = 28,
+        position = 29,
         section = sectionSettings
     )
     default TileCounter showTileCounter() {
@@ -354,7 +365,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "tileCounterStep",
         name = "Tile counter step",
         description = "The number of tiles between the displayed tile counter numbers",
-        position = 29,
+        position = 30,
         section = sectionSettings
     )
     default int tileCounterStep()
@@ -374,7 +385,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculation cutoff",
         description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
             "made towards the path target before the calculation will be stopped",
-        position = 30,
+        position = 31,
         section = sectionSettings
     )
     default int calculationCutoff()
@@ -386,7 +397,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "showTransportInfo",
         name = "Show transport info",
         description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-        position = 31,
+        position = 32,
         section = sectionSettings
     )
     default boolean showTransportInfo() {
@@ -396,7 +407,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Display",
         description = "Options for displaying the path on the world map, minimap and scene tiles",
-        position = 32
+        position = 33
     )
     String sectionDisplay = "sectionDisplay";
 
@@ -404,7 +415,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawMap",
         name = "Draw path on world map",
         description = "Whether the path should be drawn on the world map",
-        position = 33,
+        position = 34,
         section = sectionDisplay
     )
     default boolean drawMap() {
@@ -415,7 +426,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawMinimap",
         name = "Draw path on minimap",
         description = "Whether the path should be drawn on the minimap",
-        position = 34,
+        position = 35,
         section = sectionDisplay
     )
     default boolean drawMinimap() {
@@ -426,7 +437,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTiles",
         name = "Draw path on tiles",
         description = "Whether the path should be drawn on the game tiles",
-        position = 35,
+        position = 36,
         section = sectionDisplay
     )
     default boolean drawTiles() {
@@ -437,7 +448,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "pathStyle",
         name = "Path style",
         description = "Whether to display the path as tiles or a segmented line",
-        position = 36,
+        position = 37,
         section = sectionDisplay
     )
     default TileStyle pathStyle() {
@@ -447,7 +458,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Colours",
         description = "Colours for the path map, minimap and scene tiles",
-        position = 37
+        position = 38
     )
     String sectionColours = "sectionColours";
 
@@ -456,7 +467,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPath",
         name = "Path",
         description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 38,
+        position = 39,
         section = sectionColours
     )
     default Color colourPath() {
@@ -469,7 +480,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculating",
         description = "Colour of the path tiles while the pathfinding calculation is in progress," +
             "<br>and the colour of unused targets if there are more than a single target",
-        position = 39,
+        position = 40,
         section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -481,7 +492,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 40,
+        position = 41,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -493,7 +504,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 41,
+        position = 42,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -505,7 +516,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 42,
+        position = 43,
         section = sectionColours
     )
     default Color colourText() {
@@ -515,7 +526,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Debug Options",
         description = "Various options for debugging",
-        position = 43,
+        position = 44,
         closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
@@ -524,7 +535,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTransports",
         name = "Draw transports",
         description = "Whether transports should be drawn",
-        position = 44,
+        position = 45,
         section = sectionDebug
     )
     default boolean drawTransports() {
@@ -535,7 +546,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawCollisionMap",
         name = "Draw collision map",
         description = "Whether the collision map should be drawn",
-        position = 45,
+        position = 46,
         section = sectionDebug
     )
     default boolean drawCollisionMap() {
@@ -546,7 +557,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawDebugPanel",
         name = "Show debug panel",
         description = "Toggles displaying the pathfinding debug stats panel",
-        position = 46,
+        position = 47,
         section = sectionDebug
     )
     default boolean drawDebugPanel() {
@@ -557,7 +568,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "postTransports",
         name = "Post transports",
         description = "Whether to post the transports used in the current path as a PluginMessage event",
-        position = 47,
+        position = 48,
         section = sectionDebug
     )
     default boolean postTransports() {

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -89,7 +89,7 @@ public class ShortestPathPlugin extends Plugin {
     private static final String START = ColorUtil.wrapWithColorTag("Start", JagexColors.MENU_TARGET);
     private static final String TARGET = ColorUtil.wrapWithColorTag("Target", JagexColors.MENU_TARGET);
     private static final BufferedImage MARKER_IMAGE = ImageUtil.loadImageResource(ShortestPathPlugin.class, "/marker.png");
-    private static final Pattern TRANSPORT_OPTIONS_REGEX = Pattern.compile("^(avoidWilderness|currencyThreshold|use\\w+)$");
+    private static final Pattern TRANSPORT_OPTIONS_REGEX = Pattern.compile("^(avoidWilderness|includeBankPath|currencyThreshold|use\\w+)$");
 
     @Inject
     private Client client;

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -74,12 +74,16 @@ public class CollisionMap {
     private final List<Node> neighbors = new ArrayList<>(16);
     private final boolean[] traversable = new boolean[8];
 
-    public List<Node> getNeighbors(Node node, VisitedTiles visited, PathfinderConfig config) {
+    public List<Node> getNeighbors(Node node, VisitedTiles visited, PathfinderConfig config, int wildernessLevel) {
         final int x = WorldPointUtil.unpackWorldX(node.packedPosition);
         final int y = WorldPointUtil.unpackWorldY(node.packedPosition);
         final int z = WorldPointUtil.unpackWorldPlane(node.packedPosition);
 
         neighbors.clear();
+
+        if (!config.isBankVisited() && config.getDestinations("bank").contains(node.packedPosition)) {
+            config.setBankVisited(true, node.packedPosition, wildernessLevel);
+        }
 
         @SuppressWarnings("unchecked") // Casting EMPTY_LIST to List<Transport> is safe here
         Set<Transport> transports = config.getTransportsPacked().getOrDefault(node.packedPosition, (Set<Transport>)Collections.EMPTY_SET);

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -89,7 +89,7 @@ public class Pathfinder implements Runnable {
     }
 
     private void addNeighbors(Node node) {
-        List<Node> nodes = map.getNeighbors(node, visited, config);
+        List<Node> nodes = map.getNeighbors(node, visited, config, wildernessLevel);
         for (int i = 0; i < nodes.size(); ++i) {
             Node neighbor = nodes.get(i);
 


### PR DESCRIPTION
Adds a new config option `Include path to bank` to support including the path to the closest bank to fetch banked items for more teleports.
![image1](https://github.com/user-attachments/assets/7d455aef-6bcd-4f28-8f30-946016829afe)

This also supports paths with multiple teleports, e.g. teleporting to first get closer to the bank and then teleporting from the bank towards the target.
![image2](https://github.com/user-attachments/assets/bdb6b2ca-a0c6-4c5a-8e4e-1a28f28166af)