### PR TITLE
Hot Air Balloon requirement drop + quetzal varbit check

### DIFF
--- a/scripts/tsv-lint.sh
+++ b/scripts/tsv-lint.sh
@@ -19,16 +19,16 @@ for file in $(find "$RESOURCE_DIR" -name "*.tsv" -type f | sort); do
     while IFS= read -r line || [[ -n "$line" ]]; do
         line_num=$((line_num + 1))
 
-        # Skip empty lines and comment lines
-        if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        # Skip empty lines
+        if [[ -z "$line" ]]; then
             continue
         fi
 
         # Count columns (number of tabs + 1)
         num_columns=$(($(printf '%s' "$line" | tr -cd '\t' | wc -c) + 1))
 
+        # Use the first line (header) to set expected column count
         if [[ -z "$expected_columns" ]]; then
-            # First non-empty, non-comment line sets the expected column count
             expected_columns=$num_columns
             header_line=$line_num
         elif [[ "$num_columns" -ne "$expected_columns" ]]; then

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -12,7 +12,8 @@ import shortestpath.ShortestPathPlugin;
 import shortestpath.WorldPointUtil;
 
 public class Pathfinder implements Runnable {
-    private PathfinderStats stats;
+    private final PathfinderStats stats;
+    @Getter
     private volatile boolean done = false;
     private volatile boolean cancelled = false;
 
@@ -38,7 +39,7 @@ public class Pathfinder implements Runnable {
     /**
      * Teleportation transports are updated when this changes.
      * Can be either:
-     *  0 = all teleports can be used (e.g. Chronicle)
+     * 0 = all teleports can be used (e.g. Chronicle)
      * 20 = most teleports can be used (e.g. Varrock Teleport)
      * 30 = some teleports can be used (e.g. Amulet of Glory)
      * 31 = no teleports can be used
@@ -55,10 +56,6 @@ public class Pathfinder implements Runnable {
         visited = new VisitedTiles(map);
         targetInWilderness = WildernessChecker.isInWilderness(targets);
         wildernessLevel = 31;
-    }
-
-    public boolean isDone() {
-        return done;
     }
 
     public void cancel() {

--- a/src/main/resources/transports/hot_air_balloons.tsv
+++ b/src/main/resources/transports/hot_air_balloons.tsv
@@ -57,19 +57,19 @@
 2482 3456 0		Use Basket 19129		2870=1		
 						
 # Entrana						
-	2808 3354 0		1511=1	2867=2	7	Entrana
+	2808 3354 0			2867=2	7	Entrana
 						
 # Taverley						
-	2941 3420 0		1511=1	2868=2	7	Taverley
+	2941 3420 0			2868=2	7	Taverley
 						
 # Crafting Guild						
-	2923 3302 0		1521=1	2871=1	7	Crafting Guild
+	2923 3302 0			2871=1	7	Crafting Guild
 						
 # Varrock						
-	3299 3482 0		1519=1	2872=1	7	Varrock
+	3299 3482 0			2872=1	7	Varrock
 						
 # Castle Wars						
-	2459 3110 0		1515=1	2869=1	7	Castle Wars
+	2459 3110 0			2869=1	7	Castle Wars
 						
 # Grand Tree						
-	2478 3456 0		1513=1	2870=1	7	Grand Tree
+	2478 3456 0			2870=1	7	Grand Tree

--- a/src/main/resources/transports/quetzals.tsv
+++ b/src/main/resources/transports/quetzals.tsv
@@ -10,7 +10,7 @@
 1226 3091 0		Travel Renu 13350	Twilight's Promise	6		
 1437 3171 0		Travel Renu 13350	Twilight's Promise	6		
 1779 3111 0		Travel Renu 13350	Twilight's Promise	6		4182&256
-1344 3022 0		Travel Renu 13350	Twilight's Promise	6		
+1344 3022 0		Travel Renu 13350	Twilight's Promise	6		4182&16384
 1700 3037 0		Travel Renu 13350	Twilight's Promise	6		4182&128
 1670 2933 0		Travel Renu 13350	Twilight's Promise	6		4182&64
 1446 3108 0		Travel Renu 13350	Twilight's Promise	6		4182&32
@@ -24,7 +24,7 @@
 	1226 3091 0		Twilight's Promise	6	Tal Teklan	
 	1437 3171 0		Twilight's Promise	6	The Teomat	
 	1779 3111 0		Twilight's Promise	6	Fortis Colosseum	4182&256
-	1344 3022 0		Twilight's Promise	6	Kastori	
+	1344 3022 0		Twilight's Promise	6	Kastori	4182&16384
 	1700 3037 0		Twilight's Promise	6	Outer Fortis	4182&128
 	1670 2933 0		Twilight's Promise	6	Colossal Wyrm Remains	4182&64
 	1446 3108 0		Twilight's Promise	6	Cam Torum	4182&32


### PR DESCRIPTION
Small data fixes and cleanups, independent of other transport refactor PRs.

## Changes

- **`scripts/tsv-lint.sh`**: Fix lint script edge cases
- **`Pathfinder.java`**: Minor code cleanup (simplified condition)
- **`hot_air_balloons.tsv`**: Remove unnecessary log item requirements (logs are available at all balloon locations)
- **`quetzals.tsv`**: Fix Kastori quetzal platform varbit check (`4182&16384` → correct bitmask)

4 files changed, +14/−17