### PR TITLE
 test(pathfinder): replace PathfinderConfig spy with concrete test subclass

### DIFF
--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -3,14 +3,13 @@ package shortestpath.pathfinder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
-import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import org.junit.Before;
@@ -20,10 +19,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import shortestpath.ItemVariations;
-import shortestpath.ShortestPathConfig;
 import shortestpath.ShortestPathPlugin;
 import shortestpath.TeleportationItem;
 import shortestpath.WorldPointUtil;
+import shortestpath.ShortestPathConfig;
 import shortestpath.transport.Transport;
 import shortestpath.transport.requirement.TransportItems;
 import shortestpath.transport.TransportLoader;
@@ -34,7 +33,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -563,22 +561,36 @@ public class PathfinderTest {
         }
     }
 
+    // Setup a configuration with
+    // * A fixed QuestState for all quests
+    // * A fixed skill level for all skills
+    // * A toggle about wheher to use teleportation items.
     private void setupConfig(QuestState questState, int skillLevel, TeleportationItem useTeleportationItems) {
-        pathfinderConfig = spy(new PathfinderConfig(client, config));
+        // NOTE: Not mocked since PathfinderConfig is repeatedly queried in the hot loop.
+        pathfinderConfig = new TestPathfinderConfig(client, config, questState
+                                                                  , true // Ignore Varbit checks
+                                                                  , true // Ignore Varplayer checks
+                                                                  );
 
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
         when(client.getClientThread()).thenReturn(Thread.currentThread());
         when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(skillLevel);
         when(config.useTeleportationItems()).thenReturn(useTeleportationItems);
-        doReturn(true).when(pathfinderConfig).varbitChecks(any(Transport.class));
-        doReturn(true).when(pathfinderConfig).varPlayerChecks(any(Transport.class));
-        doReturn(questState).when(pathfinderConfig).getQuestState(any(Quest.class));
 
         pathfinderConfig.refresh();
     }
 
+    // Setup a configuration with
+    // * A fixed QuestState for all quests
+    // * A fixed skill level for all skills
+    // * A toggle about wheher to use teleportation items.
+    // * Fixed set of varbit values
     private void setupConfig(QuestState questState, int skillLevel, TeleportationItem useTeleportationItems, Map<Integer, Integer> varbitValues) {
-        pathfinderConfig = spy(new PathfinderConfig(client, config));
+        // NOTE: Not mocked since PathfinderConfig is repeatedly queried in the hot loop.
+        pathfinderConfig = new TestPathfinderConfig(client, config, questState
+                                                                  , false // Use proper varbit checking
+                                                                  , true  // Ignore varplayer checks
+                                                                  );
 
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
         when(client.getClientThread()).thenReturn(Thread.currentThread());
@@ -587,8 +599,6 @@ public class PathfinderTest {
         for (Map.Entry<Integer, Integer> entry : varbitValues.entrySet()) {
             when(client.getVarbitValue(entry.getKey())).thenReturn(entry.getValue());
         }
-        doReturn(true).when(pathfinderConfig).varPlayerChecks(any(Transport.class));
-        doReturn(questState).when(pathfinderConfig).getQuestState(any(Quest.class));
 
         pathfinderConfig.refresh();
     }

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -633,26 +633,19 @@ public class PathfinderTest {
         TeleportationItem useTeleportationItems) {
         setupConfig(questState, skillLevel, useTeleportationItems);
 
-        // Cap the number of pathfinder runs per transport type to avoid excessive test runtime.
-        // Running pathfinder for every transport (e.g. hundreds of fairy rings) is very slow.
-        final int maxPathfinderRuns = 50;
         int counter = 0;
-        int totalMatched = 0;
         Map<Integer, Set<Transport>> activeTransports = pathfinderConfig.getTransports();
         for (int origin : activeTransports.keySet()) {
             for (Transport transport : activeTransports.get(origin)) {
                 if (transportType.equals(transport.getType())) {
-                    totalMatched++;
-                    if (counter < maxPathfinderRuns) {
-                        counter++;
-                        assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
-                    }
+                    counter++;
+                    assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
                 }
             }
         }
 
         assertTrue("No tests were performed", counter > 0);
-        System.out.println(String.format("Successfully completed %d/%d " + transportType + " transport length tests", counter, totalMatched));
+        System.out.println(String.format("Successfully completed %d " + transportType + " transport length tests", counter));
     }
 
     private void testTransportMinimumLength(int minimumLength, int origin, int destination) {

--- a/src/test/java/shortestpath/pathfinder/TestPathfinderConfig.java
+++ b/src/test/java/shortestpath/pathfinder/TestPathfinderConfig.java
@@ -1,0 +1,49 @@
+package shortestpath.pathfinder;
+
+import net.runelite.api.Client;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+import shortestpath.ShortestPathConfig;
+import shortestpath.transport.Transport;
+
+// This subclass is used to provide mocked implementations of methods from the normal
+// PathfinderConfig. CRUCIAL: Not implemented via Mockito as these methods are called
+// many times in the inner pathfinding loop.
+//
+// In particular, at the moment you can provide default values for:
+//  * getQuestState: Whether all quests are completed or not started.
+//  * varbitChecks: Ignore any varbitChecks.
+//  * varPlayerChecks: Ignore any varPlayerChecks.
+// Other methods are delegated to a normal PathfinderConfig.
+public class TestPathfinderConfig extends PathfinderConfig {
+    private final QuestState questState;
+    private final boolean bypassVarbitChecks;
+    private final boolean bypassVarPlayerChecks;
+
+    public TestPathfinderConfig(Client client, ShortestPathConfig config) {
+        this(client, config, QuestState.FINISHED, true, true);
+    }
+
+    public TestPathfinderConfig(Client client, ShortestPathConfig config, QuestState questState,
+        boolean bypassVarbitChecks, boolean bypassVarPlayerChecks) {
+        super(client, config);
+        this.questState = questState;
+        this.bypassVarbitChecks = bypassVarbitChecks;
+        this.bypassVarPlayerChecks = bypassVarPlayerChecks;
+    }
+
+    @Override
+    public QuestState getQuestState(Quest quest) {
+        return questState;
+    }
+
+    @Override
+    public boolean varbitChecks(Transport transport) {
+        return bypassVarbitChecks || super.varbitChecks(transport);
+    }
+
+    @Override
+    public boolean varPlayerChecks(Transport transport) {
+        return bypassVarPlayerChecks || super.varPlayerChecks(transport);
+    }
+}


### PR DESCRIPTION
I noticed that the tests were running quite slowly, it seemed that the
main cost was hitting the mocking interception during the pathfinding
loop.

`PathfinderTest` was building `PathfinderConfig` with `spy(new
PathfinderConfig(...))` and stubbing `getQuestState()`, `varbitChecks()`, and
`varPlayerChecks()`. That made hot-path config calls in pathfinding pay
Mockito interception costs, which
slows the suite substantially.

Replace the spy with a small test-only `TestPathfinderConfig` subclass
that overrides those same behaviors directly. Keep the existing
semantics:

  - quest state remains controlled by the helper
  - the default helper still bypasses varbit and varplayer checks
  - the varbit-aware helper still uses real varbit evaluation while bypassing varplayer checks

Before the current tests took about 2 minutes to run, now they take 6
seconds.