### PR TITLE
Enhance transport rendering: differentiate available and unavailable transports on the map

### DIFF
--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -35,6 +35,9 @@ public class PathMapOverlay extends Overlay {
         drawAfterLayer(ComponentID.WORLD_MAP_MAPVIEW);
     }
 
+    private static final Color COLOR_AVAILABLE = Color.WHITE;
+    private static final Color COLOR_UNAVAILABLE = Color.ORANGE;
+
     @Override
     public Dimension render(Graphics2D graphics) {
         if (!plugin.drawMap) {
@@ -96,7 +99,7 @@ public class PathMapOverlay extends Overlay {
                     }
 
                     boolean isAvailable = availableAtOrigin.contains(b);
-                    graphics.setColor(isAvailable ? Color.WHITE : Color.ORANGE);
+                    graphics.setColor(isAvailable ? COLOR_AVAILABLE : COLOR_UNAVAILABLE);
                     graphics.drawLine(mapAX, mapAY, mapBX, mapBY);
                 }
             }

--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -8,6 +8,8 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.widgets.ComponentID;
@@ -66,8 +68,10 @@ public class PathMapOverlay extends Overlay {
         }
 
         if (plugin.drawTransports) {
-            graphics.setColor(Color.WHITE);
-            for (int a : plugin.getTransports().keySet()) {
+            Map<Integer, Set<Transport>> allTransports = plugin.getAllTransports();
+            Map<Integer, Set<Transport>> availableTransports = plugin.getTransports();
+
+            for (int a : allTransports.keySet()) {
                 if (a == Transport.UNDEFINED_ORIGIN) {
                     continue; // skip teleports
                 }
@@ -78,7 +82,9 @@ public class PathMapOverlay extends Overlay {
                     continue;
                 }
 
-                for (Transport b : plugin.getTransports().getOrDefault(a, new HashSet<>())) {
+                Set<Transport> availableAtOrigin = availableTransports.getOrDefault(a, new HashSet<>());
+
+                for (Transport b : allTransports.getOrDefault(a, new HashSet<>())) {
                     if (b == null || TransportType.isTeleport(b.getType())) {
                         continue; // skip teleports
                     }
@@ -89,6 +95,8 @@ public class PathMapOverlay extends Overlay {
                         continue;
                     }
 
+                    boolean isAvailable = availableAtOrigin.contains(b);
+                    graphics.setColor(isAvailable ? Color.WHITE : Color.ORANGE);
                     graphics.drawLine(mapAX, mapAY, mapBX, mapBY);
                 }
             }

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -9,6 +9,8 @@ import java.awt.Polygon;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
@@ -35,25 +37,35 @@ public class PathTileOverlay extends Overlay {
         setLayer(OverlayLayer.ABOVE_SCENE);
     }
 
+    private static final Color COLOR_AVAILABLE = Color.WHITE;
+    private static final Color COLOR_UNAVAILABLE = Color.ORANGE;
+
     private void renderTransports(Graphics2D graphics) {
-        for (int a : plugin.getTransports().keySet()) {
+        Map<Integer, Set<Transport>> allTransports = plugin.getAllTransports();
+        Map<Integer, Set<Transport>> availableTransports = plugin.getTransports();
+
+        for (int a : allTransports.keySet()) {
             if (a == Transport.UNDEFINED_ORIGIN) {
                 continue; // skip teleports
             }
 
-            boolean drawStart = false;
-
             Point ca = tileCenter(a);
-
             if (ca == null) {
                 continue;
             }
 
+            boolean drawStart = false;
             StringBuilder s = new StringBuilder();
-            for (Transport b : plugin.getTransports().getOrDefault(a, new HashSet<>())) {
+            Set<Transport> availableAtOrigin = availableTransports.getOrDefault(a, new HashSet<>());
+
+            for (Transport b : allTransports.getOrDefault(a, new HashSet<>())) {
                 if (b == null || TransportType.isTeleport(b.getType())) {
                     continue; // skip teleports
                 }
+
+                boolean isAvailable = availableAtOrigin.contains(b);
+                graphics.setColor(isAvailable ? COLOR_AVAILABLE : COLOR_UNAVAILABLE);
+
                 PrimitiveIntList destinations = WorldPointUtil.toLocalInstance(client, b.getDestination());
                 for (int i = 0; i < destinations.size(); i++) {
                     int destination = destinations.get(i);

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -991,7 +991,7 @@ public interface ShortestPathConfig extends Config {
     @ConfigItem(
         keyName = "drawTransports",
         name = "Draw transports",
-        description = "Whether transports should be drawn",
+        description = "Draw all transports on the map and game view.<br>White = available, Orange = unavailable (missing requirements)",
         position = 76,
         section = sectionDebug
     )

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -602,6 +602,10 @@ public class ShortestPathPlugin extends Plugin {
         return pathfinderConfig.getTransports();
     }
 
+    public Map<Integer, Set<Transport>> getAllTransports() {
+        return pathfinderConfig.getAllTransports();
+    }
+
     public CollisionMap getMap() {
         return pathfinderConfig.getMap();
     }

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -87,6 +87,7 @@ public class PathfinderConfig {
     private final SplitFlagMap mapData;
     private final ThreadLocal<CollisionMap> map;
     /** All transports by origin. The WorldPointUtil.UNDEFINED key is used for transports centered on the player. */
+    @Getter
     private final Map<Integer, Set<Transport>> allTransports;
     private final Set<Transport> usableTeleports;
     private final Map<String, Set<Integer>> allDestinations;


### PR DESCRIPTION
I was always adding transports that were already there, but just not shown because of my level.

So now it renders all unavailable transports in orange.

<img width="2219" height="1351" alt="image" src="https://github.com/user-attachments/assets/1b28348a-0208-4c1a-a7bc-dd5d27220057" />
