### PR TITLE
Workaround: Move POH Spirit Tree and Fairy Ring to starting tile

### DIFF
--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -119,6 +119,7 @@ public class PathfinderConfig {
         this.mapData = SplitFlagMap.fromResources();
         this.map = ThreadLocal.withInitial(() -> new CollisionMap(mapData));
         this.allTransports = TransportLoader.loadAllFromResources();
+        remapPohDestinations();
         this.usableTeleports = new HashSet<>(allTransports.size() / 20);
         this.transports = new HashMap<>(allTransports.size() / 2);
         this.transportsPacked = new PrimitiveIntHashMap<>(allTransports.size() / 2);
@@ -340,6 +341,26 @@ public class PathfinderConfig {
         if (bankVisited) {
             refreshUsableTeleports();
             refreshTeleports(packedLocation, wildernessLevel);
+        }
+    }
+
+    /**
+     * Remaps POH transport destinations to the house landing tile.
+     * Transports that arrive inside the POH (e.g., fairy ring DIQ, spirit tree "Your house")
+     * are remapped so chaining with other POH transports is possible.
+     * Called once at load time since Transport objects in allTransports are shared references.
+     */
+    private void remapPohDestinations() {
+        int pohLanding = WorldPointUtil.packWorldPoint(1923, 5709, 0);
+        for (Set<Transport> transports : allTransports.values()) {
+            for (Transport transport : transports) {
+                int destination = transport.getDestination();
+                int destX = WorldPointUtil.unpackWorldX(destination);
+                int destY = WorldPointUtil.unpackWorldY(destination);
+                if (destination != pohLanding && ShortestPathPlugin.isInsidePoh(destX, destY)) {
+                    transport.setDestination(pohLanding);
+                }
+            }
         }
     }
 

--- a/src/main/java/shortestpath/transport/Transport.java
+++ b/src/main/java/shortestpath/transport/Transport.java
@@ -48,6 +48,11 @@ public class Transport {
      */
     @Getter
     private int destination = UNDEFINED_DESTINATION;
+
+    public void setDestination(int packedDestination) {
+        this.destination = packedDestination;
+    }
+
     /**
      * The quests required to use this transport
      */

--- a/src/main/resources/transports/fairy_rings.tsv
+++ b/src/main/resources/transports/fairy_rings.tsv
@@ -101,8 +101,8 @@
 	2740 2738 0			Monkey Madness I		5	C L R
 	2682 3081 0					5	C L S
 	3037 4763 0					5	D I P
-# Player-owned house (arrives at POH landing tile to enable chaining with other POH transports - normally 2027 5700)							
-	1923 5709 0					5	D I Q
+# Player-owned house							
+	2027 5700 0					5	D I Q
 	3038 5348 0					5	D I R
 	3108 3149 0					5	D I S
 	2658 3230 0					5	D J P

--- a/src/main/resources/transports/fairy_rings.tsv
+++ b/src/main/resources/transports/fairy_rings.tsv
@@ -101,7 +101,7 @@
 	2740 2738 0			Monkey Madness I		5	C L R
 	2682 3081 0					5	C L S
 	3037 4763 0					5	D I P
-# Player-owned house (arrives at POH landing tile to enable chaining with other POH transports - normally 2027 5700)									
+# Player-owned house (arrives at POH landing tile to enable chaining with other POH transports - normally 2027 5700)							
 	1923 5709 0					5	D I Q
 	3038 5348 0					5	D I R
 	3108 3149 0					5	D I S

--- a/src/main/resources/transports/fairy_rings.tsv
+++ b/src/main/resources/transports/fairy_rings.tsv
@@ -101,7 +101,7 @@
 	2740 2738 0			Monkey Madness I		5	C L R
 	2682 3081 0					5	C L S
 	3037 4763 0					5	D I P
-# Player-owned house (arrives at POH landing tile to enable chaining with other POH transports - normally 2027 5700)
+# Player-owned house (arrives at POH landing tile to enable chaining with other POH transports - normally 2027 5700)									
 	1923 5709 0					5	D I Q
 	3038 5348 0					5	D I R
 	3108 3149 0					5	D I S

--- a/src/main/resources/transports/fairy_rings.tsv
+++ b/src/main/resources/transports/fairy_rings.tsv
@@ -101,7 +101,8 @@
 	2740 2738 0			Monkey Madness I		5	C L R
 	2682 3081 0					5	C L S
 	3037 4763 0					5	D I P
-	2027 5700 0					5	D I Q
+# Player-owned house (arrives at POH landing tile to enable chaining with other POH transports - normally 2027 5700)
+	1923 5709 0					5	D I Q
 	3038 5348 0					5	D I R
 	3108 3149 0					5	D I S
 	2658 3230 0					5	D J P

--- a/src/main/resources/transports/spirit_trees.tsv
+++ b/src/main/resources/transports/spirit_trees.tsv
@@ -191,7 +191,7 @@
 	1693 3540 0			Tree Gnome Village	3	A: Hosidius	
 # Farming Guild							
 	1251 3750 0		85 Farming	Tree Gnome Village	3	B: Farming Guild	4771=20;4772=255
-# Player-owned house (allows players who boosted to build it to use it after boost wears off; arrives at POH landing tile to enable chaining with other POH transports, normally 2007 5700)
+# Player-owned house (allows players who boosted to build it to use it after boost wears off; arrives at POH landing tile to enable chaining with other POH transports, normally 2007 5700)							
 	1923 5709 0			Tree Gnome Village	3	C: Your house	
 # Poison Waste							
 	2339 3109 0			The Path of Glouphrie	3	D: Poison Waste	

--- a/src/main/resources/transports/spirit_trees.tsv
+++ b/src/main/resources/transports/spirit_trees.tsv
@@ -190,9 +190,9 @@
 # Hosidius							
 	1693 3540 0			Tree Gnome Village	3	A: Hosidius	
 # Farming Guild							
-	1251 3750 0			Tree Gnome Village	3	B: Farming Guild	
-# Player-owned house (allows players who boosted to build it to use it after boost wears off)							
-	2007 5700 0			Tree Gnome Village	3	C: Your house	
+	1251 3750 0		85 Farming	Tree Gnome Village	3	B: Farming Guild	4771=20;4772=255
+# Player-owned house (allows players who boosted to build it to use it after boost wears off; arrives at POH landing tile to enable chaining with other POH transports, normally 2007 5700)
+	1923 5709 0			Tree Gnome Village	3	C: Your house
 # Poison Waste							
 	2339 3109 0			The Path of Glouphrie	3	D: Poison Waste	
 # Laguna Aurorae							

--- a/src/main/resources/transports/spirit_trees.tsv
+++ b/src/main/resources/transports/spirit_trees.tsv
@@ -190,10 +190,10 @@
 # Hosidius							
 	1693 3540 0			Tree Gnome Village	3	A: Hosidius	
 # Farming Guild							
-	1251 3750 0		85 Farming	Tree Gnome Village	3	B: Farming Guild	4771=20;4772=255
+	1251 3750 0			Tree Gnome Village	3	B: Farming Guild	
 # Player-owned house (allows players who boosted to build it to use it after boost wears off; arrives at POH landing tile to enable chaining with other POH transports, normally 2007 5700)							
 	1923 5709 0			Tree Gnome Village	3	C: Your house	
 # Poison Waste							
 	2339 3109 0			The Path of Glouphrie	3	D: Poison Waste	
 # Laguna Aurorae							
-	1202 2785 0		58 Sailing	Pandemonium	3	E: Laguna Aurorae	
+	1202 2785 0			Pandemonium	3	E: Laguna Aurorae	

--- a/src/main/resources/transports/spirit_trees.tsv
+++ b/src/main/resources/transports/spirit_trees.tsv
@@ -192,7 +192,7 @@
 # Farming Guild							
 	1251 3750 0		85 Farming	Tree Gnome Village	3	B: Farming Guild	4771=20;4772=255
 # Player-owned house (allows players who boosted to build it to use it after boost wears off; arrives at POH landing tile to enable chaining with other POH transports, normally 2007 5700)
-	1923 5709 0			Tree Gnome Village	3	C: Your house
+	1923 5709 0			Tree Gnome Village	3	C: Your house	
 # Poison Waste							
 	2339 3109 0			The Path of Glouphrie	3	D: Poison Waste	
 # Laguna Aurorae							

--- a/src/main/resources/transports/spirit_trees.tsv
+++ b/src/main/resources/transports/spirit_trees.tsv
@@ -191,8 +191,8 @@
 	1693 3540 0			Tree Gnome Village	3	A: Hosidius	
 # Farming Guild							
 	1251 3750 0			Tree Gnome Village	3	B: Farming Guild	
-# Player-owned house (allows players who boosted to build it to use it after boost wears off; arrives at POH landing tile to enable chaining with other POH transports, normally 2007 5700)							
-	1923 5709 0			Tree Gnome Village	3	C: Your house	
+# Player-owned house (allows players who boosted to build it to use it after boost wears off)							
+	2007 5700 0			Tree Gnome Village	3	C: Your house	
 # Poison Waste							
 	2339 3109 0			The Path of Glouphrie	3	D: Poison Waste	
 # Laguna Aurorae							


### PR DESCRIPTION
With shortest clue plugin I have an annoyance, that the plugin cannot chain Fairy Ring or Spirit Tree into POH Facilities (such as nexus).

Consider following scenario: 
Spellbook is on Ancients, and you need to get to Catherby. You have a quest cape in your inventory. A reasonable path would be QP TP -> Ring DIQ -> Nexus to Catherby. Because of how POH works, the plugin does not see this path and tells me to go charter instead.

This is not an ideal fix, but perfectly servicable, until a proper POH pathing fix comes.