### PR TITLE
Make invisible wall walkable

### DIFF
--- a/collision-map-update/CollisionMapDumper.java
+++ b/collision-map-update/CollisionMapDumper.java
@@ -677,6 +677,11 @@ public class CollisionMapDumper
 		YANILLE_MAGIC_GUILD_DOOR_1733(1733),
 
 		ZANARIS_SHED_DOOR_2406(2406),
+		
+		// The invisible walls are placed all over the map. There purpose is unknown.
+		// They dont seem to block player movement.
+		// Most anoyingly they block the entrance to the death plateau.
+		INVISIBLE_WALL_38848(38848, FlagMap.TILE_DEFAULT)
 		;
 
 		/**


### PR DESCRIPTION
I was working on why I could not route to the death plateau.

These are all over the place and most of them are not blocking players.

It is a bit expirmental and I noticed some places where some non-passable terain is now marked as walkable.

Mostly on the death plato walk from the house to the first obstical

But I think overall it's an improvement.

Let me know what you think