### PR TITLE
preview: Show modified locations (as well as completely new ones)

### DIFF
--- a/scripts/diff_coordinate_json.py
+++ b/scripts/diff_coordinate_json.py
@@ -1,21 +1,101 @@
 #!/usr/bin/env python3
-"""Filter the head coordinate dump down to coordinates not present in the base dump.
+"""Filter the head coordinate dump down to semantically changed preview tiles.
 
 This exists for the GitHub coordinate preview workflow, which computes dumps for the
-merge-base commit and the PR head, then renders only newly introduced coordinates.
+merge-base commit and the PR head, then renders only newly introduced or
+semantically changed coordinates.
 
-The comparison intentionally keys only on the packed coordinate string. For the
-preview use-case we only care whether a tile is newly introduced to the rendered
-set, not whether the label or source metadata for an existing tile changed.
+The comparison keys on the rendered preview identity for a tile. New coordinates
+are always included. For existing coordinates, pure label removals are ignored,
+while label additions or mixed replacements are included. Source metadata is
+intentionally excluded so line-number churn does not trigger preview noise.
 """
 
 import json
 import sys
 from pathlib import Path
 
+MERGED_VALUE_SEPARATOR = "; "
+BOLD_MARKER = "**"
+
 
 def read_json(path_str: str):
     return json.loads(Path(path_str).read_text(encoding="utf-8"))
+
+
+def label_parts(item: dict) -> set[str]:
+    return {
+        entry["label"].strip()
+        for entry in item["entries"]
+    }
+
+
+def is_changed(base_item: dict | None, head_item: dict) -> bool:
+    if base_item is None:
+        return True
+
+    base_labels = label_parts(base_item)
+    head_labels = label_parts(head_item)
+
+    # Previews are asymmetric: we want to surface newly added meaning at a tile,
+    # but avoid re-rendering old coordinates when a PR only removes one of the
+    # existing labels. Mixed edits (some labels removed, others added) are still
+    # shown because the tile's visible meaning changed in a non-removal-only way.
+    if head_labels == base_labels:
+        return False
+
+    if head_labels < base_labels:
+        return False
+
+    return True
+
+
+# Classify each unique head-side label once so both renderers can consume a
+# single ordered list with explicit new/old metadata. New labels are moved
+# to the front to make the reason this coordinate rendered obvious.
+def order_preview_entries(base_item: dict | None, head_item: dict) -> list[dict]:
+    base_labels = label_parts(base_item) if base_item is not None else set()
+    new_entries = []
+    existing_entries = []
+    seen_labels = set()
+
+    for entry in head_item["entries"]:
+        label = entry["label"]
+        if label in seen_labels:
+            continue
+        seen_labels.add(label)
+        annotated_entry = {
+            "label": entry["label"],
+            "source": entry["source"],
+            "is_new": label not in base_labels,
+        }
+        if label in base_labels:
+            existing_entries.append(annotated_entry)
+        else:
+            new_entries.append(annotated_entry)
+
+    return new_entries + existing_entries
+
+### Render a field with new items bolded, separated by ";".
+def render_preview_field(ordered_entries: list[dict], field: str) -> str:
+    rendered_values = []
+    for entry in ordered_entries:
+        value = entry[field]
+        if entry["is_new"]:
+            rendered_values.append(f"{BOLD_MARKER}{value}{BOLD_MARKER}")
+        else:
+            rendered_values.append(value)
+    return MERGED_VALUE_SEPARATOR.join(rendered_values)
+
+
+def to_preview_item(base_item: dict | None, item: dict) -> dict:
+    ordered_entries = order_preview_entries(base_item, item)
+    return {
+        "id": item["id"],
+        "label": render_preview_field(ordered_entries, "label"),
+        "coordinate": item["coordinate"],
+        "source": render_preview_field(ordered_entries, "source"),
+    }
 
 
 def main() -> int:
@@ -29,8 +109,12 @@ def main() -> int:
     base_path, head_path, output_path = sys.argv[1:]
     base_items = read_json(base_path)
     head_items = read_json(head_path)
-    base_coordinates = {item["coordinate"] for item in base_items}
-    changed = [item for item in head_items if item["coordinate"] not in base_coordinates]
+    base_by_coordinate = {item["coordinate"]: item for item in base_items}
+    changed = [
+        to_preview_item(base_by_coordinate.get(item["coordinate"]), item)
+        for item in head_items
+        if is_changed(base_by_coordinate.get(item["coordinate"]), item)
+    ]
 
     Path(output_path).write_text(json.dumps(changed), encoding="utf-8")
     return 0

--- a/scripts/dump_transport_coordinates.py
+++ b/scripts/dump_transport_coordinates.py
@@ -4,13 +4,19 @@
 Reads every *.tsv file from the transport resources directory and emits a JSON
 array where each element represents one previewable tile coordinate:
 
-    [{"id": "coord-X-Y-P", "label": "...", "coordinate": "X/Y/P", "source": "transports/file.tsv:LINE"}, ...]
+    [{"id": "coord-<hash>", "entries": [{"label": "...", "source": "..."}], "coordinate": "X/Y/P"}, ...]
 
-Coordinates that appear in multiple rows are merged into a single entry by
-concatenating their labels and source references with "; ".
+Coordinates that appear in multiple rows are merged into a single entry. Labels
+stay structured in this intermediate JSON so diffing can reason about additions
+and removals without re-parsing a display string. Each label keeps its first
+source line alongside it so the final rendered `label` and `source` strings can
+be reordered in lockstep. The emitted id is a stable hash of the rendered
+preview identity (coordinate + merged labels), so it changes when the visible
+meaning of a tile changes but not when only source line references move.
 """
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -39,8 +45,9 @@ def coordinate_string(x: int, y: int, p: int) -> str:
     return f"{x}/{y}/{p}"
 
 
