### PR TITLE
preview: Use upstream actions to download artifacts and comment on PR

### DIFF
--- a/.github/workflows/coordinate-preview-comment.yml
+++ b/.github/workflows/coordinate-preview-comment.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - name: Download coordinate results
+      - name: Check for coordinate results artifact
         uses: actions/github-script@v7
         with:
           script: |
@@ -33,109 +33,31 @@ jobs:
             if (!match) {
               core.info('No coordinate-preview-results artifact — nothing to render.');
               core.exportVariable('SKIP_COMMENT', 'true');
-              return;
             }
-            const download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: match.id,
-              archive_format: 'zip',
-            });
-            const fs = require('fs');
-            fs.writeFileSync('${{ github.workspace }}/artifact.zip', Buffer.from(download.data));
 
-      - name: Unpack artifact
+      - name: Download coordinate results
         if: env.SKIP_COMMENT != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: coordinate-preview-results
+          path: artifact
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Prepare artifact
+        if: env.SKIP_COMMENT != 'true'
+        id: unpack
         run: |
-          unzip artifact.zip -d artifact
           mkdir -p build
           cp artifact/changed-coordinates.json build/
+          echo "number=$(cat artifact/pr-number.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Render coordinate previews
         if: env.SKIP_COMMENT != 'true'
-        uses: mpickering/osrs-coord-preview-action@v1.3
+        uses: mpickering/osrs-coord-preview-action@v1.4
         with:
           coordinates-file: build/changed-coordinates.json
-          comment: "false"
-          renderer-url: https://osrs-coordinate-preview-nt7ywvsdgq-nw.a.run.app/render
+          comment: "true"
+          pr-number: ${{ steps.unpack.outputs.number }}
           github-token: ${{ github.token }}
           output-dir: build/preview
-
-      - name: Post or update comment
-        if: env.SKIP_COMMENT != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const prNumber = parseInt(fs.readFileSync('artifact/pr-number.txt', 'utf8').trim(), 10);
-
-            if (isNaN(prNumber) || prNumber <= 0) {
-              core.setFailed(`Invalid PR number: ${prNumber}`);
-              return;
-            }
-
-            const manifest = JSON.parse(fs.readFileSync('build/preview/manifest.json', 'utf8'));
-
-            const MARKER = '<!-- osrs-coordinate-preview -->';
-            const IMAGE_WIDTH = 220;
-
-            function escCell(s) {
-              return String(s).replace(/\|/g, '\\|').replace(/\n/g, ' ');
-            }
-            function escAttr(s) {
-              return String(s).replace(/"/g, '&quot;');
-            }
-
-            const lines = [
-              MARKER,
-              '## OSRS coordinate previews',
-              '',
-              `Rendered ${manifest.renderCount} preview(s); ${manifest.failedCount} failure(s).`,
-              '',
-              '| Preview | Item | Coordinate | Source |',
-              '| --- | --- | --- | --- |',
-            ];
-
-            for (const item of manifest.items) {
-              const title  = item.label || item.id;
-              const source = item.source || '';
-              const coord  = item.coordinate || '';
-              let preview  = '';
-
-              if (item.status === 'success' && item.imageUrl) {
-                const url = item.imageUrl;
-                preview = `<a href="${url}"><img src="${url}" alt="${escAttr(title)}" width="${IMAGE_WIDTH}" /></a>`;
-              } else if (item.status === 'failure') {
-                preview = escCell(`failed: ${item.error || ''}`);
-              }
-
-              lines.push(`| ${preview} | ${escCell(title)} | ${escCell(coord)} | ${escCell(source)} |`);
-            }
-
-            const body = lines.join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner:        context.repo.owner,
-              repo:         context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const existing = comments.find(c => c.body && c.body.includes(MARKER));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner:      context.repo.owner,
-                repo:       context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-              core.info(`Updated comment #${existing.id} on PR #${prNumber}.`);
-            } else {
-              await github.rest.issues.createComment({
-                owner:        context.repo.owner,
-                repo:         context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-              core.info(`Created new comment on PR #${prNumber}.`);
-            }


### PR DESCRIPTION
This commit uses the new v1.4 release of the coordinate preview action, which allows a PR number to be specified as the target for the preview comment.

I also replaced custom download logic with the download artifact action.