### PR TITLE
Fix pathfinder for unreachable targets

### DIFF
--- a/src/main/java/shortestpath/WorldPointUtil.java
+++ b/src/main/java/shortestpath/WorldPointUtil.java
@@ -22,6 +22,9 @@ import static net.runelite.api.Perspective.LOCAL_COORD_BITS;
  * This representation allows efficient storage and hashing of coordinates within the pathfinding data structures.
  */
 public class WorldPointUtil {
+    public static final int CHEBYSHEV_DISTANCE_METRIC = 1;
+    public static final int EUCLIDEAN_SQUARED_DISTANCE_METRIC = 1414213562;
+    public static final int MANHATTAN_DISTANCE_METRIC = 2;
     public static final int UNDEFINED = -1;
 
     /**
@@ -125,8 +128,8 @@ public class WorldPointUtil {
      *
      * @param previousPacked first packed point.
      * @param currentPacked second packed point.
-     * @param diagonal {@code 1} for Chebyshev (max), {@code 2} for Manhattan (sum). Any other value returns {@code Integer.MAX_VALUE}.
-     * @return distance or {@code Integer.MAX_VALUE} if plane differs or metric is unsupported.
+     * @param diagonal {@code 1} for Chebyshev (max), {@code 2} for Manhattan (sum). Otherwise returns Euclidean squared distance.
+     * @return distance or {@code Integer.MAX_VALUE} if plane differs.
      */
     public static int distanceBetween(int previousPacked, int currentPacked, int diagonal) {
         final int previousX = WorldPointUtil.unpackWorldX(previousPacked);
@@ -160,12 +163,12 @@ public class WorldPointUtil {
      * @param currentX x of second point.
      * @param currentY y of second point.
      * @param currentZ plane of second point.
-     * @param diagonal metric selector ({@code 1}=Chebyshev, {@code 2}=Manhattan).
-     * @return distance or {@code Integer.MAX_VALUE} if planes differ or unsupported metric.
+     * @param diagonal metric selector ({@code 1}=Chebyshev, {@code 2}=Manhattan, otherwise Euclidean squared distance).
+     * @return distance or {@code Integer.MAX_VALUE} if planes differ.
      */
     public static int distanceBetween(int previousX, int previousY, int previousZ,
         int currentX, int currentY, int currentZ, int diagonal) {
-        final int dz = Math.abs(previousZ - currentZ);
+        final int dz = previousZ - currentZ;
 
         if (dz != 0) {
             return Integer.MAX_VALUE;
@@ -175,27 +178,27 @@ public class WorldPointUtil {
     }
 
     /**
-     * Computes a 2D distance using either Chebyshev or Manhattan metric.
+     * Computes a 2D distance using either Chebyshev, Manhattan or Euclidean squared distance metric.
      *
      * @param previousX x of first point.
      * @param previousY y of first point.
      * @param currentX x of second point.
      * @param currentY y of second point.
-     * @param diagonal metric selector ({@code 1}=Chebyshev, {@code 2}=Manhattan).
-     * @return distance or {@code Integer.MAX_VALUE} for unsupported metric.
+     * @param diagonal metric selector ({@code 1}=Chebyshev, {@code 2}=Manhattan, otherwise Euclidean squared distance).
+     * @return distance.
      */
     public static int distanceBetween2D(int previousX, int previousY,
         int currentX, int currentY, int diagonal) {
-        final int dx = Math.abs(previousX - currentX);
-        final int dy = Math.abs(previousY - currentY);
+        final int dx = previousX - currentX;
+        final int dy = previousY - currentY;
 
-        if (diagonal == 1) {
-            return Math.max(dx, dy);
-        } else if (diagonal == 2) {
-            return dx + dy;
+        if (diagonal == CHEBYSHEV_DISTANCE_METRIC) {
+            return Math.max(Math.abs(dx), Math.abs(dy));
+        } else if (diagonal == MANHATTAN_DISTANCE_METRIC) {
+            return Math.abs(dx) + Math.abs(dy);
         }
 
-        return Integer.MAX_VALUE;
+        return dx * dx + dy * dy;
     }
 
     /**

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -168,12 +168,10 @@ public class Pathfinder implements Runnable {
             // - 3) If another tie occurs, pick the path with minimum x-coordinate
             // - 4) If another tie occurs, pick the path with minimum y-coordinate
             for (int target : targets) {
+                int remainingDistance = WorldPointUtil.distanceBetween(target, node.packedPosition, WorldPointUtil.EUCLIDEAN_SQUARED_DISTANCE_METRIC);
+                int travelledDistance = node.cost;
                 int remainingX = WorldPointUtil.unpackWorldX(node.packedPosition);
                 int remainingY = WorldPointUtil.unpackWorldY(node.packedPosition);
-                int dx = WorldPointUtil.unpackWorldX(target) - remainingX;
-                int dy = WorldPointUtil.unpackWorldY(target) - remainingY;
-                int remainingDistance = dx * dx + dy * dy;
-                int travelledDistance = node.cost;
                 if ((remainingDistance < bestRemainingDistance) ||
                     (remainingDistance == bestRemainingDistance && travelledDistance < bestTravelledDistance) ||
                     (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && remainingX < bestRemainingX) ||

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -113,7 +113,7 @@ public class Pathfinder implements Runnable {
         int bestRemainingX = Integer.MAX_VALUE;
         int bestRemainingY = Integer.MAX_VALUE;
         int bestTravelledDistance = Integer.MAX_VALUE;
-        double bestRemainingDistance = Integer.MAX_VALUE;
+        int bestRemainingDistance = Integer.MAX_VALUE;
         long cutoffDurationMillis = config.getCalculationCutoffMillis();
         long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
 
@@ -159,12 +159,20 @@ public class Pathfinder implements Runnable {
                 break;
             }
 
+            // Pathfinding to an unreachable target is slightly different from normal pathfinding.
+            // Straight-line movement before diagonal movement is no longer prioritized, because the
+            // original target is moved to the closest reachable tile. To avoid having to move the
+            // original target we instead do the following to favour the closest reachable tile:
+            // - 1) Pick the path with the minimum Euclidean distance (no need to use square root though)
+            // - 2) If a tie occurs, pick the path with minimum travelled distance
+            // - 3) If another tie occurs, pick the path with minimum x-coordinate
+            // - 4) If another tie occurs, pick the path with minimum y-coordinate
             for (int target : targets) {
                 int remainingX = WorldPointUtil.unpackWorldX(node.packedPosition);
                 int remainingY = WorldPointUtil.unpackWorldY(node.packedPosition);
                 int dx = WorldPointUtil.unpackWorldX(target) - remainingX;
                 int dy = WorldPointUtil.unpackWorldY(target) - remainingY;
-                double remainingDistance = Math.sqrt(dx * dx + dy * dy);
+                int remainingDistance = dx * dx + dy * dy;
                 int travelledDistance = node.cost;
                 if ((remainingDistance < bestRemainingDistance) ||
                     (remainingDistance == bestRemainingDistance && travelledDistance < bestTravelledDistance) ||

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -110,8 +110,10 @@ public class Pathfinder implements Runnable {
         stats.start();
         boundary.addFirst(new Node(start, null));
 
-        int bestDistance = Integer.MAX_VALUE;
-        long bestHeuristic = Integer.MAX_VALUE;
+        int bestRemainingX = Integer.MAX_VALUE;
+        int bestRemainingY = Integer.MAX_VALUE;
+        int bestTravelledDistance = Integer.MAX_VALUE;
+        double bestRemainingDistance = Integer.MAX_VALUE;
         long cutoffDurationMillis = config.getCalculationCutoffMillis();
         long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
 
@@ -158,13 +160,22 @@ public class Pathfinder implements Runnable {
             }
 
             for (int target : targets) {
-                int distance = WorldPointUtil.distanceBetween(node.packedPosition, target);
-                long heuristic = distance + (long) WorldPointUtil.distanceBetween(node.packedPosition, target, 2);
-                if (heuristic < bestHeuristic || (heuristic <= bestHeuristic && distance < bestDistance)) {
+                int remainingX = WorldPointUtil.unpackWorldX(node.packedPosition);
+                int remainingY = WorldPointUtil.unpackWorldY(node.packedPosition);
+                int dx = WorldPointUtil.unpackWorldX(target) - remainingX;
+                int dy = WorldPointUtil.unpackWorldY(target) - remainingY;
+                double remainingDistance = Math.sqrt(dx * dx + dy * dy);
+                int travelledDistance = node.cost;
+                if ((remainingDistance < bestRemainingDistance) ||
+                    (remainingDistance == bestRemainingDistance && travelledDistance < bestTravelledDistance) ||
+                    (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && remainingX < bestRemainingX) ||
+                    (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && remainingX == bestRemainingX && remainingY < bestRemainingY)) {
+                    bestRemainingDistance = remainingDistance;
+                    bestTravelledDistance = travelledDistance;
+                    bestRemainingX = remainingX;
+                    bestRemainingY = remainingY;
                     bestLastNode = node;
                     pathNeedsUpdate = true;
-                    bestDistance = distance;
-                    bestHeuristic = heuristic;
                     cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
                 }
             }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -36,6 +36,10 @@ public class Pathfinder implements Runnable {
     private PrimitiveIntList path = new PrimitiveIntList();
     private boolean pathNeedsUpdate = false;
     private Node bestLastNode;
+    private int bestRemainingDistance = Integer.MAX_VALUE;
+    private int bestTravelledDistance = Integer.MAX_VALUE;
+    private int bestX = Integer.MAX_VALUE;
+    private int bestY = Integer.MAX_VALUE;
     /**
      * Teleportation transports are updated when this changes.
      * Can be either:
@@ -105,15 +109,77 @@ public class Pathfinder implements Runnable {
         }
     }
 
+    /**
+     * Pathfinding to an unreachable target is slightly different from normal pathfinding.
+     * Straight-line movement before diagonal movement is no longer prioritized, because the
+     * original target is moved to the closest reachable tile. To avoid having to move the
+     * original target we instead do the following to favour the closest reachable tile:
+     * - 1) Pick the path with the minimum Euclidean distance (no need to use square root though)
+     * - 2) If a tie occurs, pick the path with minimum travelled distance
+     * - 3) If another tie occurs, pick the path with minimum x-coordinate
+     * - 4) If another tie occurs, pick the path with minimum y-coordinate
+     */
+    private boolean updateBestPathWhenUnreachable(Node node) {
+        boolean update = false;
+
+        for (int target : targets) {
+            int remainingDistance = WorldPointUtil.distanceBetween(target, node.packedPosition, WorldPointUtil.EUCLIDEAN_SQUARED_DISTANCE_METRIC);
+            int travelledDistance = node.cost;
+            int x = WorldPointUtil.unpackWorldX(node.packedPosition);
+            int y = WorldPointUtil.unpackWorldY(node.packedPosition);
+            if ((remainingDistance < bestRemainingDistance) ||
+                (remainingDistance == bestRemainingDistance && travelledDistance < bestTravelledDistance) ||
+                (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && x < bestX) ||
+                (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && y == bestX && y < bestY)) {
+                bestRemainingDistance = remainingDistance;
+                bestTravelledDistance = travelledDistance;
+                bestX = x;
+                bestY = y;
+                bestLastNode = node;
+                pathNeedsUpdate = true;
+                update = true;
+            }
+        }
+
+        return update;
+    }
+
+    /**
+     * Update teleports based on wilderness level
+     */
+    private void updateWildernessLevel(Node node) {
+        if (wildernessLevel > 0) {
+            // We don't need to remove teleports when going from 20 to 21 or higher,
+            // because the teleport is either used at the very start of the
+            // path or when going from 31 or higher to 30, or from 21 or higher to 20.
+
+            boolean update = false;
+
+            // These are overlapping boundaries, so if the node isn't in level 30, it's in 0-29
+            // likewise, if the node isn't in level 20, it's in 0-19
+            if (wildernessLevel > 30 && !WildernessChecker.isInLevel30Wilderness(node.packedPosition)) {
+                wildernessLevel = 30;
+                update = true;
+            }
+            if (wildernessLevel > 20 && !WildernessChecker.isInLevel20Wilderness(node.packedPosition)) {
+                wildernessLevel = 20;
+                update = true;
+            }
+            if (wildernessLevel > 0 && !WildernessChecker.isInWilderness(node.packedPosition)) {
+                wildernessLevel = 0;
+                update = true;
+            }
+            if (update) {
+                config.refreshTeleports(node.packedPosition, wildernessLevel);
+            }
+        }
+    }
+
     @Override
     public void run() {
         stats.start();
         boundary.addFirst(new Node(start, null));
 
-        int bestRemainingX = Integer.MAX_VALUE;
-        int bestRemainingY = Integer.MAX_VALUE;
-        int bestTravelledDistance = Integer.MAX_VALUE;
-        int bestRemainingDistance = Integer.MAX_VALUE;
         long cutoffDurationMillis = config.getCalculationCutoffMillis();
         long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
 
@@ -127,31 +193,7 @@ public class Pathfinder implements Runnable {
                 node = boundary.removeFirst();
             }
 
-            if (wildernessLevel > 0) {
-                // We don't need to remove teleports when going from 20 to 21 or higher,
-                // because the teleport is either used at the very start of the
-                // path or when going from 31 or higher to 30, or from 21 or higher to 20.
-
-                boolean update = false;
-
-                // These are overlapping boundaries, so if the node isn't in level 30, it's in 0-29
-                // likewise, if the node isn't in level 20, it's in 0-19
-                if (wildernessLevel > 30 && !WildernessChecker.isInLevel30Wilderness(node.packedPosition)) {
-                    wildernessLevel = 30;
-                    update = true;
-                }
-                if (wildernessLevel > 20 && !WildernessChecker.isInLevel20Wilderness(node.packedPosition)) {
-                    wildernessLevel = 20;
-                    update = true;
-                }
-                if (wildernessLevel > 0 && !WildernessChecker.isInWilderness(node.packedPosition)) {
-                    wildernessLevel = 0;
-                    update = true;
-                }
-                if (update) {
-                    config.refreshTeleports(node.packedPosition, wildernessLevel);
-                }
-            }
+            updateWildernessLevel(node);
 
             if (targets.contains(node.packedPosition)) {
                 bestLastNode = node;
@@ -159,31 +201,8 @@ public class Pathfinder implements Runnable {
                 break;
             }
 
-            // Pathfinding to an unreachable target is slightly different from normal pathfinding.
-            // Straight-line movement before diagonal movement is no longer prioritized, because the
-            // original target is moved to the closest reachable tile. To avoid having to move the
-            // original target we instead do the following to favour the closest reachable tile:
-            // - 1) Pick the path with the minimum Euclidean distance (no need to use square root though)
-            // - 2) If a tie occurs, pick the path with minimum travelled distance
-            // - 3) If another tie occurs, pick the path with minimum x-coordinate
-            // - 4) If another tie occurs, pick the path with minimum y-coordinate
-            for (int target : targets) {
-                int remainingDistance = WorldPointUtil.distanceBetween(target, node.packedPosition, WorldPointUtil.EUCLIDEAN_SQUARED_DISTANCE_METRIC);
-                int travelledDistance = node.cost;
-                int remainingX = WorldPointUtil.unpackWorldX(node.packedPosition);
-                int remainingY = WorldPointUtil.unpackWorldY(node.packedPosition);
-                if ((remainingDistance < bestRemainingDistance) ||
-                    (remainingDistance == bestRemainingDistance && travelledDistance < bestTravelledDistance) ||
-                    (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && remainingX < bestRemainingX) ||
-                    (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && remainingX == bestRemainingX && remainingY < bestRemainingY)) {
-                    bestRemainingDistance = remainingDistance;
-                    bestTravelledDistance = travelledDistance;
-                    bestRemainingX = remainingX;
-                    bestRemainingY = remainingY;
-                    bestLastNode = node;
-                    pathNeedsUpdate = true;
-                    cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
-                }
+            if (updateBestPathWhenUnreachable(node)) {
+                cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
             }
 
             if (System.currentTimeMillis() > cutoffTimeMillis) {

--- a/src/test/java/shortestpath/WorldPointUtilTest.java
+++ b/src/test/java/shortestpath/WorldPointUtilTest.java
@@ -57,9 +57,11 @@ public class WorldPointUtilTest {
         int a = WorldPointUtil.packWorldPoint(10, 10, 0);
         int b = WorldPointUtil.packWorldPoint(15, 13, 0); // dx=5 dy=3
         assertEquals(5, WorldPointUtil.distanceBetween(a, b)); // Chebyshev
+        assertEquals(5, WorldPointUtil.distanceBetween(a, b, WorldPointUtil.CHEBYSHEV_DISTANCE_METRIC)); // Chebyshev
         assertEquals(5, WorldPointUtil.distanceBetween2D(a, b)); // Chebyshev 2D
-        assertEquals(5 + 3, WorldPointUtil.distanceBetween(a, b, 2)); // Manhattan
-        assertEquals(Integer.MAX_VALUE, WorldPointUtil.distanceBetween(a, b, 99));
+        assertEquals(5 + 3, WorldPointUtil.distanceBetween(a, b, WorldPointUtil.MANHATTAN_DISTANCE_METRIC)); // Manhattan
+        assertEquals(5 * 5 + 3 * 3, WorldPointUtil.distanceBetween(a, b, WorldPointUtil.EUCLIDEAN_SQUARED_DISTANCE_METRIC)); // Euclidean squared
+        assertEquals(5 * 5 + 3 * 3, WorldPointUtil.distanceBetween(a, b, 99));
     }
 
     @Test
@@ -74,7 +76,8 @@ public class WorldPointUtilTest {
         WorldPoint a = new WorldPoint(100, 150, 0);
         WorldPoint b = new WorldPoint(103, 160, 0); // dx=3 dy=10
         assertEquals(10, WorldPointUtil.distanceBetween(a, b)); // Chebyshev
-        assertEquals(13, WorldPointUtil.distanceBetween(a, b, 2)); // Manhattan
+        assertEquals(10 + 3, WorldPointUtil.distanceBetween(a, b, WorldPointUtil.MANHATTAN_DISTANCE_METRIC)); // Manhattan
+        assertEquals(10 * 10 + 3 * 3, WorldPointUtil.distanceBetween(a, b, WorldPointUtil.EUCLIDEAN_SQUARED_DISTANCE_METRIC)); // Euclidean squared
     }
 
     @Test


### PR DESCRIPTION
Pathfinding towards an unreachable target behaves slightly different to pathfinding to a reachable target. This is because the game will choose a new target that is as close as possible to the original target. It is inconvenient for this plugin to change the original target to a new target as close as possible. Instead, we will attempt to pathfind as close as possible while still keeping the original target. My testing so far seems to indicate that this improved pathfinding for unreachable targets is the same as the in-game pathfinding. Pathfinding to reachable targets should (hopefully) be unchanged. The approach I have chosen is to first minimize the remaining Euclidean distance. If a tie occurs we minimize the travelled distance. If another tie occurs we choose the minimum x-coordinate. If another tie occurs we choose the minimum y-coordinate. This should hopefully reproduce the in-game implementation that picks the closest reachable tile within a 21x21 area around the original target with ties resolved by picking the first when iterating from south-west to north-east (apart from extending the 21x21 area indefinitely, but that is sort of the point of this whole plugin). The below animation shows how the new implementation reproduces in-game behaviour (purple tiles are unreachable):
![anim](https://github.com/user-attachments/assets/eb30080d-979a-4671-b9e9-e0655e9011a5)

I suspect I may have overcomplicated the logic, so feel free to suggest a simpler implementation.

I believe that `WorldPointUtil.distanceBetween` with Manhattan distance metric is now unused, but I would like to keep it in case we want to use it for something else at a later point.