-def coordinate_id(x: int, y: int, p: int) -> str:
-    return f"coord-{x}-{y}-{p}"
+def coordinate_id(coordinate: str, label: str) -> str:
+    digest = hashlib.sha1(f"{coordinate}|{label}".encode("utf-8")).hexdigest()[:12]
+    return f"coord-{digest}"
 
 
 def transport_type_name(filename: str) -> str:
@@ -48,12 +55,15 @@ def transport_type_name(filename: str) -> str:
     return " ".join(word.capitalize() for word in Path(filename).stem.split("_"))
 
 
-def merge_values(existing: str, new: str) -> str:
-    if not existing:
-        return new
-    if not new or existing == new:
+def merge_entries(existing: list[dict], label: str, source: str) -> list[dict]:
+    label = (label or "").strip()
+    source = (source or "").strip()
+    if not label:
         return existing
-    return existing + MERGED_VALUE_SEPARATOR + new
+    for entry in existing:
+        if entry["label"] == label:
+            return existing
+    return [*existing, {"label": label, "source": source}]
 
 
 def build_label(type_name: str, role: str, display_info: str, object_info: str) -> str:
@@ -126,21 +136,28 @@ def export_coordinates(base_dir: Path) -> list:
 
                 if coord_str not in items:
                     items[coord_str] = {
-                        "id": coordinate_id(x, y, p),
-                        "label": label,
+                        "entries": [{"label": label, "source": source}],
                         "coordinate": coord_str,
-                        "source": source,
                     }
                 else:
                     existing = items[coord_str]
                     items[coord_str] = {
-                        "id": existing["id"],
-                        "label": merge_values(existing["label"], label),
+                        "entries": merge_entries(existing["entries"], label, source),
                         "coordinate": coord_str,
-                        "source": merge_values(existing["source"], source),
                     }
 
-    return list(items.values())
+    result = []
+    for item in items.values():
+        merged_label = MERGED_VALUE_SEPARATOR.join(
+            entry["label"] for entry in item["entries"]
+        )
+        result.append({
+            "id": coordinate_id(item["coordinate"], merged_label),
+            "entries": item["entries"],
+            "coordinate": item["coordinate"],
+        })
+
+    return result
 
 
 def main() -> int:

--- a/src/main/resources/transports/teleportation_boxes.tsv
+++ b/src/main/resources/transports/teleportation_boxes.tsv
@@ -21,7 +21,7 @@
 1870 5698 0	2967 4254 0	Teleport Menu Basic Jewellery Box 37492	4	7: Corporeal Beast
 1870 5698 0	3245 9500 0	Teleport Menu Basic Jewellery Box 37492	4	8: Chasm of Tears
 1870 5698 0	1631 3940 0	Teleport Menu Basic Jewellery Box 37492	4	9: Wintertodt Camp
-1870 5698 0	2865 3546 0	Teleport Menu Fancy Jewellery Box 37501	4	A: Warriors' Guild
+1870 5698 0	2882 3547 0	Teleport Menu Fancy Jewellery Box 37501	4	A: Warriors' Guild
 1870 5698 0	3192 3368 0	Teleport Menu Fancy Jewellery Box 37501	4	B: Champions' Guild
 1870 5698 0	3052 3490 0	Teleport Menu Fancy Jewellery Box 37501	4	C: Edgeville Monastery
 1870 5698 0	2653 3439 0	Teleport Menu Fancy Jewellery Box 37501	4	D: Ranging Guild


### PR DESCRIPTION
The coordinate preview previously only showed tiles that were completely new in. That missed an important class of changes: edits to an existing transport that make it point at a coordinate that already exists.

Change the preview pipeline to diff on the coordinate/label combination instead of just the coordinate. Existing coordinates are now included when they gain new preview labels, while pure removals remain suppressed to avoid noise.

Also a few tweaks to the label display.

* Reorder the labels so "new" ones are first in the list.
* Display new labels as bold.