### PR TITLE
Feature/Add specificity to POH teleport pathfinding display

### DIFF
--- a/src/main/java/shortestpath/JewelleryBoxTier.java
+++ b/src/main/java/shortestpath/JewelleryBoxTier.java
@@ -1,0 +1,30 @@
+package shortestpath;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JewelleryBoxTier {
+    NONE("None"),
+    BASIC("Basic"),
+    FANCY("Fancy"),
+    ORNATE("Ornate"),
+    ;
+
+    private final String type;
+
+    @Override
+    public String toString() {
+        return type;
+    }
+
+    public static JewelleryBoxTier fromType(String type) {
+        for (JewelleryBoxTier tier : values()) {
+            if (tier.type.equals(type)) {
+                return tier;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/shortestpath/PathMapTooltipOverlay.java
+++ b/src/main/java/shortestpath/PathMapTooltipOverlay.java
@@ -19,7 +19,6 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import shortestpath.transport.Transport;
-import shortestpath.transport.TransportType;
 
 public class PathMapTooltipOverlay extends Overlay {
     private static final int TOOLTIP_OFFSET_HEIGHT = 25;
@@ -27,12 +26,6 @@ public class PathMapTooltipOverlay extends Overlay {
     private static final int TOOLTIP_PADDING_HEIGHT = 1;
     private static final int TOOLTIP_PADDING_WIDTH = 2;
     private static final int TOOLTIP_TEXT_OFFSET_HEIGHT = -2;
-    
-    // POH (Player Owned House) bounds for detecting when path goes through POH
-    private static final int POH_MIN_X = 1792;
-    private static final int POH_MAX_X = 2047;
-    private static final int POH_MIN_Y = 5696;
-    private static final int POH_MAX_Y = 5767;
 
     private final Client client;
     private final ShortestPathPlugin plugin;
@@ -102,7 +95,7 @@ public class PathMapTooltipOverlay extends Overlay {
                     && transport.getDisplayInfo() != null && !transport.getDisplayInfo().isEmpty()) {
                     String displayInfo = transport.getDisplayInfo();
                     // Check if this transport goes to POH - if so, look ahead to find the exit transport
-                    String pohExitInfo = getPohExitInfo(nextPoint, path, pathIndex);
+                    String pohExitInfo = plugin.getPohExitInfo(nextPoint, path, pathIndex);
                     if (pohExitInfo != null) {
                         displayInfo = displayInfo + " (Exit: " + pohExitInfo + ")";
                     }
@@ -149,140 +142,5 @@ public class PathMapTooltipOverlay extends Overlay {
         }
 
         return true;
-    }
-
-    /**
-     * Checks if the destination is inside POH and looks ahead in the path to find the exit transport.
-     * If the immediate exit leads to a fairy ring or other notable transport shortly after,
-     * that information is included instead.
-     * @param destination The destination point to check
-     * @param path The full path
-     * @param currentIndex The current index in the path
-     * @return The display info of the POH exit transport, or null if not applicable
-     */
-    private String getPohExitInfo(int destination, PrimitiveIntList path, int currentIndex) {
-        if (path == null || currentIndex < 0) {
-            return null;
-        }
-        
-        int destX = WorldPointUtil.unpackWorldX(destination);
-        int destY = WorldPointUtil.unpackWorldY(destination);
-        
-        // Check if destination is inside POH
-        if (destX < POH_MIN_X || destX > POH_MAX_X || destY < POH_MIN_Y || destY > POH_MAX_Y) {
-            return null;
-        }
-
-        int pohExitIndex = -1;
-        String immediateExitInfo = null;
-
-        // Look ahead in the path to find the next transport that exits POH
-        for (int i = currentIndex + 1; i < path.size() - 1; i++) {
-            int stepLocation = path.get(i);
-            int nextLocation = path.get(i + 1);
-            
-            int stepX = WorldPointUtil.unpackWorldX(stepLocation);
-            int stepY = WorldPointUtil.unpackWorldY(stepLocation);
-            int nextX = WorldPointUtil.unpackWorldX(nextLocation);
-            int nextY = WorldPointUtil.unpackWorldY(nextLocation);
-            
-            // Check if this step is inside POH but next step is outside (exit transport)
-            boolean stepInsidePoh = stepX >= POH_MIN_X && stepX <= POH_MAX_X && stepY >= POH_MIN_Y && stepY <= POH_MAX_Y;
-            boolean nextInsidePoh = nextX >= POH_MIN_X && nextX <= POH_MAX_X && nextY >= POH_MIN_Y && nextY <= POH_MAX_Y;
-            
-            if (stepInsidePoh && !nextInsidePoh) {
-                pohExitIndex = i + 1; // Index of the first step outside POH
-                // Found the exit transport - get its display info
-                for (Transport transport : plugin.getTransports().getOrDefault(stepLocation, new HashSet<>())) {
-                    if (nextLocation == transport.getDestination()) {
-                        String exitInfo = transport.getDisplayInfo();
-                        if (exitInfo != null && !exitInfo.isEmpty()) {
-                            TransportType exitType = transport.getType();
-                            if (TransportType.TELEPORTATION_BOX.equals(exitType)) {
-                                String objInfo = transport.getObjectInfo();
-                                if (objInfo != null && objInfo.contains("Xeric's Talisman")) {
-                                    immediateExitInfo = "Xeric's Talisman: " + exitInfo;
-                                } else if (objInfo != null && objInfo.contains("Digsite")) {
-                                    immediateExitInfo = "Digsite Pendant: " + exitInfo;
-                                } else {
-                                    immediateExitInfo = "Jewelry Box: " + exitInfo;
-                                }
-                            } else if (TransportType.TELEPORTATION_PORTAL_POH.equals(exitType)) {
-                                immediateExitInfo = "Nexus: " + exitInfo.replace(" Portal", "");
-                            } else {
-                                immediateExitInfo = exitInfo.replace(" Portal", "");
-                            }
-                        }
-                        break;
-                    }
-                }
-                break;
-            }
-            
-            // If we've left POH without finding a transport, stop looking
-            if (!stepInsidePoh) {
-                break;
-            }
-        }
-        
-        // If we found a POH exit, look further ahead to see if there's a fairy ring,
-        // spirit tree, or other notable transport used shortly after
-        if (pohExitIndex > 0 && pohExitIndex < path.size() - 1) {
-            String secondaryTransportInfo = findSecondaryTransport(path, pohExitIndex);
-            if (secondaryTransportInfo != null) {
-                return secondaryTransportInfo;
-            }
-        }
-        
-        return immediateExitInfo;
-    }
-
-    /**
-     * Looks ahead from the POH exit point to find fairy rings, spirit trees, or other
-     * notable transports that might be the real destination reason for going through POH.
-     * @param path The full path
-     * @param startIndex The index to start looking from (first step outside POH)
-     * @return The display info of a secondary transport if found within a reasonable distance, or null
-     */
-    private String findSecondaryTransport(PrimitiveIntList path, int startIndex) {
-        // Look up to 30 steps ahead (reasonable walking distance to a nearby transport)
-        int maxLookahead = Math.min(startIndex + 30, path.size() - 1);
-        
-        for (int i = startIndex; i < maxLookahead; i++) {
-            int stepLocation = path.get(i);
-            int nextLocation = path.get(i + 1);
-            
-            for (Transport transport : plugin.getTransports().getOrDefault(stepLocation, new HashSet<>())) {
-                if (nextLocation == transport.getDestination()) {
-                    TransportType type = transport.getType();
-                    // Check for notable transport types that are likely the real reason for the route
-                    if (TransportType.FAIRY_RING.equals(type)) {
-                        String code = transport.getDisplayInfo();
-                        if (code != null && !code.isEmpty()) {
-                            return "Fairy Ring " + code;
-                        }
-                    } else if (TransportType.SPIRIT_TREE.equals(type)) {
-                        String dest = transport.getDisplayInfo();
-                        if (dest != null && !dest.isEmpty()) {
-                            return "Spirit Tree: " + dest;
-                        }
-                    } else if (TransportType.GNOME_GLIDER.equals(type)) {
-                        String dest = transport.getDisplayInfo();
-                        if (dest != null && !dest.isEmpty()) {
-                            return "Glider: " + dest;
-                        }
-                    } else if (TransportType.WILDERNESS_OBELISK.equals(type)) {
-                        String dest = transport.getDisplayInfo();
-                        if (dest != null && !dest.isEmpty()) {
-                            return "Obelisk: " + dest;
-                        }
-                    }
-                    // For other transports, we just use the immediate POH exit
-                    // as they're likely the actual destination
-                }
-            }
-        }
-        
-        return null;
     }
 }

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -18,6 +18,14 @@ public interface ShortestPathConfig extends Config {
     )
     String sectionSettings = "sectionSettings";
 
+    @ConfigSection(
+        name = "Player-Owned House",
+        description = "Options for POH (Player-Owned House) teleports",
+        position = 31,
+        closedByDefault = true
+    )
+    String sectionPoh = "sectionPoh";
+
     @ConfigItem(
         keyName = "avoidWilderness",
         name = "Avoid wilderness",
@@ -116,7 +124,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useGnomeGliders",
         name = "Use gnome gliders",
         description = "Whether to include gnome gliders in the path",
-        position = 9,
+        position = 10,
         section = sectionSettings
     )
     default boolean useGnomeGliders() {
@@ -127,7 +135,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useHotAirBalloons",
         name = "Use hot air balloons",
         description = "Whether to include hot air balloons in the path",
-        position = 10,
+        position = 11,
         section = sectionSettings
     )
     default boolean useHotAirBalloons() {
@@ -138,7 +146,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useMagicCarpets",
         name = "Use magic carpets",
         description = "Whether to include magic carpets in the path",
-        position = 11,
+        position = 12,
         section = sectionSettings
     )
     default boolean useMagicCarpets() {
@@ -150,7 +158,7 @@ public interface ShortestPathConfig extends Config {
         name = "Use magic mushtrees",
         description = "Whether to include Fossil Island Magic Mushtrees in the path<br>" +
             "(e.g. the Mycelium transport network from Verdant Valley to Mushroom Meadow)",
-        position = 12,
+        position = 13,
         section = sectionSettings
     )
     default boolean useMagicMushtrees() {
@@ -162,7 +170,7 @@ public interface ShortestPathConfig extends Config {
         name = "Use minecarts",
         description = "Whether to include minecarts in the path<br>" +
             "(e.g. the Keldagrim and Lovakengj minecart networks)",
-        position = 13,
+        position = 14,
         section = sectionSettings
     )
     default boolean useMinecarts() {
@@ -173,7 +181,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useQuetzals",
         name = "Use quetzals",
         description = "Whether to include quetzals in the path",
-        position = 14,
+        position = 15,
         section = sectionSettings
     )
     default boolean useQuetzals() {
@@ -184,7 +192,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useSpiritTrees",
         name = "Use spirit trees",
         description = "Whether to include spirit trees in the path",
-        position = 15,
+        position = 9,
         section = sectionSettings
     )
     default boolean useSpiritTrees() {
@@ -205,23 +213,11 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
-        keyName = "useTeleportationBoxes",
-        name = "Use teleportation boxes",
-        description = "Whether to include teleportation boxes or mounted items in the path<br>" +
-            "(e.g. the PoH jewellery box or PoH mounted glory amulet)",
-        position = 17,
-        section = sectionSettings
-    )
-    default boolean useTeleportationBoxes() {
-        return true;
-    }
-
-    @ConfigItem(
         keyName = "useTeleportationLevers",
         name = "Use teleportation levers",
         description = "Whether to include teleportation levers in the path<br>" +
             "(e.g. the lever from Edgeville to Wilderness)",
-        position = 18,
+        position = 17,
         section = sectionSettings
     )
     default boolean useTeleportationLevers() {
@@ -233,7 +229,7 @@ public interface ShortestPathConfig extends Config {
         name = "Use teleportation portals",
         description = "Whether to include teleportation portals in the path<br>" +
             "(e.g. the portal from Ferox Enclave to Castle Wars)",
-        position = 19,
+        position = 18,
         section = sectionSettings
     )
     default boolean useTeleportationPortals() {
@@ -241,21 +237,10 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
-        keyName = "useTeleportationPortalsPoh",
-        name = "Use teleportation portals (POH)",
-        description = "Whether to include player-owned-house (POH) teleportation portals/nexus in the path",
-        position = 20,
-        section = sectionSettings
-    )
-    default boolean useTeleportationPortalsPoh() {
-        return false;
-    }
-
-    @ConfigItem(
         keyName = "useTeleportationSpells",
         name = "Use teleportation spells",
         description = "Whether to include teleportation spells in the path",
-        position = 21,
+        position = 19,
         section = sectionSettings
     )
     default boolean useTeleportationSpells() {
@@ -267,7 +252,7 @@ public interface ShortestPathConfig extends Config {
         name = "Use teleportation to minigames",
         description = "Whether to include teleportation to minigames/activities/grouping in the path<br>" +
             "(e.g. the Nightmare Zone minigame teleport). These teleports share a 20 minute cooldown.",
-        position = 22,
+        position = 20,
         section = sectionSettings
     )
     default boolean useTeleportationMinigames() {
@@ -278,7 +263,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useWildernessObelisks",
         name = "Use wilderness obelisks",
         description = "Whether to include wilderness obelisks in the path",
-        position = 23,
+        position = 21,
         section = sectionSettings
     )
     default boolean useWildernessObelisks() {
@@ -289,7 +274,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "useSeasonalTransports",
         name = "Use seasonal transports",
         description = "Whether to include seasonal transports like League teleports in the path",
-        position = 24,
+        position = 22,
         section = sectionSettings
     )
     default boolean useSeasonalTransports() {
@@ -301,7 +286,7 @@ public interface ShortestPathConfig extends Config {
         name = "Include path to bank",
         description = "Whether to include the path to the closest bank<br>" +
             "when suggesting teleports from the bank",
-        position = 25,
+        position = 23,
         section = sectionSettings
     )
     default boolean includeBankPath() {
@@ -313,7 +298,7 @@ public interface ShortestPathConfig extends Config {
         name = "Currency threshold",
         description = "The maximum amount of currency to use on a single transportation method." +
             "<br>The currencies affected by the threshold are coins, trading sticks, ecto-tokens and warrior guild tokens.",
-        position = 26,
+        position = 24,
         section = sectionSettings
     )
     default int currencyThreshold() {
@@ -325,7 +310,7 @@ public interface ShortestPathConfig extends Config {
         name = "Cancel instead of recalculating",
         description = "Whether the path should be cancelled rather than recalculated " +
             "when the recalculate distance limit is exceeded",
-        position = 27,
+        position = 25,
         section = sectionSettings
     )
     default boolean cancelInstead() {
@@ -340,7 +325,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "recalculateDistance",
         name = "Recalculate distance",
         description = "Distance from the path the player should be for it to be recalculated (-1 for never)",
-        position = 28,
+        position = 26,
         section = sectionSettings
     )
     default int recalculateDistance() {
@@ -355,7 +340,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "finishDistance",
         name = "Finish distance",
         description = "Distance from the target tile at which the path should be ended (-1 for never)",
-        position = 29,
+        position = 27,
         section = sectionSettings
     )
     default int reachedDistance() {
@@ -366,7 +351,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "showTileCounter",
         name = "Show tile counter",
         description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-        position = 30,
+        position = 28,
         section = sectionSettings
     )
     default TileCounter showTileCounter() {
@@ -377,7 +362,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "tileCounterStep",
         name = "Tile counter step",
         description = "The number of tiles between the displayed tile counter numbers",
-        position = 31,
+        position = 29,
         section = sectionSettings
     )
     default int tileCounterStep()
@@ -397,7 +382,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculation cutoff",
         description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
             "made towards the path target before the calculation will be stopped",
-        position = 32,
+        position = 30,
         section = sectionSettings
     )
     default int calculationCutoff()
@@ -409,18 +394,101 @@ public interface ShortestPathConfig extends Config {
         keyName = "showTransportInfo",
         name = "Show transport info",
         description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-        position = 33,
+        position = 31,
         section = sectionSettings
     )
     default boolean showTransportInfo() {
         return true;
     }
 
+    @ConfigItem(
+        keyName = "usePoh",
+        name = "Enable POH teleports",
+        description = "Master toggle for all Player-Owned House (POH) teleports.<br>" +
+            "When disabled, all POH transports are excluded regardless of individual settings below.",
+        position = 32,
+        section = sectionPoh
+    )
+    default boolean usePoh() {
+        return false;
+    }
+
+    @ConfigItem(
+        keyName = "usePohFairyRing",
+        name = "POH fairy ring",
+        description = "Whether to include the POH fairy ring in the path.<br>" +
+            "Enable this if you have built a fairy ring in your house (85 Construction or boosted)",
+        position = 33,
+        section = sectionPoh
+    )
+    default boolean usePohFairyRing() {
+        return false;
+    }
+
+    @ConfigItem(
+        keyName = "usePohSpiritTree",
+        name = "POH spirit tree",
+        description = "Whether to include the POH spirit tree in the path.<br>" +
+            "Enable this if you have built a spirit tree in your house (75 Construction, 83 Farming or boosted)",
+        position = 34,
+        section = sectionPoh
+    )
+    default boolean usePohSpiritTree() {
+        return false;
+    }
+
+    @ConfigItem(
+        keyName = "useTeleportationPortalsPoh",
+        name = "POH portal nexus",
+        description = "Whether to include POH teleportation portals/nexus in the path",
+        position = 35,
+        section = sectionPoh
+    )
+    default boolean useTeleportationPortalsPoh() {
+        return false;
+    }
+
+    @ConfigItem(
+        keyName = "pohJewelleryBoxTier",
+        name = "POH jewellery box tier",
+        description = "The tier of jewellery box built in your POH<br>" +
+            "(Basic: 1-9, Fancy: A-J, Ornate: K-R). Set to None to disable jewellery box.",
+        position = 36,
+        section = sectionPoh
+    )
+    default JewelleryBoxTier pohJewelleryBoxTier() {
+        return JewelleryBoxTier.ORNATE;
+    }
+
+    @ConfigItem(
+        keyName = "usePohMountedItems",
+        name = "POH mounted items",
+        description = "Whether to include POH mounted items in the path<br>" +
+            "(e.g. mounted glory, Xeric's talisman, digsite pendant, mythical cape)",
+        position = 37,
+        section = sectionPoh
+    )
+    default boolean usePohMountedItems() {
+        return true;
+    }
+
+    @ConfigItem(
+        keyName = "usePohObelisk",
+        name = "POH wilderness obelisk",
+        description = "Whether to include the POH wilderness obelisk in the path.<br>" +
+            "Enable this if you have built an obelisk in your house (80 Construction or boosted)",
+        position = 38,
+        section = sectionPoh
+    )
+    default boolean usePohObelisk() {
+        return false;
+    }
+
     @ConfigSection(
         name = "Transport Thresholds",
         description = "Set customizable thresholds for how much faster a transportation<br>"+
             "method must be to be preferred over other methods",
-        position = 34,
+        position = 39,
         closedByDefault = true
     )
     String sectionThresholds = "sectionThresholds";
@@ -434,7 +502,7 @@ public interface ShortestPathConfig extends Config {
         name = "Agility shortcut threshold",
         description = "How many extra tiles an agility shortcut must save<br>" +
             "to be preferred over walking or other transports",
-        position = 35,
+        position = 36,
         section = sectionThresholds
     )
     default int costAgilityShortcuts() {
@@ -450,7 +518,7 @@ public interface ShortestPathConfig extends Config {
         name = "Grapple shortcut threshold",
         description = "How many extra tiles a grapple shortcut must save<br>" +
             "to be preferred over walking or other transports",
-        position = 36,
+        position = 37,
         section = sectionThresholds
     )
     default int costGrappleShortcuts() {
@@ -466,7 +534,7 @@ public interface ShortestPathConfig extends Config {
         name = "Boat threshold",
         description = "How many extra tiles a small boat must save<br>" +
             "to be preferred over walking or other transports",
-        position = 37,
+        position = 38,
         section = sectionThresholds
     )
     default int costBoats() {
@@ -482,7 +550,7 @@ public interface ShortestPathConfig extends Config {
         name = "Canoe threshold",
         description = "How many extra tiles a canoe must save<br>" +
             "to be preferred over walking or other transports",
-        position = 38,
+        position = 39,
         section = sectionThresholds
     )
     default int costCanoes() {
@@ -498,7 +566,7 @@ public interface ShortestPathConfig extends Config {
         name = "Charter ship threshold",
         description = "How many extra tiles a charter ship must save<br>" +
             "to be preferred over walking or other transports",
-        position = 39,
+        position = 40,
         section = sectionThresholds
     )
     default int costCharterShips() {
@@ -514,7 +582,7 @@ public interface ShortestPathConfig extends Config {
         name = "Ship threshold",
         description = "How many extra tiles a passenger ship must save<br>" +
             "to be preferred over walking or other transports",
-        position = 40,
+        position = 41,
         section = sectionThresholds
     )
     default int costShips() {
@@ -530,7 +598,7 @@ public interface ShortestPathConfig extends Config {
         name = "Fairy ring threshold",
         description = "How many extra tiles a fairy ring must save<br>" +
             "to be preferred over walking or other transports",
-        position = 41,
+        position = 42,
         section = sectionThresholds
     )
     default int costFairyRings() {
@@ -546,7 +614,7 @@ public interface ShortestPathConfig extends Config {
         name = "Gnome glider threshold",
         description = "How many extra tiles a gnome glider must save<br>" +
             "to be preferred over walking or other transports",
-        position = 42,
+        position = 43,
         section = sectionThresholds
     )
     default int costGnomeGliders() {
@@ -562,7 +630,7 @@ public interface ShortestPathConfig extends Config {
         name = "Hot air balloon threshold",
         description = "How many extra tiles a hot air balloon must save<br>" +
             "to be preferred over walking or other transports",
-        position = 43,
+        position = 44,
         section = sectionThresholds
     )
     default int costHotAirBalloons() {
@@ -578,7 +646,7 @@ public interface ShortestPathConfig extends Config {
         name = "Magic carpets threshold",
         description = "How many extra tiles a magic carpet must save<br>" +
             "to be preferred over walking or other transports",
-        position = 44,
+        position = 45,
         section = sectionThresholds
     )
     default int costMagicCarpets() {
@@ -594,7 +662,7 @@ public interface ShortestPathConfig extends Config {
         name = "Magic mushtrees threshold",
         description = "How many extra tiles a magic mushtree must save<br>" +
             "to be preferred over walking or other transports",
-        position = 45,
+        position = 46,
         section = sectionThresholds
     )
     default int costMagicMushtrees() {
@@ -610,7 +678,7 @@ public interface ShortestPathConfig extends Config {
         name = "Minecart threshold",
         description = "How many extra tiles a minecart must save<br>" +
             "to be preferred over walking or other transports",
-        position = 46,
+        position = 47,
         section = sectionThresholds
     )
     default int costMinecarts() {
@@ -626,7 +694,7 @@ public interface ShortestPathConfig extends Config {
         name = "Quetzal threshold",
         description = "How many extra tiles a quetzal must save<br>" +
             "to be preferred over walking or other transports",
-        position = 47,
+        position = 48,
         section = sectionThresholds
     )
     default int costQuetzals() {
@@ -642,7 +710,7 @@ public interface ShortestPathConfig extends Config {
         name = "Spirit tree threshold",
         description = "How many extra tiles a spirit tree must save<br>" +
             "to be preferred over walking or other transports",
-        position = 48,
+        position = 49,
         section = sectionThresholds
     )
     default int costSpiritTrees() {
@@ -658,7 +726,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation item (non-consumable) threshold",
         description = "How many extra tiles a non-consumable (permanent) teleportation item<br>" +
             "must save to be preferred over walking or other transports",
-        position = 49,
+        position = 50,
         section = sectionThresholds
     )
     default int costNonConsumableTeleportationItems() {
@@ -674,7 +742,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation item (consumable) threshold",
         description = "How many extra tiles a consumable (non-permanent) teleportation item<br>" +
             "must save to be preferred over walking or other transports",
-        position = 50,
+        position = 51,
         section = sectionThresholds
     )
     default int costConsumableTeleportationItems() {
@@ -690,7 +758,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation box threshold",
         description = "How many extra tiles a teleportation box must save<br>" +
             "to be preferred over walking or other transports",
-        position = 51,
+        position = 52,
         section = sectionThresholds
     )
     default int costTeleportationBoxes() {
@@ -706,7 +774,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation lever threshold",
         description = "How many extra tiles a teleportation lever must save<br>" +
             "to be preferred over walking or other transports",
-        position = 52,
+        position = 53,
         section = sectionThresholds
     )
     default int costTeleportationLevers() {
@@ -722,7 +790,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation portal threshold",
         description = "How many extra tiles a teleportation portal must save<br>" +
             "to be preferred over walking or other transports",
-        position = 53,
+        position = 54,
         section = sectionThresholds
     )
     default int costTeleportationPortals() {
@@ -738,7 +806,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation spell threshold",
         description = "How many extra tiles a teleportation spell must save<br>" +
             "to be preferred over walking or other transports",
-        position = 54,
+        position = 55,
         section = sectionThresholds
     )
     default int costTeleportationSpells() {
@@ -754,7 +822,7 @@ public interface ShortestPathConfig extends Config {
         name = "Teleportation to minigame threshold",
         description = "How many extra tiles a minigame teleport must save<br>" +
             "to be preferred over walking or other transports",
-        position = 55,
+        position = 56,
         section = sectionThresholds
     )
     default int costTeleportationMinigames() {
@@ -770,7 +838,7 @@ public interface ShortestPathConfig extends Config {
         name = "Wilderness obelisk threshold",
         description = "How many extra tiles a wilderness obelisk must save<br>" +
             "to be preferred over walking or other transports",
-        position = 56,
+        position = 57,
         section = sectionThresholds
     )
     default int costWildernessObelisks() {
@@ -786,7 +854,7 @@ public interface ShortestPathConfig extends Config {
         name = "Seasonal transport threshold",
         description = "How many extra tiles a seasonal transport must save<br>" +
             "to be preferred over walking or other transports",
-        position = 57,
+        position = 58,
         section = sectionThresholds
     )
     default int costSeasonalTransports() {
@@ -796,7 +864,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Display",
         description = "Options for displaying the path on the world map, minimap and scene tiles",
-        position = 58
+        position = 59
     )
     String sectionDisplay = "sectionDisplay";
 
@@ -804,7 +872,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawMap",
         name = "Draw path on world map",
         description = "Whether the path should be drawn on the world map",
-        position = 59,
+        position = 60,
         section = sectionDisplay
     )
     default boolean drawMap() {
@@ -815,7 +883,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawMinimap",
         name = "Draw path on minimap",
         description = "Whether the path should be drawn on the minimap",
-        position = 60,
+        position = 61,
         section = sectionDisplay
     )
     default boolean drawMinimap() {
@@ -826,7 +894,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTiles",
         name = "Draw path on tiles",
         description = "Whether the path should be drawn on the game tiles",
-        position = 61,
+        position = 62,
         section = sectionDisplay
     )
     default boolean drawTiles() {
@@ -837,7 +905,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "pathStyle",
         name = "Path style",
         description = "Whether to display the path as tiles or a segmented line",
-        position = 62,
+        position = 63,
         section = sectionDisplay
     )
     default TileStyle pathStyle() {
@@ -847,7 +915,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Colours",
         description = "Colours for the path map, minimap and scene tiles",
-        position = 63
+        position = 64
     )
     String sectionColours = "sectionColours";
 
@@ -856,7 +924,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourPath",
         name = "Path",
         description = "Colour of the path tiles on the world map, minimap and in the game scene",
-        position = 64,
+        position = 65,
         section = sectionColours
     )
     default Color colourPath() {
@@ -869,7 +937,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculating",
         description = "Colour of the path tiles while the pathfinding calculation is in progress," +
             "<br>and the colour of unused targets if there are more than a single target",
-        position = 65,
+        position = 66,
         section = sectionColours
     )
     default Color colourPathCalculating() {
@@ -881,7 +949,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 66,
+        position = 67,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -893,7 +961,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 67,
+        position = 68,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -905,7 +973,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 68,
+        position = 69,
         section = sectionColours
     )
     default Color colourText() {
@@ -915,7 +983,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigSection(
         name = "Debug Options",
         description = "Various options for debugging",
-        position = 69,
+        position = 70,
         closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
@@ -924,7 +992,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTransports",
         name = "Draw transports",
         description = "Whether transports should be drawn",
-        position = 70,
+        position = 71,
         section = sectionDebug
     )
     default boolean drawTransports() {
@@ -935,7 +1003,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawCollisionMap",
         name = "Draw collision map",
         description = "Whether the collision map should be drawn",
-        position = 71,
+        position = 72,
         section = sectionDebug
     )
     default boolean drawCollisionMap() {
@@ -946,7 +1014,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawDebugPanel",
         name = "Show debug panel",
         description = "Toggles displaying the pathfinding debug stats panel",
-        position = 72,
+        position = 73,
         section = sectionDebug
     )
     default boolean drawDebugPanel() {
@@ -957,7 +1025,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "postTransports",
         name = "Post transports",
         description = "Whether to post the transports used in the current path as a PluginMessage event",
-        position = 73,
+        position = 74,
         section = sectionDebug
     )
     default boolean postTransports() {

--- a/src/main/resources/transports/fairy_rings.tsv
+++ b/src/main/resources/transports/fairy_rings.tsv
@@ -43,7 +43,8 @@
 2740 2738 0		Configure Fairy ring 29495		Monkey Madness I		5	
 2682 3081 0		Configure Fairy ring 29495				5	
 3037 4763 0		Configure Fairy ring 29495				5	
-2027 5700 0		Configure Fairy ring 29228	85 Construction			5	
+# POH fairy ring (controlled by usePohFairyRing setting)
+2027 5700 0		Configure Fairy ring 29228				5	
 3038 5348 0		Configure Fairy ring 29495				5	
 3108 3149 0		Configure Fairy ring 29495				5	
 2658 3230 0		Configure Fairy ring 29495				5	
@@ -98,7 +99,7 @@
 	2740 2738 0			Monkey Madness I		5	C L R
 	2682 3081 0					5	C L S
 	3037 4763 0					5	D I P
-	2027 5700 0		85 Construction			5	D I Q
+	2027 5700 0					5	D I Q
 	3038 5348 0					5	D I R
 	3108 3149 0					5	D I S
 	2658 3230 0					5	D J P

--- a/src/main/resources/transports/spirit_trees.tsv
+++ b/src/main/resources/transports/spirit_trees.tsv
@@ -141,8 +141,8 @@
 1253 3748 0		Travel Spirit Tree 8355	85 Farming				4771=20;4772=20
 1252 3748 0		Travel Spirit Tree 8355	85 Farming				4771=20;4772=20
 							
-# Player-owned house							
-#		Travel Spirit Tree 29227	75 Construction;83 Farming				
+# Player-owned house (allows players who boosted to build it to use it after boost wears off)
+2007 5700 0		Travel Spirit Tree 29227					
 							
 # Poison Waste							
 2337 3110 0		Travel Spirit Tree 49595					
@@ -180,7 +180,7 @@
 	1693 3540 0		83 Farming	Tree Gnome Village	3	A: Hosidius	4771=20;4772=255
 # Farming Guild							
 	1251 3750 0		85 Farming	Tree Gnome Village	3	B: Farming Guild	4771=20;4772=255
-# Player-owned house							
-#			75 Construction;83 Farming	Tree Gnome Village	3	C: Your house	
+# Player-owned house (allows players who boosted to build it to use it after boost wears off)
+	2007 5700 0			Tree Gnome Village	3	C: Your house	
 # Poison Waste							
 	2339 3109 0			The Path of Glouphrie	3	D: Poison Waste	

--- a/src/main/resources/transports/teleportation_boxes.tsv
+++ b/src/main/resources/transports/teleportation_boxes.tsv
@@ -4,14 +4,14 @@
 1960 5750 0	3105 3251 0	Draynor Village Amulet of Glory 13523	4	Draynor Village
 1960 5750 0	3293 3163 0	Al Kharid Amulet of Glory 13523	4	Al Kharid
 1960 5750 0	2457 2850 0	Teleport Mythical cape 31986	4	Myths' Guild
-1886 5760 0	1579 3530 0	Look out Xeric's Talisman 33411	4	1. Lookout
-1886 5760 0	1752 3566 0	Glade Xeric's Talisman 33412	4	2. Glade
-1886 5760 0	1504 3815 0	Inferno Xeric's Talisman 33413	4	3. Inferno
-1886 5760 0	1644 3673 0	Heart Xeric's Talisman 33414	4	4. Heart
-1886 5760 0	1254 3560 0	Honour Xeric's Talisman 33415	4	5. Honour
-1886 5760 0	3341 3445 0	Digsite Digsite Pendant 33417	4	1. Digsite
-1886 5760 0	3763 3869 1	Fossil Island Digsite Pendant 33418	4	2. Fossil Island
-1886 5760 0	3549 10456 0	Lithkren Digsite Pendant 33419	4	3. Lithkren
+1886 5760 0	1579 3530 0	Look out Xeric's Talisman 33411	4	1: Lookout
+1886 5760 0	1752 3566 0	Glade Xeric's Talisman 33412	4	2: Glade
+1886 5760 0	1504 3815 0	Inferno Xeric's Talisman 33413	4	3: Inferno
+1886 5760 0	1644 3673 0	Heart Xeric's Talisman 33414	4	4: Heart
+1886 5760 0	1254 3560 0	Honour Xeric's Talisman 33415	4	5: Honour
+1886 5760 0	3341 3445 0	Digsite Digsite Pendant 33417	4	1: Digsite
+1886 5760 0	3763 3869 1	Fossil Island Digsite Pendant 33418	4	2: Fossil Island
+1886 5760 0	3549 10456 0	Lithkren Digsite Pendant 33419	4	3: Lithkren
 1870 5698 0	3315 3235 0	Teleport Menu Basic Jewellery Box 37492	4	1: Emir's Arena
 1870 5698 0	2440 3090 0	Teleport Menu Basic Jewellery Box 37492	4	2: Castle Wars
 1870 5698 0	3151 3635 0	Teleport Menu Basic Jewellery Box 37492	4	3: Ferox Enclave

--- a/src/main/resources/transports/teleportation_items.tsv
+++ b/src/main/resources/transports/teleportation_items.tsv
@@ -116,7 +116,7 @@
 3028 3842 0			21166=1||21169=1||21171=1||21173=1||21175=1		4	Burning amulet: Lava Maze	T	20		
 										
 # Teleport to house (tablet) - These depend on the current player's home location, determined by varbit 2187, and teleport inside or outside determined by varbit 4744										
-1923 5709 0			8013=1		4	Teleport to House tablet	T	20	4744=0	
+1923 5709 0			8013=1		4	Teleport to House	T	20	4744=0	
 # 1 - Rimmington										
 2953 3224 0			8013=1		4	Teleport to House tablet	T	20	2187=1;4744=1	
 # 2 - Taverly										

--- a/src/main/resources/transports/teleportation_spells.tsv
+++ b/src/main/resources/transports/teleportation_spells.tsv
@@ -18,25 +18,25 @@
 2965 3378 0	AIR_RUNE=3&&WATER_RUNE=1&&LAW_RUNE=1	37 Magic		4	Falador Teleport	20	4070=0	
 								
 # Teleport to House - These depend on the current player's home location  determined by varbit 2187								
-1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0	
+1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;4744=0	
 # 1 - Rimmington								
-2953 3224 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=1	
+2953 3224 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=1;4744=1	
 # 2 - Taverly								
-2893 3465 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=2	
+2893 3465 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=2;4744=1	
 # 3 - Pollnivneach								
-3340 3003 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=3	
+3340 3003 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=3;4744=1	
 # 4 - Rellekka								
-2670 3631 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=4	
+2670 3631 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=4;4744=1	
 # 5 - Brimhaven								
-2757 3178 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=5	
+2757 3178 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=5;4744=1	
 # 6 - Yanille								
-2544 3096 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=6	
+2544 3096 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=6;4744=1	
 # 7 - Prifddinas								
-3239 6076 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=7	
+3239 6076 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=7;4744=1	
 # 8 - Hosidius								
-1743 3517 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=8	
+1743 3517 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=8;4744=1	
 # 9 - Aldarin								
-1422 2963 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=9	
+1422 2963 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=9;4744=1	
 								
 # Camelot Teleport								
 2757 3478 0	AIR_RUNE=5&&LAW_RUNE=1	45 Magic		4	Camelot Teleport	20	4070=0	

--- a/src/main/resources/transports/wilderness_obelisks.tsv
+++ b/src/main/resources/transports/wilderness_obelisks.tsv
@@ -60,7 +60,7 @@
 3308 3916 0		Activate Obelisk 14831					
 3308 3917 0		Activate Obelisk 14831					
 # Player Owned House							
-#		Activate Obelisk 31554	80 Construction			3	
+1888 5717 0		Activate Obelisk 31554	80 Construction			3	
 # Level 13 Wilderness - South-east of Ferox Enclave							
 	3156 3620 0					3	1: Level 13 Wilderness
 							

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import shortestpath.ItemVariations;
+import shortestpath.JewelleryBoxTier;
 import shortestpath.ShortestPathConfig;
 import shortestpath.ShortestPathPlugin;
 import shortestpath.TeleportationItem;
@@ -214,7 +215,9 @@ public class PathfinderTest {
 
     @Test
     public void testTeleportationBoxes() {
-        when(config.useTeleportationBoxes()).thenReturn(true);
+        when(config.usePoh()).thenReturn(true);
+        when(config.pohJewelleryBoxTier()).thenReturn(JewelleryBoxTier.ORNATE);
+        when(config.usePohMountedItems()).thenReturn(true);
         testTransportLength(2, TransportType.TELEPORTATION_BOX);
     }
 
@@ -291,6 +294,8 @@ public class PathfinderTest {
     @Test
     public void testWildernessObelisks() {
         when(config.useWildernessObelisks()).thenReturn(true);
+        when(config.usePoh()).thenReturn(true);
+        when(config.usePohObelisk()).thenReturn(true);
         testTransportLength(2, TransportType.WILDERNESS_OBELISK);
     }
 
@@ -487,6 +492,7 @@ public class PathfinderTest {
         when(client.getClientThread()).thenReturn(Thread.currentThread());
         when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(skillLevel);
         when(config.useTeleportationItems()).thenReturn(useTeleportationItems);
+        when(config.usePoh()).thenReturn(false); // Default POH to disabled
         doReturn(true).when(pathfinderConfig).varbitChecks(any(Transport.class));
         doReturn(true).when(pathfinderConfig).varPlayerChecks(any(Transport.class));
         doReturn(questState).when(pathfinderConfig).getQuestState(any(Quest.class));


### PR DESCRIPTION
Previously, POH teleport instructions lacked detail about which mounted item 
or portal to use once inside the house, making it unclear how to follow the path.

This change adds full specificity to POH teleport displays:
- Shows the exact POH item: 'Xeric's Talisman', 'Digsite Pendant', 'Nexus', etc.
- Shows the destination: 'Xeric's Talisman: Lookout', 'Nexus: Varrock'
- Includes hotkey numbers for mounted items: '1. Lookout', '2. Glade', '3. Inferno'
- Added missing Digsite Pendant destinations to teleportation_boxes.tsv

Now when the pathfinder routes through POH, players can see exactly which 
teleport item to use and which option to select, eliminating confusion.

Example displays:
- 'Teleport to House (Exit: Xeric's Talisman: 1. Lookout)'
- 'Teleport to House (Exit: Nexus: Catherby)'
- 'Teleport to House (Exit: Fairy Ring C J R)'