### PR TITLE
Correct destination location for Warrior's Guild Jewellery Box teleport

### DIFF
--- a/src/main/resources/transports/teleportation_boxes.tsv
+++ b/src/main/resources/transports/teleportation_boxes.tsv
@@ -21,7 +21,7 @@
 1870 5698 0	2967 4254 0	Teleport Menu Basic Jewellery Box 37492	4	7: Corporeal Beast
 1870 5698 0	3245 9500 0	Teleport Menu Basic Jewellery Box 37492	4	8: Chasm of Tears
 1870 5698 0	1631 3940 0	Teleport Menu Basic Jewellery Box 37492	4	9: Wintertodt Camp
-1870 5698 0	2865 3546 0	Teleport Menu Fancy Jewellery Box 37501	4	A: Warriors' Guild
+1870 5698 0	2882 3547 0	Teleport Menu Fancy Jewellery Box 37501	4	A: Warriors' Guild
 1870 5698 0	3192 3368 0	Teleport Menu Fancy Jewellery Box 37501	4	B: Champions' Guild
 1870 5698 0	3052 3490 0	Teleport Menu Fancy Jewellery Box 37501	4	C: Edgeville Monastery
 1870 5698 0	2653 3439 0	Teleport Menu Fancy Jewellery Box 37501	4	D: Ranging Guild


### PR DESCRIPTION
Fixes #408