### PR TITLE
Fix parsing of house portal teleports

### DIFF
--- a/src/main/resources/transports/teleportation_items.tsv
+++ b/src/main/resources/transports/teleportation_items.tsv
@@ -120,21 +120,21 @@
 # 1 - Rimmington										
 2953 3224 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=1;4744=1	
 # 2 - Taverly										
-2893 3465 0		10 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=2;4744=1	
+2893 3465 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=2;4744=1	
 # 3 - Pollnivneach										
-3340 3003 0		20 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=3;4744=1	
+3340 3003 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=3;4744=1	
 # 4 - Rellekka										
-2670 3631 0		30 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=4;4744=1	
+2670 3631 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=4;4744=1	
 # 5 - Brimhaven										
-2757 3178 0		40 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=5;4744=1	
+2757 3178 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=5;4744=1	
 # 6 - Yanille										
-2544 3096 0		50 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=6;4744=1	
+2544 3096 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=6;4744=1	
 # 7 - Prifddinas										
-3239 6076 0		70 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=7;4744=1	
+3239 6076 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=7;4744=1	
 # 8 - Hosidius										
-1743 3517 0		25 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=8;4744=1	
+1743 3517 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=8;4744=1	
 # 9 - Aldarin										
-1422 2963 0		35 Construction	8013=1		4	Teleport to House tablet (Outside)	T	20	2187=9;4744=1	
+1422 2963 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=9;4744=1	
 										
 #  Teleport tablets										
 3213 3424 0			8007=1		4	Varrock tablet	T	20		
@@ -221,25 +221,25 @@
 # Capes										
 2931 3286 0		99 Crafting	9780=1||9781=1		4	Crafting cape: Teleport	F	20		
 # The Construction cape's home teleports, determined by varbit 2187, and teleport inside or outside determined by varbit 4744										
-1923 5709 0		99 Construction	9789=1||9790=1		4	Construction cape: Tele to POH	F	20	4744=0	
+1923 5709 0			9789=1||9790=1		4	Construction cape: Tele to POH	F	20	4744=0	
 # 1 - Rimmington										
-2952 3224 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=1;4744=1	
+2952 3224 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=1;4744=1	
 # 2 - Taverly										
-2892 3465 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=2;4744=1	
+2892 3465 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=2;4744=1	
 # 3 - Pollnivneach										
-3339 3001 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=3;4744=1	
+3339 3001 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=3;4744=1	
 # 4 - Rellekka										
-2669 3629 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=4;4744=1	
+2669 3629 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=4;4744=1	
 # 5 - Brimhaven										
-2756 3176 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=5;4744=1	
+2756 3176 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=5;4744=1	
 # 6 - Yanille										
-2545 3097 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=6;4744=1	
+2545 3097 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=6;4744=1	
 # 7 - Prifddinas										
-3239 6077 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=7;4744=1	
+3239 6077 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=7;4744=1	
 # 8 - Hosidius										
-1740 3517 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=8;4744=1	
+1740 3517 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=8;4744=1	
 # 9 - Aldarin										
-1422 2963 0		99 Construction	9789=1||9790=1		4	Construction cape: Home	F	20	2187=9;4744=1	
+1422 2963 0			9789=1||9790=1		4	Construction cape: Home	F	20	2187=9;4744=1	
 2952 3224 0		99 Construction	9789=1||9790=1		4	Construction cape: Rimmington	F	20		
 2892 3465 0		99 Construction	9789=1||9790=1		4	Construction cape: Taverley	F	20		
 3339 3001 0		99 Construction	9789=1||9790=1		4	Construction cape: Pollnivneach	F	20		

--- a/src/main/resources/transports/teleportation_portals.tsv
+++ b/src/main/resources/transports/teleportation_portals.tsv
@@ -127,21 +127,21 @@
 # Rimmington								
 2953 3224 0	1923 5709 0	Home Portal 15478			2187=1		4	Home Portal
 # Taverly								
-2893 3465 0	1923 5709 0	Home Portal 15477	10 Construction		2187=2		4	Home Portal
+2893 3465 0	1923 5709 0	Home Portal 15477			2187=2		4	Home Portal
 # Pollnivneach								
-3340 3003 0	1923 5709 0	Home Portal 15479	20 Construction		2187=3		4	Home Portal
+3340 3003 0	1923 5709 0	Home Portal 15479			2187=3		4	Home Portal
 # Rellekka								
-2670 3631 0	1923 5709 0	Home Portal 15480	30 Construction		2187=4		4	Home Portal
+2670 3631 0	1923 5709 0	Home Portal 15480			2187=4		4	Home Portal
 # Brimhaven								
-2757 3178 0	1923 5709 0	Home Portal 15481	40 Construction		2187=5		4	Home Portal
+2757 3178 0	1923 5709 0	Home Portal 15481			2187=5		4	Home Portal
 # Yanille								
-2544 3096 0	1923 5709 0	Home Portal 15482	50 Construction		2187=6		4	Home Portal
+2544 3096 0	1923 5709 0	Home Portal 15482			2187=6		4	Home Portal
 # Prifddinas								
-3239 6076 0	1923 5709 0	Home Portal 34947	70 Construction		2187=7		4	Home Portal
+3239 6076 0	1923 5709 0	Home Portal 34947			2187=7		4	Home Portal
 # Hosidius								
-1743 3517 0	1923 5709 0	Home Portal 28822	25 Construction		2187=8		4	Home Portal
+1743 3517 0	1923 5709 0	Home Portal 28822			2187=8		4	Home Portal
 # Aldarin								
-1422 2963 0	1923 5709 0	Home Portal 55353	35 Construction		2187=9		4	Home Portal
+1422 2963 0	1923 5709 0	Home Portal 55353			2187=9		4	Home Portal
 								
 # Myths' Guild Portals								
 2456 2855 2	2904 3512 0	Enter Portal of Heroes 31621		Dragon Slayer II			1	Heroes' Guild


### PR DESCRIPTION
This fix removes the level requirements from teleports which are already guarded by using the correct varbits for house location.

Fixes #387 