### PR TITLE
Display Required Item Pickup Hint

### DIFF
--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -7,6 +7,8 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
+import java.util.Map;
+import java.util.Set;
 import java.util.HashSet;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
@@ -16,8 +18,8 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import shortestpath.pathfinder.CollisionMap;
+import shortestpath.pathfinder.PathStep;
 import shortestpath.transport.Transport;
-import shortestpath.transport.TransportType;
 
 public class PathMapOverlay extends Overlay {
     private final Client client;
@@ -96,19 +98,19 @@ public class PathMapOverlay extends Overlay {
 
         if (plugin.getPathfinder() != null) {
             Color colour = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
-            PrimitiveIntList path = plugin.getPathfinder().getPath();
+            java.util.List<PathStep> path = plugin.getPathfinder().getPath();
             Point cursorPos = client.getMouseCanvasPosition();
             for (int i = 0; i < path.size(); i++) {
                 graphics.setColor(colour);
-                int point = path.get(i);
-                int lastPoint = (i > 0) ? path.get(i - 1) : point;
+                int point = path.get(i).getPackedPosition();
+                int lastPoint = (i > 0) ? path.get(i - 1).getPackedPosition() : point;
                 if (WorldPointUtil.distanceBetween(point, lastPoint) > 1) {
                     drawOnMap(graphics, lastPoint, point, true, cursorPos);
                 }
                 drawOnMap(graphics, point, true, cursorPos);
             }
             for (int target : plugin.getPathfinder().getTargets()) {
-                if (path.size() > 0 && target != path.get(path.size() - 1)) {
+                if (path.size() > 0 && target != path.get(path.size() - 1).getPackedPosition()) {
                     graphics.setColor(plugin.colourPathCalculating);
                     drawOnMap(graphics, target, true, cursorPos);
                 }

--- a/src/main/java/shortestpath/PathMapTooltipOverlay.java
+++ b/src/main/java/shortestpath/PathMapTooltipOverlay.java
@@ -7,8 +7,8 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
+import java.util.HashSet;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
 import net.runelite.api.widgets.ComponentID;
@@ -19,6 +19,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import shortestpath.transport.Transport;
+import shortestpath.pathfinder.PathStep;
 
 public class PathMapTooltipOverlay extends Overlay {
     private static final int TOOLTIP_OFFSET_HEIGHT = 25;
@@ -47,19 +48,19 @@ public class PathMapTooltipOverlay extends Overlay {
         }
 
         if (plugin.getPathfinder() != null) {
-            PrimitiveIntList path = plugin.getPathfinder().getPath();
+            List<PathStep> path = plugin.getPathfinder().getPath();
             Point cursorPos = client.getMouseCanvasPosition();
             for (int i = 0; i < path.size(); i++) {
                 int nextPoint = WorldPointUtil.UNDEFINED;
                 if (path.size() > i + 1) {
-                    nextPoint = path.get(i + 1);
+                    nextPoint = path.get(i + 1).getPackedPosition();
                 }
-                if (drawTooltip(graphics, cursorPos, path.get(i), nextPoint, i + 1, path, i)) {
+                if (drawTooltip(graphics, cursorPos, path.get(i).getPackedPosition(), nextPoint, i + 1, path, i)) {
                     return null;
                 }
             }
             for (int target : plugin.getPathfinder().getTargets()) {
-                if (path.size() > 0 && target != path.get(path.size() - 1)) {
+                if (path.size() > 0 && target != path.get(path.size() - 1).getPackedPosition()) {
                     drawTooltip(graphics, cursorPos, target, WorldPointUtil.UNDEFINED, -1, path, -1);
                 }
             }
@@ -68,7 +69,7 @@ public class PathMapTooltipOverlay extends Overlay {
         return null;
     }
 
-    private boolean drawTooltip(Graphics2D graphics, Point cursorPos, int point, int nextPoint, int n, PrimitiveIntList path, int pathIndex) {
+    private boolean drawTooltip(Graphics2D graphics, Point cursorPos, int point, int nextPoint, int n, List<PathStep> path, int pathIndex) {
         int offsetPoint = WorldPointUtil.dxdy(point, 1, -1);
         int startX = plugin.mapWorldPointToGraphicsPointX(point);
         int startY = plugin.mapWorldPointToGraphicsPointY(point);

--- a/src/main/java/shortestpath/PathMinimapOverlay.java
+++ b/src/main/java/shortestpath/PathMinimapOverlay.java
@@ -13,6 +13,7 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import shortestpath.pathfinder.PathStep;
 
 public class PathMinimapOverlay extends Overlay {
     private final Client client;
@@ -41,10 +42,10 @@ public class PathMinimapOverlay extends Overlay {
         }
         graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 
-        PrimitiveIntList pathPoints = plugin.getPathfinder().getPath();
+        java.util.List<PathStep> pathPoints = plugin.getPathfinder().getPath();
         Color pathColor = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
         for (int i = 0; i < pathPoints.size(); i++) {
-            int pathPoint = pathPoints.get(i);
+            int pathPoint = pathPoints.get(i).getPackedPosition();
             if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {
                 continue;
             }
@@ -52,7 +53,7 @@ public class PathMinimapOverlay extends Overlay {
             drawOnMinimap(graphics, pathPoint, pathColor);
         }
         for (int target : plugin.getPathfinder().getTargets()) {
-            if (pathPoints.size() > 0 && target != pathPoints.get(pathPoints.size() - 1)) {
+            if (pathPoints.size() > 0 && target != pathPoints.get(pathPoints.size() - 1).getPackedPosition()) {
                 drawOnMinimap(graphics, target, plugin.colourPathCalculating);
             }
         }

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -18,6 +18,7 @@ import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import shortestpath.pathfinder.CollisionMap;
+import shortestpath.pathfinder.PathStep;
 import shortestpath.transport.Transport;
 
 public class PathTileOverlay extends Overlay {
@@ -145,27 +146,28 @@ public class PathTileOverlay extends Overlay {
                     plugin.colourPath.getAlpha() / 2)
                 : colorCalculating;
 
-            PrimitiveIntList path = plugin.getPathfinder().getPath();
+            java.util.List<PathStep> path = plugin.getPathfinder().getPath();
             int counter = 0;
             if (TileStyle.LINES.equals(plugin.pathStyle)) {
                 for (int i = 1; i < path.size(); i++) {
-                    drawLine(graphics, path.get(i - 1), path.get(i), color, 1 + counter++);
-                    drawTransportInfo(graphics, path.get(i - 1), path.get(i), path, i - 1);
+                    drawLine(graphics, path.get(i - 1).getPackedPosition(), path.get(i).getPackedPosition(), color, 1 + counter++);
+                    drawTransportInfo(graphics, path.get(i - 1).getPackedPosition(), path.get(i).getPackedPosition(), path, i - 1);
                 }
             } else {
                 boolean showTiles = TileStyle.TILES.equals(plugin.pathStyle);
                 for (int i = 0; i < path.size(); i++) {
                     // Skip drawing tiles inside POH (no collision data, tiles render at wrong positions)
-                    int pathX = WorldPointUtil.unpackWorldX(path.get(i));
-                    int pathY = WorldPointUtil.unpackWorldY(path.get(i));
+                    int pathPoint = path.get(i).getPackedPosition();
+                    int pathX = WorldPointUtil.unpackWorldX(pathPoint);
+                    int pathY = WorldPointUtil.unpackWorldY(pathPoint);
                     if (!ShortestPathPlugin.isInsidePoh(pathX, pathY)) {
-                        drawTile(graphics, path.get(i), color, counter, showTiles);
+                        drawTile(graphics, pathPoint, color, counter, showTiles);
                     }
                     counter++;
-                    drawTransportInfo(graphics, path.get(i), (i + 1 == path.size()) ? WorldPointUtil.UNDEFINED : path.get(i + 1), path, i);
+                    drawTransportInfo(graphics, pathPoint, (i + 1 == path.size()) ? WorldPointUtil.UNDEFINED : path.get(i + 1).getPackedPosition(), path, i);
                 }
                 for (int target : plugin.getPathfinder().getTargets()) {
-                    if (path.size() > 0 && target != path.get(path.size() - 1)) {
+                    if (path.size() > 0 && target != path.get(path.size() - 1).getPackedPosition()) {
                         drawTile(graphics, target, colorCalculating, -1, showTiles);
                     }
                 }
@@ -296,7 +298,7 @@ public class PathTileOverlay extends Overlay {
         }
     }
 
-    private void drawTransportInfo(Graphics2D graphics, int location, int locationEnd, PrimitiveIntList path, int pathIndex) {
+    private void drawTransportInfo(Graphics2D graphics, int location, int locationEnd, java.util.List<PathStep> path, int pathIndex) {
         if (locationEnd == WorldPointUtil.UNDEFINED || !plugin.showTransportInfo ||
             WorldPointUtil.unpackWorldPlane(location) != client.getPlane()) {
             return;

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -9,6 +9,8 @@ import java.awt.Polygon;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
@@ -19,6 +21,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import shortestpath.pathfinder.CollisionMap;
 import shortestpath.pathfinder.PathStep;
+import shortestpath.transport.BankPickupRequirements;
 import shortestpath.transport.Transport;
 
 public class PathTileOverlay extends Overlay {
@@ -86,7 +89,7 @@ public class PathTileOverlay extends Overlay {
 
     private void renderCollisionMap(Graphics2D graphics) {
         CollisionMap map = plugin.getMap();
-        for (Tile[] row : client.getScene().getTiles()[client.getPlane()]) {
+        for (Tile[] row : client.getTopLevelWorldView().getScene().getTiles()[client.getTopLevelWorldView().getPlane()]) {
             for (Tile tile : row) {
                 if (tile == null) {
                     continue;
@@ -134,17 +137,17 @@ public class PathTileOverlay extends Overlay {
 
         if (plugin.drawTiles && plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
             Color colorCalculating = new Color(
-                plugin.colourPathCalculating.getRed(),
-                plugin.colourPathCalculating.getGreen(),
-                plugin.colourPathCalculating.getBlue(),
-                plugin.colourPathCalculating.getAlpha() / 2);
+                    plugin.colourPathCalculating.getRed(),
+                    plugin.colourPathCalculating.getGreen(),
+                    plugin.colourPathCalculating.getBlue(),
+                    plugin.colourPathCalculating.getAlpha() / 2);
             Color color = plugin.getPathfinder().isDone()
-                ? new Color(
+                    ? new Color(
                     plugin.colourPath.getRed(),
                     plugin.colourPath.getGreen(),
                     plugin.colourPath.getBlue(),
                     plugin.colourPath.getAlpha() / 2)
-                : colorCalculating;
+                    : colorCalculating;
 
             java.util.List<PathStep> path = plugin.getPathfinder().getPath();
             int counter = 0;
@@ -182,7 +185,7 @@ public class PathTileOverlay extends Overlay {
             return null;
         }
 
-        if (WorldPointUtil.unpackWorldPlane(b) != client.getPlane()) {
+        if (WorldPointUtil.unpackWorldPlane(b) != client.getTopLevelWorldView().getPlane()) {
             return null;
         }
 
@@ -243,7 +246,7 @@ public class PathTileOverlay extends Overlay {
         int start = starts.get(0);
         int end = ends.get(0);
 
-        final int z = client.getPlane();
+        final int z = client.getTopLevelWorldView().getPlane();
         if (WorldPointUtil.unpackWorldPlane(start) != z) {
             return;
         }
@@ -293,14 +296,14 @@ public class PathTileOverlay extends Overlay {
             String counterText = Integer.toString(counter);
             graphics.setColor(plugin.colourText);
             graphics.drawString(
-                counterText,
-                (int) (x - graphics.getFontMetrics().getStringBounds(counterText, graphics).getWidth() / 2), (int) y);
+                    counterText,
+                    (int) (x - graphics.getFontMetrics().getStringBounds(counterText, graphics).getWidth() / 2), (int) y);
         }
     }
 
     private void drawTransportInfo(Graphics2D graphics, int location, int locationEnd, java.util.List<PathStep> path, int pathIndex) {
         if (locationEnd == WorldPointUtil.UNDEFINED || !plugin.showTransportInfo ||
-            WorldPointUtil.unpackWorldPlane(location) != client.getPlane()) {
+                WorldPointUtil.unpackWorldPlane(location) != client.getTopLevelWorldView().getPlane()) {
             return;
         }
 
@@ -336,7 +339,7 @@ public class PathTileOverlay extends Overlay {
             }
             text = text + " (Exit: " + pohExitInfo + ")";
 
-            Point p = Perspective.localToCanvas(client, playerLocalPoint, client.getPlane());
+            Point p = Perspective.localToCanvas(client, playerLocalPoint, client.getTopLevelWorldView().getPlane());
             if (p == null) {
                 return;
             }
@@ -353,6 +356,47 @@ public class PathTileOverlay extends Overlay {
         }
 
         int vertical_offset = 0;
+
+        // Check if this is a bank step and items need to be picked up
+        Set<Integer> bankLocations = plugin.getPathfinderConfig().getDestinations("bank");
+        if (bankLocations != null && plugin.getPathfinderConfig().bank != null) {
+            List<String> bankPickupItems = BankPickupRequirements.getRequiredBankItems(
+                    client,
+                    plugin.getPathfinderConfig().bank,
+                    plugin.getTransports(),
+                    bankLocations,
+                    path,
+                    pathIndex
+            );
+            if (!bankPickupItems.isEmpty()) {
+                String pickupText = "Pick up: " + String.join(", ", bankPickupItems);
+
+                PrimitiveIntList points = WorldPointUtil.toLocalInstance(client, location);
+                for (int i = 0; i < points.size(); i++) {
+                    LocalPoint lp = WorldPointUtil.toLocalPoint(client, points.get(i));
+                    if (lp == null) {
+                        continue;
+                    }
+
+                    Point p = Perspective.localToCanvas(client, lp, client.getTopLevelWorldView().getPlane());
+                    if (p == null) {
+                        continue;
+                    }
+
+                    Rectangle2D textBounds = graphics.getFontMetrics().getStringBounds(pickupText, graphics);
+                    double height = textBounds.getHeight();
+                    int x = (int) (p.getX() - textBounds.getWidth() / 2);
+                    int y = (int) (p.getY() - height) - vertical_offset;
+                    graphics.setColor(Color.BLACK);
+                    graphics.drawString(pickupText, x + 1, y + 1);
+                    graphics.setColor(plugin.colourText);
+                    graphics.drawString(pickupText, x, y);
+
+                    vertical_offset += (int) height + TRANSPORT_LABEL_GAP;
+                }
+            }
+        }
+
         for (Transport transport : plugin.getTransports().getOrDefault(location, new HashSet<>())) {
             if (locationEnd != transport.getDestination()) {
                 continue;
@@ -376,7 +420,7 @@ public class PathTileOverlay extends Overlay {
                     continue;
                 }
 
-                Point p = Perspective.localToCanvas(client, lp, client.getPlane());
+                Point p = Perspective.localToCanvas(client, lp, client.getTopLevelWorldView().getPlane());
                 if (p == null) {
                     continue;
                 }

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -233,7 +233,7 @@ public class ShortestPathPlugin extends Plugin {
                 if (ends.isEmpty()) {
                     setTarget(WorldPointUtil.UNDEFINED);
                 } else {
-                    pathfinder = new Pathfinder(this, pathfinderConfig, start, ends);
+                    pathfinder = new Pathfinder(pathfinderConfig, start, ends, this::postPluginMessages);
                     pathfinderFuture = pathfindingExecutor.submit(pathfinder);
                 }
             }

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -65,6 +65,7 @@ import net.runelite.client.util.Text;
 import shortestpath.pathfinder.CollisionMap;
 import shortestpath.pathfinder.Pathfinder;
 import shortestpath.pathfinder.PathfinderConfig;
+import shortestpath.pathfinder.PathStep;
 import shortestpath.transport.Transport;
 import shortestpath.transport.TransportType;
 
@@ -245,14 +246,14 @@ public class ShortestPathPlugin extends Plugin {
     }
 
     public boolean isNearPath(int location) {
-        PrimitiveIntList path = null;
+        List<PathStep> path = null;
         if (pathfinder == null || (path = pathfinder.getPath()) == null || path.isEmpty() ||
             config.recalculateDistance() < 0 || lastLocation == (lastLocation = location)) {
             return true;
         }
 
         for (int i = 0; i < path.size(); i++) {
-            if (WorldPointUtil.distanceBetween(location, path.get(i)) < config.recalculateDistance()) {
+            if (WorldPointUtil.distanceBetween(location, path.get(i).getPackedPosition()) < config.recalculateDistance()) {
                 return true;
             }
         }
@@ -384,11 +385,12 @@ public class ShortestPathPlugin extends Plugin {
             List<WorldPoint> transportDestinations = new ArrayList<>();
             List<String> transportObjectInfos = new ArrayList<>();
             List<String> transportDisplayInfos = new ArrayList<>();
-            PrimitiveIntList currentPath = pathfinder.getPath();
+            List<PathStep> currentPath = pathfinder.getPath();
             for (int i = 1; i < currentPath.size(); i++) {
-                int origin = currentPath.get(i-1);
-                int destination = currentPath.get(i);
-                for (Transport transport : pathfinderConfig.getTransports().getOrDefault(origin, new HashSet<>())) {
+                int origin = currentPath.get(i - 1).getPackedPosition();
+                int destination = currentPath.get(i).getPackedPosition();
+                boolean banked = currentPath.get(i).isBankVisited();
+                for (Transport transport : pathfinderConfig.getTransportAvailability(banked).getTransportsByOrigin().getOrDefault(origin, new HashSet<>())) {
                     if (transport.getDestination() == destination) {
                         transportOrigins.add(WorldPointUtil.unpackWorldPoint(origin));
                         transportDestinations.add(WorldPointUtil.unpackWorldPoint(destination));
@@ -457,10 +459,10 @@ public class ShortestPathPlugin extends Plugin {
                     }
                 }
                 int selectedTile = getSelectedWorldPoint();
-                PrimitiveIntList path = null;
+                List<PathStep> path = null;
                 if ((path = pathfinder.getPath()) != null) {
                     for (int i = 0; i < path.size(); i++) {
-                        if (path.get(i) == selectedTile) {
+                        if (path.get(i).getPackedPosition() == selectedTile) {
                             addMenuEntry(event, CLEAR, PATH, 1);
                             break;
                         }
@@ -597,7 +599,7 @@ public class ShortestPathPlugin extends Plugin {
     }
 
     private void scrollFairyRingPanel() {
-        PrimitiveIntList path = null;
+        List<PathStep> path = null;
         Map<Integer, Set<Transport>> transports = null;
 
         if (pathfinder == null
@@ -609,8 +611,8 @@ public class ShortestPathPlugin extends Plugin {
         String fairyRingCode = null;
 
         for (int i = 1; i < path.size(); i++) {
-            int destination = path.get(i);
-            int origin = path.get(i - 1);
+            int destination = path.get(i).getPackedPosition();
+            int origin = path.get(i - 1).getPackedPosition();
             Set<Transport> candidateTransports = transports.get(origin);
             if (candidateTransports != null) {
                 for (Transport transport : candidateTransports) {
@@ -670,12 +672,22 @@ public class ShortestPathPlugin extends Plugin {
         );
     }
 
-    public Map<Integer, Set<Transport>> getTransports() {
-        return pathfinderConfig.getTransports();
-    }
-
     public CollisionMap getMap() {
         return pathfinderConfig.getMap();
+    }
+
+    /**
+     * WARNING: This is a legacy wrapper for coarse display-oriented callers only.
+     *
+     * It collapses banked/unbanked transport availability into a single view via
+     * PathfinderConfig.getTransports(), which is not valid for path-state-sensitive logic.
+     *
+     * Do not use this for reasoning about which transports are available at a specific
+     * step of a path. Use PathfinderConfig.getTransportAvailability(boolean) and the
+     * path's PathStep state instead.
+     */
+    public Map<Integer, Set<Transport>> getTransports() {
+        return pathfinderConfig.getTransports();
     }
 
     /**
@@ -697,7 +709,7 @@ public class ShortestPathPlugin extends Plugin {
      * @param currentIndex The current index in the path
      * @return The display info of the POH exit transport, or null if not applicable
      */
-    public String getPohExitInfo(int destination, PrimitiveIntList path, int currentIndex) {
+    public String getPohExitInfo(int destination, List<PathStep> path, int currentIndex) {
         if (path == null || currentIndex < 0) {
             return null;
         }
@@ -715,8 +727,8 @@ public class ShortestPathPlugin extends Plugin {
 
         // Look ahead in the path to find the next transport that exits POH
         for (int i = currentIndex + 1; i < path.size() - 1; i++) {
-            int stepLocation = path.get(i);
-            int nextLocation = path.get(i + 1);
+            int stepLocation = path.get(i).getPackedPosition();
+            int nextLocation = path.get(i + 1).getPackedPosition();
             
             int stepX = WorldPointUtil.unpackWorldX(stepLocation);
             int stepY = WorldPointUtil.unpackWorldY(stepLocation);

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -1,12 +1,11 @@
 package shortestpath.pathfinder;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import shortestpath.WorldPointUtil;
 import shortestpath.transport.Transport;
+
 
 public class CollisionMap {
 
@@ -81,20 +80,43 @@ public class CollisionMap {
 
         neighbors.clear();
 
-        if (!config.isBankVisited() && config.getDestinations("bank").contains(node.packedPosition)) {
-            config.setBankVisited(true, node.packedPosition, wildernessLevel);
-        }
+        // Either we have already visited a bank, if the current tile is a bank switch into the bankVisited state for the
+        // rest of the path.
+        boolean pathBankVisited = node.bankVisited
+            || (config.isBankPathEnabled() && config.getDestinations("bank").contains(node.packedPosition));
 
-        @SuppressWarnings("unchecked") // Casting EMPTY_LIST to List<Transport> is safe here
-        Set<Transport> transports = config.getTransportsPacked().getOrDefault(node.packedPosition, (Set<Transport>)Collections.EMPTY_SET);
-
-        // Transports are pre-filtered by PathfinderConfig.refreshTransports
-        // Thus any transports in the list are guaranteed to be valid per the user's settings
+        // Firstly check if there are any transports or teleports which are applicable from the current tile.
+        Set<Transport> transports = config.getTransportsPacked(pathBankVisited).getOrDefault(node.packedPosition, Set.of());
         for (Transport transport : transports) {
-            if (visited.get(transport.getDestination())) continue;
-            neighbors.add(new TransportNode(transport.getDestination(), node, transport.getDuration(), config.getAdditionalTransportCost(transport)));
+            // Do not consider a transport if we have already visited its target tile.
+            if (visited.get(transport.getDestination(), pathBankVisited)) {
+                continue;
+            }
+            // NB: Do not need to check for wilderness level for transports, since transports have specific origin tile.
+            neighbors.add(new TransportNode(
+                transport.getDestination(),
+                node,
+                transport.getDuration(),
+                config.getAdditionalTransportCost(transport),
+                pathBankVisited));
         }
 
+        // MP: Future optimisation here, the path state should only consider using teleports at the first point they are available.
+        // On each iteration, the entire list of teleports is traversed to discover that we have already reached the destination.
+        for (Transport transport : config.getUsableTeleports(pathBankVisited)) {
+            if (visited.get(transport.getDestination(), pathBankVisited)) {
+                continue;
+            }
+            if (!transport.isUsableAtWildernessLevel(wildernessLevel)) { continue; }
+            neighbors.add(new TransportNode(
+                transport.getDestination(),
+                node,
+                transport.getDuration(),
+                config.getAdditionalTransportCost(transport),
+                pathBankVisited));
+        }
+
+        // Then add tiles which we can walk to, which go into the FIFO boundary queue.
         if (isBlocked(x, y, z)) {
             boolean westBlocked = isBlocked(x - 1, y, z);
             boolean eastBlocked = isBlocked(x + 1, y, z);
@@ -126,20 +148,21 @@ public class CollisionMap {
         for (int i = 0; i < traversable.length; i++) {
             OrdinalDirection d = ORDINAL_VALUES[i];
             int neighborPacked = packedPointFromOrdinal(node.packedPosition, d);
-            if (visited.get(neighborPacked)) continue;
+            if (visited.get(neighborPacked, pathBankVisited)) continue;
 
             if (traversable[i]) {
-                neighbors.add(new Node(neighborPacked, node));
+                neighbors.add(new Node(neighborPacked, node, Node.cost(neighborPacked, node), pathBankVisited));
             } else if (Math.abs(d.x + d.y) == 1 && isBlocked(x + d.x, y + d.y, z)) {
                 // The transport starts from a blocked adjacent tile, e.g. fairy ring
                 // Only checks non-teleport transports (includes portals and levers, but not items and spells)
-                @SuppressWarnings("unchecked") // Casting EMPTY_LIST to List<Transport> is safe here
-                Set<Transport> neighborTransports = config.getTransportsPacked().getOrDefault(neighborPacked, (Set<Transport>)Collections.EMPTY_SET);
+                Set<Transport> neighborTransports = config.getTransportsPacked(pathBankVisited).getOrDefault(neighborPacked, Set.of());
                 for (Transport transport : neighborTransports) {
-                    if (transport.getOrigin() == Transport.UNDEFINED_ORIGIN || visited.get(transport.getOrigin())) {
+                    if (transport.getOrigin() == Transport.UNDEFINED_ORIGIN
+                        || !(transport.isUsableAtWildernessLevel(wildernessLevel))
+                        || visited.get(transport.getOrigin(), pathBankVisited)) {
                         continue;
                     }
-                    neighbors.add(new Node(transport.getOrigin(), node));
+                    neighbors.add(new Node(transport.getOrigin(), node, Node.cost(transport.getOrigin(), node), pathBankVisited));
                 }
             }
         }

--- a/src/main/java/shortestpath/pathfinder/Node.java
+++ b/src/main/java/shortestpath/pathfinder/Node.java
@@ -1,24 +1,33 @@
 package shortestpath.pathfinder;
 
-import shortestpath.PrimitiveIntList;
+import java.util.ArrayList;
+import java.util.List;
 import shortestpath.WorldPointUtil;
 
 public class Node {
     public final int packedPosition;
     public final Node previous;
     public final int cost;
+    // bankVisited records whether we have already visited a bank on the current path.
+    public final boolean bankVisited;
 
+    // A constructor which propagates the previous Node's banked state at the new position.
     public Node(int packedPosition, Node previous, int cost) {
+        this(packedPosition, previous, cost, previous != null && previous.bankVisited);
+    }
+
+    public Node(int packedPosition, Node previous, int cost, boolean bankVisited) {
         this.packedPosition = packedPosition;
         this.previous = previous;
         this.cost = cost;
+        this.bankVisited = bankVisited;
     }
 
     public Node(int packedPosition, Node previous) {
         this(packedPosition, previous, cost(packedPosition, previous));
     }
 
-    public PrimitiveIntList getPath() {
+    public List<PathStep> getPathSteps() {
         Node node = this;
         int n = 0;
 
@@ -26,17 +35,22 @@ public class Node {
             node = node.previous;
             n++;
         }
-        PrimitiveIntList path = new PrimitiveIntList(n, true);
+
+        List<PathStep> pathSteps = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            pathSteps.add(null);
+        }
+
         node = this;
         while (node != null) {
-            path.set(--n, node.packedPosition);
+            pathSteps.set(--n, new PathStep(node.packedPosition, node.bankVisited));
             node = node.previous;
         }
 
-        return path;
+        return pathSteps;
     }
 
-    private static int cost(int packedPosition, Node previous) {
+    public static int cost(int packedPosition, Node previous) {
         int previousCost = 0;
         int travelTime = 0;
 

--- a/src/main/java/shortestpath/pathfinder/PathStep.java
+++ b/src/main/java/shortestpath/pathfinder/PathStep.java
@@ -1,0 +1,14 @@
+package shortestpath.pathfinder;
+
+import lombok.Getter;
+
+@Getter
+public final class PathStep {
+    private final int packedPosition;
+    private final boolean bankVisited;
+
+    public PathStep(int packedPosition, boolean bankVisited) {
+        this.packedPosition = packedPosition;
+        this.bankVisited = bankVisited;
+    }
+}

--- a/src/main/java/shortestpath/pathfinder/PathTerminationReason.java
+++ b/src/main/java/shortestpath/pathfinder/PathTerminationReason.java
@@ -1,0 +1,8 @@
+package shortestpath.pathfinder;
+
+public enum PathTerminationReason {
+    TARGET_REACHED,
+    SEARCH_EXHAUSTED,
+    CUTOFF_REACHED,
+    CANCELLED
+}

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -8,7 +8,6 @@ import java.util.Queue;
 import java.util.Set;
 import lombok.Getter;
 import shortestpath.PrimitiveIntList;
-import shortestpath.ShortestPathPlugin;
 import shortestpath.WorldPointUtil;
 
 public class Pathfinder implements Runnable {
@@ -22,10 +21,10 @@ public class Pathfinder implements Runnable {
     @Getter
     private final Set<Integer> targets;
 
-    private final ShortestPathPlugin plugin;
     private final PathfinderConfig config;
     private final CollisionMap map;
     private final boolean targetInWilderness;
+    private final Runnable completionCallback;
 
     // Capacities should be enough to store all nodes without requiring the queue to grow
     // They were found by checking the max queue size
@@ -46,16 +45,20 @@ public class Pathfinder implements Runnable {
      */
     private int wildernessLevel;
 
-    public Pathfinder(ShortestPathPlugin plugin, PathfinderConfig config, int start, Set<Integer> targets) {
+    public Pathfinder(PathfinderConfig config, int start, Set<Integer> targets, Runnable completionCallback) {
         stats = new PathfinderStats();
-        this.plugin = plugin;
         this.config = config;
         this.map = config.getMap();
         this.start = start;
         this.targets = targets;
+        this.completionCallback = completionCallback;
         visited = new VisitedTiles(map);
         targetInWilderness = WildernessChecker.isInWilderness(targets);
         wildernessLevel = 31;
+    }
+
+    public Pathfinder(PathfinderConfig config, int start, Set<Integer> targets) {
+        this(config, start, targets, null);
     }
 
     public void cancel() {
@@ -184,7 +187,9 @@ public class Pathfinder implements Runnable {
 
         stats.end(); // Include cleanup in stats to get the total cost of pathfinding
 
-        plugin.postPluginMessages();
+        if (completionCallback != null) {
+            completionCallback.run();
+        }
     }
 
     public static class PathfinderStats {

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -115,9 +115,7 @@ public class Pathfinder implements Runnable {
 
     private void addNeighbors(Node node) {
         List<Node> nodes = map.getNeighbors(node, visited, config, wildernessLevel);
-        for (int i = 0; i < nodes.size(); ++i) {
-            Node neighbor = nodes.get(i);
-
+        for (Node neighbor : nodes) {
             if (config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness)) {
                 continue;
             }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -35,6 +35,8 @@ public class Pathfinder implements Runnable {
     private PrimitiveIntList path = new PrimitiveIntList();
     private boolean pathNeedsUpdate = false;
     private Node bestLastNode;
+    private int reachedTarget = WorldPointUtil.UNDEFINED;
+    private PathTerminationReason terminationReason;
     /**
      * Teleportation transports are updated when this changes.
      * Can be either:
@@ -86,6 +88,29 @@ public class Pathfinder implements Runnable {
         }
 
         return path;
+    }
+
+    public PathfinderResult getResult() {
+        PathfinderStats currentStats = getStats();
+        if (currentStats == null) {
+            return null;
+        }
+
+        PrimitiveIntList currentPath = getPath();
+        boolean reached = reachedTarget != WorldPointUtil.UNDEFINED;
+        int target = reached ? reachedTarget : (targets.isEmpty() ? WorldPointUtil.UNDEFINED : targets.iterator().next());
+        int closestReachedPoint = bestLastNode != null ? bestLastNode.packedPosition : start;
+        return new PathfinderResult(
+            start,
+            target,
+            reached,
+            currentPath,
+            closestReachedPoint,
+            currentStats.getNodesChecked(),
+            currentStats.getTransportsChecked(),
+            currentStats.getElapsedTimeNanos(),
+            terminationReason
+        );
     }
 
     private void addNeighbors(Node node) {
@@ -157,6 +182,8 @@ public class Pathfinder implements Runnable {
             if (targets.contains(node.packedPosition)) {
                 bestLastNode = node;
                 pathNeedsUpdate = true;
+                reachedTarget = node.packedPosition;
+                terminationReason = PathTerminationReason.TARGET_REACHED;
                 break;
             }
 
@@ -173,10 +200,17 @@ public class Pathfinder implements Runnable {
             }
 
             if (System.currentTimeMillis() > cutoffTimeMillis) {
+                terminationReason = PathTerminationReason.CUTOFF_REACHED;
                 break;
             }
 
             addNeighbors(node);
+        }
+
+        if (cancelled) {
+            terminationReason = PathTerminationReason.CANCELLED;
+        } else if (terminationReason == null) {
+            terminationReason = PathTerminationReason.SEARCH_EXHAUSTED;
         }
 
         done = !cancelled;

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -7,7 +7,6 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import lombok.Getter;
-import shortestpath.PrimitiveIntList;
 import shortestpath.WorldPointUtil;
 
 public class Pathfinder implements Runnable {
@@ -32,7 +31,7 @@ public class Pathfinder implements Runnable {
     private final Queue<Node> pending = new PriorityQueue<>(256);
     private final VisitedTiles visited;
 
-    private PrimitiveIntList path = new PrimitiveIntList();
+    private List<PathStep> pathSteps = List.of();
     private boolean pathNeedsUpdate = false;
     private Node bestLastNode;
     private int reachedTarget = WorldPointUtil.UNDEFINED;
@@ -76,18 +75,18 @@ public class Pathfinder implements Runnable {
         return null;
     }
 
-    public PrimitiveIntList getPath() {
+    public List<PathStep> getPath() {
         Node lastNode = bestLastNode; // For thread safety, read bestLastNode once
         if (lastNode == null) {
-            return path;
+            return pathSteps;
         }
 
         if (pathNeedsUpdate) {
-            path = lastNode.getPath();
+            pathSteps = lastNode.getPathSteps();
             pathNeedsUpdate = false;
         }
 
-        return path;
+        return pathSteps;
     }
 
     public PathfinderResult getResult() {
@@ -96,7 +95,7 @@ public class Pathfinder implements Runnable {
             return null;
         }
 
-        PrimitiveIntList currentPath = getPath();
+        List<PathStep> currentPath = getPath();
         boolean reached = reachedTarget != WorldPointUtil.UNDEFINED;
         int target = reached ? reachedTarget : (targets.isEmpty() ? WorldPointUtil.UNDEFINED : targets.iterator().next());
         int closestReachedPoint = bestLastNode != null ? bestLastNode.packedPosition : start;
@@ -120,7 +119,7 @@ public class Pathfinder implements Runnable {
                 continue;
             }
 
-            visited.set(neighbor.packedPosition);
+            visited.set(neighbor.packedPosition, neighbor.bankVisited);
             if (neighbor instanceof TransportNode) {
                 pending.add(neighbor);
                 ++stats.transportsChecked;
@@ -134,7 +133,7 @@ public class Pathfinder implements Runnable {
     @Override
     public void run() {
         stats.start();
-        boundary.addFirst(new Node(start, null));
+        boundary.addFirst(new Node(start, null, 0, false));
 
         int bestDistance = Integer.MAX_VALUE;
         long bestHeuristic = Integer.MAX_VALUE;
@@ -156,24 +155,16 @@ public class Pathfinder implements Runnable {
                 // because the teleport is either used at the very start of the
                 // path or when going from 31 or higher to 30, or from 21 or higher to 20.
 
-                boolean update = false;
-
                 // These are overlapping boundaries, so if the node isn't in level 30, it's in 0-29
                 // likewise, if the node isn't in level 20, it's in 0-19
                 if (wildernessLevel > 30 && !WildernessChecker.isInLevel30Wilderness(node.packedPosition)) {
                     wildernessLevel = 30;
-                    update = true;
                 }
                 if (wildernessLevel > 20 && !WildernessChecker.isInLevel20Wilderness(node.packedPosition)) {
                     wildernessLevel = 20;
-                    update = true;
                 }
                 if (wildernessLevel > 0 && !WildernessChecker.isInWilderness(node.packedPosition)) {
                     wildernessLevel = 0;
-                    update = true;
-                }
-                if (update) {
-                    config.refreshTeleports(node.packedPosition, wildernessLevel);
                 }
             }
 

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -65,17 +65,19 @@ public class PathfinderConfig {
      * All transports by origin. The WorldPointUtil.UNDEFINED key is used for transports centered on the player.
      */
     private final Map<Integer, Set<Transport>> allTransports;
-    private final Set<Transport> usableTeleports;
     private final Map<String, Set<Integer>> allDestinations;
     private final Map<String, Set<Integer>> filteredDestinations;
     private final Map<Integer, Integer> itemsAndQuantities = new HashMap<>(28 + 11 + 500);
     private final List<Integer> filteredTargets = new ArrayList<>(4);
 
-    @Getter
-    private final Map<Integer, Set<Transport>> transports;
-    // Copy of transports with packed positions for the hotpath; lists are not copied and are the same reference in both maps
-    @Getter
-    private final PrimitiveIntHashMap<Set<Transport>> transportsPacked;
+    /*
+     * Which transports are available for the current user configuration in the
+     * unbanked/banked state.
+     *  - transportAvailabilityWithoutBank answers the question, which transport can a player take right now?
+     *  - transportAvailabilityWithBank answers the question, which transports can a player take if they visit a bank?
+     */
+    private TransportAvailability transportAvailabilityWithoutBank;
+    private TransportAvailability transportAvailabilityWithBank;
     /**
      * Reference that points to either allDestinations or filteredDestinations
      */
@@ -88,8 +90,6 @@ public class PathfinderConfig {
     private long calculationCutoffMillis;
     @Getter
     private boolean avoidWilderness;
-    @Getter
-    private boolean bankVisited;
 
     // Centralized transport type enable/disable config
     private final TransportTypeConfig transportTypeConfig;
@@ -120,9 +120,8 @@ public class PathfinderConfig {
         this.map = ThreadLocal.withInitial(() -> new CollisionMap(mapData));
         this.allTransports = TransportLoader.loadAllFromResources();
         remapPohDestinations();
-        this.usableTeleports = new HashSet<>(allTransports.size() / 20);
-        this.transports = new HashMap<>(allTransports.size() / 2);
-        this.transportsPacked = new PrimitiveIntHashMap<>(allTransports.size() / 2);
+        this.transportAvailabilityWithoutBank = new TransportAvailability.Builder(allTransports.size()).build();
+        this.transportAvailabilityWithBank = new TransportAvailability.Builder(allTransports.size()).build();
         this.allDestinations = Destination.loadAllFromResources();
         this.filteredDestinations = filterDestinations(allDestinations);
         this.destinations = allDestinations;
@@ -130,6 +129,36 @@ public class PathfinderConfig {
 
     public CollisionMap getMap() {
         return map.get();
+    }
+
+    /**
+     * WARNING: This method collapses the banked/unbanked transport distinction into a single view.
+     *
+     * It exists only for legacy display-oriented callers such as overlays which want a coarse
+     * "currently relevant" set of transports to render. It must not be used for path-state-sensitive
+     * logic, because transport availability now depends on whether a path has visited a bank.
+     *
+     * Use {@link #getTransportAvailability(boolean)}, {@link #getTransportsPacked(boolean)}, or
+     * {@link #getUsableTeleports(boolean)} for pathfinding and path analysis code.
+     */
+    public Map<Integer, Set<Transport>> getTransports() {
+        return getTransportAvailability(includeBankPath).getTransportsByOrigin();
+    }
+
+    public PrimitiveIntHashMap<Set<Transport>> getTransportsPacked(boolean bankVisited) {
+        return getTransportAvailability(bankVisited).getTransportsPacked();
+    }
+
+    public Set<Transport> getUsableTeleports(boolean bankVisited) {
+        return getTransportAvailability(bankVisited).getUsableTeleports();
+    }
+
+    public TransportAvailability getTransportAvailability(boolean bankVisited) {
+        return bankVisited ? transportAvailabilityWithBank : transportAvailabilityWithoutBank;
+    }
+
+    public boolean isBankPathEnabled() {
+        return includeBankPath;
     }
 
     public boolean hasDestination(String destinationType) {
@@ -157,7 +186,6 @@ public class PathfinderConfig {
         // Other settings (useTeleportationItems is now managed by transportTypeConfig)
         currencyThreshold = ShortestPathPlugin.override("currencyThreshold", config.currencyThreshold());
         includeBankPath = ShortestPathPlugin.override("includeBankPath", config.includeBankPath());
-        bankVisited = !includeBankPath;
 
         // Note: Transport type costs are now managed by transportTypeConfig.getCost()
         costConsumableTeleportationItems = ShortestPathPlugin.override("costConsumableTeleportationItems", config.costConsumableTeleportationItems());
@@ -175,26 +203,6 @@ public class PathfinderConfig {
         }
 
         refreshDestinations();
-    }
-
-    /**
-     * Specialized method for only updating player-held item and spell transports
-     */
-    public void refreshTeleports(int packedLocation, int wildernessLevel) {
-        Set<Transport> usableWildyTeleports = new HashSet<>(usableTeleports.size());
-
-        for (Transport teleport : usableTeleports) {
-            if (wildernessLevel <= teleport.getMaxWildernessLevel()) {
-                usableWildyTeleports.add(teleport);
-            }
-        }
-
-        if (!usableWildyTeleports.isEmpty()) {
-            Set<Transport> oldTransports = transports.getOrDefault(packedLocation, new HashSet<>());
-            oldTransports.addAll(usableWildyTeleports);
-            transports.put(packedLocation, oldTransports);
-            transportsPacked.put(packedLocation, usableWildyTeleports); // appends for collections
-        }
     }
 
     private void refreshDestinations() {
@@ -262,11 +270,9 @@ public class PathfinderConfig {
             return; // Has to run on the client thread; data will be refreshed when path finding commences
         }
 
-        // Apply runtime restrictions based on quests/items
+        // Fairy ring staff/diary requirements are enforced later in hasRequiredItems().
         transportTypeConfig.disableUnless(TransportType.FAIRY_RING,
-                client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST) > 39
-                        && (client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE) == 1
-                        || hasRequiredItems(DRAMEN_STAFF, true, true, false, false)));
+                client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST) > 39);
         transportTypeConfig.disableUnless(TransportType.GNOME_GLIDER,
                 QuestState.FINISHED.equals(getQuestState(Quest.THE_GRAND_TREE)));
         transportTypeConfig.disableUnless(TransportType.MAGIC_MUSHTREE,
@@ -274,12 +280,9 @@ public class PathfinderConfig {
         transportTypeConfig.disableUnless(TransportType.SPIRIT_TREE,
                 QuestState.FINISHED.equals(getQuestState(Quest.TREE_GNOME_VILLAGE)));
 
-        transports.clear();
-        transportsPacked.clear();
-        usableTeleports.clear();
+        TransportAvailability.Builder withoutBank = new TransportAvailability.Builder(allTransports.size());
+        TransportAvailability.Builder withBank = new TransportAvailability.Builder(allTransports.size());
         for (Map.Entry<Integer, Set<Transport>> entry : allTransports.entrySet()) {
-            int point = entry.getKey();
-            Set<Transport> usableTransports = new HashSet<>(entry.getValue().size());
             for (Transport transport : entry.getValue()) {
                 for (Quest quest : transport.getQuests()) {
                     try {
@@ -296,37 +299,25 @@ public class PathfinderConfig {
                     }
                 }
 
-                if (useTransport(transport) && hasRequiredItems(transport)) {
-                    if (point == WorldPointUtil.UNDEFINED) {
-                        usableTeleports.add(transport);
-                    } else {
-                        usableTransports.add(transport);
-                    }
+                if (!useTransport(transport)) {
+                    continue;
                 }
-            }
 
-            if (point != WorldPointUtil.UNDEFINED && !usableTransports.isEmpty()) {
-                transports.put(point, usableTransports);
-                transportsPacked.put(point, usableTransports);
-            }
-        }
-
-        // Remap all POH transport origins to the house landing tile
-        remapPohTransports();
-    }
-
-    private void refreshUsableTeleports() {
-        // Only for appending and not for removing teleports
-        for (Map.Entry<Integer, Set<Transport>> entry : allTransports.entrySet()) {
-            if (entry.getKey() == WorldPointUtil.UNDEFINED) { // is a teleport
-                for (Transport transport : entry.getValue()) {
-                    if (useTransport(transport)
-                            && hasRequiredItems(transport, false, false, true, false)) {
-                        usableTeleports.add(transport);
-                    }
+                boolean usableWithoutBank = hasRequiredItems(transport, true, true, false, true);
+                boolean usableWithBank = hasRequiredItems(transport, true, true, includeBankPath, true);
+                if (usableWithoutBank) {
+                    withoutBank.add(transport);
+                }
+                if (usableWithBank) {
+                    withBank.add(transport);
                 }
             }
         }
+
+        withoutBank.remapPohTransports();
+        withBank.remapPohTransports();
+        transportAvailabilityWithoutBank = withoutBank.build();
+        transportAvailabilityWithBank = withBank.build();
     }
 
     public boolean avoidWilderness(int packedPosition, int packedNeighborPosition, boolean targetInWilderness) {
@@ -334,14 +325,6 @@ public class PathfinderConfig {
                 && !targetInWilderness
                 && !WildernessChecker.isInWilderness(packedPosition)
                 && WildernessChecker.isInWilderness(packedNeighborPosition);
-    }
-
-    public void setBankVisited(boolean visited, int packedLocation, int wildernessLevel) {
-        bankVisited = visited;
-        if (bankVisited) {
-            refreshUsableTeleports();
-            refreshTeleports(packedLocation, wildernessLevel);
-        }
     }
 
     /**
@@ -361,40 +344,6 @@ public class PathfinderConfig {
                     transport.setDestination(pohLanding);
                 }
             }
-        }
-    }
-
-    /**
-     * Remaps POH transport origins to the house landing tile.
-     * Extracted to be reusable by both refreshTransports and refreshTransportsForBankVisit.
-     */
-    private void remapPohTransports() {
-        int pohLanding = WorldPointUtil.packWorldPoint(1923, 5709, 0);
-        Set<Transport> pohTransports = new HashSet<>();
-        Set<Integer> pohOriginsToRemove = new HashSet<>();
-
-        for (Map.Entry<Integer, Set<Transport>> entry : transports.entrySet()) {
-            int origin = entry.getKey();
-            int originX = WorldPointUtil.unpackWorldX(origin);
-            int originY = WorldPointUtil.unpackWorldY(origin);
-            if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
-                pohTransports.addAll(entry.getValue());
-                pohOriginsToRemove.add(origin);
-            }
-        }
-
-        // Remove POH origins from transports map (PrimitiveIntHashMap doesn't support remove)
-        for (Integer origin : pohOriginsToRemove) {
-            transports.remove(origin);
-        }
-
-        if (!pohTransports.isEmpty()) {
-            Set<Transport> existingPohTransports = transports.getOrDefault(pohLanding, new HashSet<>());
-            existingPohTransports.addAll(pohTransports);
-            transports.put(pohLanding, existingPohTransports);
-
-            // Also update transportsPacked for the landing tile
-            transportsPacked.put(pohLanding, existingPohTransports);
         }
     }
 
@@ -712,7 +661,7 @@ public class PathfinderConfig {
 
         if (checkBank) {
             TeleportationItem teleportSetting = transportTypeConfig.getTeleportationItemSetting();
-            if (bank != null && bankVisited
+            if (bank != null
                     && (TeleportationItem.INVENTORY_AND_BANK.equals(teleportSetting)
                     || TeleportationItem.INVENTORY_AND_BANK_NON_CONSUMABLE.equals(teleportSetting))) {
                 for (Item item : bank.getItems()) {
@@ -820,4 +769,3 @@ public class PathfinderConfig {
         return availableSpiritTrees.contains(treeName);
     }
 }
-

--- a/src/main/java/shortestpath/pathfinder/PathfinderResult.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderResult.java
@@ -1,14 +1,14 @@
 package shortestpath.pathfinder;
 
 import lombok.Getter;
-import shortestpath.PrimitiveIntList;
+import java.util.List;
 
 @Getter
 public class PathfinderResult {
     private final int start;
     private final int target;
     private final boolean reached;
-    private final PrimitiveIntList path;
+    private final List<PathStep> pathSteps;
     private final int closestReachedPoint;
     private final int nodesChecked;
     private final int transportsChecked;
@@ -19,7 +19,7 @@ public class PathfinderResult {
         int start,
         int target,
         boolean reached,
-        PrimitiveIntList path,
+        List<PathStep> pathSteps,
         int closestReachedPoint,
         int nodesChecked,
         int transportsChecked,
@@ -29,7 +29,7 @@ public class PathfinderResult {
         this.start = start;
         this.target = target;
         this.reached = reached;
-        this.path = path;
+        this.pathSteps = pathSteps;
         this.closestReachedPoint = closestReachedPoint;
         this.nodesChecked = nodesChecked;
         this.transportsChecked = transportsChecked;

--- a/src/main/java/shortestpath/pathfinder/PathfinderResult.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderResult.java
@@ -1,0 +1,39 @@
+package shortestpath.pathfinder;
+
+import lombok.Getter;
+import shortestpath.PrimitiveIntList;
+
+@Getter
+public class PathfinderResult {
+    private final int start;
+    private final int target;
+    private final boolean reached;
+    private final PrimitiveIntList path;
+    private final int closestReachedPoint;
+    private final int nodesChecked;
+    private final int transportsChecked;
+    private final long elapsedNanos;
+    private final PathTerminationReason terminationReason;
+
+    public PathfinderResult(
+        int start,
+        int target,
+        boolean reached,
+        PrimitiveIntList path,
+        int closestReachedPoint,
+        int nodesChecked,
+        int transportsChecked,
+        long elapsedNanos,
+        PathTerminationReason terminationReason
+    ) {
+        this.start = start;
+        this.target = target;
+        this.reached = reached;
+        this.path = path;
+        this.closestReachedPoint = closestReachedPoint;
+        this.nodesChecked = nodesChecked;
+        this.transportsChecked = transportsChecked;
+        this.elapsedNanos = elapsedNanos;
+        this.terminationReason = terminationReason;
+    }
+}

--- a/src/main/java/shortestpath/pathfinder/TransportAvailability.java
+++ b/src/main/java/shortestpath/pathfinder/TransportAvailability.java
@@ -1,0 +1,90 @@
+package shortestpath.pathfinder;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import lombok.Getter;
+import shortestpath.PrimitiveIntHashMap;
+import shortestpath.WorldPointUtil;
+import shortestpath.transport.Transport;
+
+@Getter
+public final class TransportAvailability {
+    private final Map<Integer, Set<Transport>> transportsByOrigin;
+    private final PrimitiveIntHashMap<Set<Transport>> transportsPacked;
+    private final Set<Transport> usableTeleports;
+
+    TransportAvailability(
+        Map<Integer, Set<Transport>> transportsByOrigin,
+        PrimitiveIntHashMap<Set<Transport>> transportsPacked,
+        Set<Transport> usableTeleports
+    ) {
+        this.transportsByOrigin = transportsByOrigin;
+        this.transportsPacked = transportsPacked;
+        this.usableTeleports = usableTeleports;
+    }
+
+    public Set<Transport> getTransportsAt(int origin) {
+        return transportsPacked.getOrDefault(origin, Set.of());
+    }
+
+    /*
+     * Build a TransportAvailability by incrementally adding available transports.
+     */
+    static final class Builder {
+        private final Map<Integer, Set<Transport>> transportsByOrigin;
+        private final PrimitiveIntHashMap<Set<Transport>> transportsPacked;
+        private final Set<Transport> usableTeleports;
+
+        Builder(int expectedTransportCount) {
+            this.transportsByOrigin = new HashMap<>(expectedTransportCount / 2);
+            this.transportsPacked = new PrimitiveIntHashMap<>(expectedTransportCount / 2);
+            this.usableTeleports = new HashSet<>(expectedTransportCount / 20);
+        }
+
+        void add(Transport transport) {
+            if (transport.getOrigin() == WorldPointUtil.UNDEFINED) {
+                usableTeleports.add(transport);
+                return;
+            }
+
+            int origin = transport.getOrigin();
+            Set<Transport> transportsAtOrigin = transportsByOrigin.computeIfAbsent(origin, ignored -> new HashSet<>());
+            transportsAtOrigin.add(transport);
+            transportsPacked.put(origin, transportsAtOrigin);
+        }
+
+        void remapPohTransports() {
+            int pohLanding = WorldPointUtil.packWorldPoint(1923, 5709, 0);
+            Set<Transport> pohTransports = new HashSet<>();
+            Set<Integer> pohOriginsToRemove = new HashSet<>();
+
+            for (Map.Entry<Integer, Set<Transport>> entry : transportsByOrigin.entrySet()) {
+                int origin = entry.getKey();
+                int originX = WorldPointUtil.unpackWorldX(origin);
+                int originY = WorldPointUtil.unpackWorldY(origin);
+                if (shortestpath.ShortestPathPlugin.isInsidePoh(originX, originY)) {
+                    pohTransports.addAll(entry.getValue());
+                    pohOriginsToRemove.add(origin);
+                }
+            }
+
+            for (Integer origin : pohOriginsToRemove) {
+                transportsByOrigin.remove(origin);
+            }
+
+            if (!pohTransports.isEmpty()) {
+                Set<Transport> existingPohTransports = transportsByOrigin.getOrDefault(pohLanding, new HashSet<>());
+                existingPohTransports.addAll(pohTransports);
+                transportsByOrigin.put(pohLanding, existingPohTransports);
+                transportsPacked.put(pohLanding, existingPohTransports);
+            }
+        }
+
+        TransportAvailability build() {
+            return new TransportAvailability(transportsByOrigin, transportsPacked, usableTeleports);
+        }
+    }
+}

--- a/src/main/java/shortestpath/pathfinder/TransportNode.java
+++ b/src/main/java/shortestpath/pathfinder/TransportNode.java
@@ -2,7 +2,11 @@ package shortestpath.pathfinder;
 
 public class TransportNode extends Node implements Comparable<TransportNode> {
     public TransportNode(int packedPosition, Node previous, int travelTime, int additionalCost) {
-        super(packedPosition, previous, cost(previous, travelTime + additionalCost));
+        this(packedPosition, previous, travelTime, additionalCost, previous != null && previous.bankVisited);
+    }
+
+    public TransportNode(int packedPosition, Node previous, int travelTime, int additionalCost, boolean bankVisited) {
+        super(packedPosition, previous, cost(previous, travelTime + additionalCost), bankVisited);
     }
 
     private static int cost(Node previous, int travelTime) {

--- a/src/main/java/shortestpath/pathfinder/VisitedTiles.java
+++ b/src/main/java/shortestpath/pathfinder/VisitedTiles.java
@@ -7,7 +7,8 @@ public class VisitedTiles {
     private final SplitFlagMap.RegionExtent regionExtents;
     private final int widthInclusive;
 
-    private final VisitedRegion[] visitedRegions;
+    private final VisitedRegion[] visitedRegionsWithoutBank;
+    private final VisitedRegion[] visitedRegionsWithBank;
     private final byte[] visitedRegionPlanes;
 
     public VisitedTiles(CollisionMap map) {
@@ -15,18 +16,20 @@ public class VisitedTiles {
         widthInclusive = regionExtents.getWidth() + 1;
         final int heightInclusive = regionExtents.getHeight() + 1;
 
-        visitedRegions = new VisitedRegion[widthInclusive * heightInclusive];
+        visitedRegionsWithoutBank = new VisitedRegion[widthInclusive * heightInclusive];
+        visitedRegionsWithBank = new VisitedRegion[widthInclusive * heightInclusive];
         visitedRegionPlanes = map.getPlanes();
     }
 
-    public boolean get(int packedPoint) {
+    public boolean get(int packedPoint, boolean bankVisited) {
         final int x = WorldPointUtil.unpackWorldX(packedPoint);
         final int y = WorldPointUtil.unpackWorldY(packedPoint);
         final int plane = WorldPointUtil.unpackWorldPlane(packedPoint);
-        return get(x, y, plane);
+        return get(x, y, plane, bankVisited);
     }
 
-    public boolean get(int x, int y, int plane) {
+    public boolean get(int x, int y, int plane, boolean bankVisited) {
+        VisitedRegion[] visitedRegions = bankVisited ? visitedRegionsWithBank : visitedRegionsWithoutBank;
         final int regionIndex = getRegionIndex(x / REGION_SIZE, y / REGION_SIZE);
         if (regionIndex < 0 || regionIndex >= visitedRegions.length) {
             return true; // Region is out of bounds; report that it's been visited to avoid exploring it further
@@ -40,14 +43,15 @@ public class VisitedTiles {
         return region.get(x % REGION_SIZE, y % REGION_SIZE, plane);
     }
 
-    public boolean set(int packedPoint) {
+    public boolean set(int packedPoint, boolean bankVisited) {
         final int x = WorldPointUtil.unpackWorldX(packedPoint);
         final int y = WorldPointUtil.unpackWorldY(packedPoint);
         final int plane = WorldPointUtil.unpackWorldPlane(packedPoint);
-        return set(x, y, plane);
+        return set(x, y, plane, bankVisited);
     }
 
-    public boolean set(int x, int y, int plane) {
+    public boolean set(int x, int y, int plane, boolean bankVisited) {
+        VisitedRegion[] visitedRegions = bankVisited ? visitedRegionsWithBank : visitedRegionsWithoutBank;
         final int regionIndex = getRegionIndex(x / REGION_SIZE, y / REGION_SIZE);
         if (regionIndex < 0 || regionIndex >= visitedRegions.length) {
             return false; // Region is out of bounds; report that it's been visited to avoid exploring it further
@@ -63,10 +67,9 @@ public class VisitedTiles {
     }
 
     public void clear() {
-        for (int i = 0; i < visitedRegions.length; ++i) {
-            if (visitedRegions[i] != null) {
-                visitedRegions[i] = null;
-            }
+        for (int i = 0; i < visitedRegionsWithoutBank.length; ++i) {
+            visitedRegionsWithoutBank[i] = null;
+            visitedRegionsWithBank[i] = null;
         }
     }
 

--- a/src/main/java/shortestpath/transport/BankPickupRequirements.java
+++ b/src/main/java/shortestpath/transport/BankPickupRequirements.java
@@ -1,0 +1,184 @@
+package shortestpath.transport;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.gameval.InventoryID;
+import shortestpath.ItemVariations;
+import shortestpath.pathfinder.PathStep;
+
+/**
+ * Determines what items need to be picked up from the bank for a given path.
+ * This handles transport-specific requirements like the Dramen staff for fairy rings.
+ */
+public class BankPickupRequirements {
+
+    /**
+     * Gets a list of items that need to be picked up from the bank at a given path step.
+     *
+     * @param client The game client
+     * @param bank The bank ItemContainer
+     * @param transports Map of transports by origin location
+     * @param bankLocations Set of bank location coordinates
+     * @param path The current path
+     * @param pathIndex The current step index in the path
+     * @return List of item names to pick up, or empty list if none needed
+     */
+    public static List<String> getRequiredBankItems(
+            Client client,
+            ItemContainer bank,
+            Map<Integer, Set<Transport>> transports,
+            Set<Integer> bankLocations,
+            List<PathStep> path,
+            int pathIndex) {
+
+        List<String> requiredItems = new ArrayList<>();
+
+        if (bank == null || path == null || pathIndex < 0 || pathIndex >= path.size()) {
+            return requiredItems;
+        }
+
+        // Check if this is a bank step
+        int currentPoint = path.get(pathIndex).getPackedPosition();
+        if (!bankLocations.contains(currentPoint)) {
+            return requiredItems;
+        }
+
+        // Check what transports are used after this bank step
+        boolean usesFairyRing = false;
+        boolean usesTeleportItem = false;
+        Transport teleportTransport = null;
+
+        for (int i = pathIndex; i < path.size() - 1; i++) {
+            int stepPoint = path.get(i).getPackedPosition();
+            int nextPoint = path.get(i + 1).getPackedPosition();
+            Set<Transport> stepTransports = transports.get(stepPoint);
+            if (stepTransports != null) {
+                for (Transport t : stepTransports) {
+                    if (t.getDestination() == nextPoint) {
+                        if (TransportType.FAIRY_RING.equals(t.getType())) {
+                            usesFairyRing = true;
+                        }
+                        if (TransportType.TELEPORTATION_ITEM.equals(t.getType()) && teleportTransport == null) {
+                            usesTeleportItem = true;
+                            teleportTransport = t;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check if Dramen/Lunar staff needs to be picked up for fairy rings
+        if (usesFairyRing) {
+            String staffPickup = checkDramenStaffInBank(client, bank);
+            if (staffPickup != null) {
+                requiredItems.add(staffPickup);
+            }
+        }
+
+        // Check if teleport item needs to be picked up
+        if (usesTeleportItem && teleportTransport != null) {
+            String teleportPickup = checkTeleportItemInBank(client, bank, teleportTransport);
+            if (teleportPickup != null) {
+                requiredItems.add(teleportPickup);
+            }
+        }
+
+        return requiredItems;
+    }
+
+    /**
+     * Checks if the Dramen/Lunar staff is in the bank and not in inventory/equipment.
+     */
+    private static String checkDramenStaffInBank(Client client, ItemContainer bank) {
+        int[] staffIds = ItemVariations.DRAMEN_STAFF.getIds();
+
+        // Check if already in inventory or equipment
+        if (hasItemInInventoryOrEquipment(client, staffIds)) {
+            return null;
+        }
+
+        // Check if in bank
+        if (hasItemInBank(bank, staffIds)) {
+            return "Dramen/Lunar staff";
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if a teleport item is in the bank and not in inventory/equipment.
+     */
+    private static String checkTeleportItemInBank(Client client, ItemContainer bank, Transport transport) {
+        if (transport.getItemRequirements() == null || transport.getItemRequirements().size() == 0) {
+            return null;
+        }
+
+        // Get the first item requirement (the teleport item itself)
+        int[] teleportItemIds = transport.getItemRequirements().getRequirements().get(0).getItemIds();
+        if (teleportItemIds == null || teleportItemIds.length == 0) {
+            return null;
+        }
+
+        // Check if already in inventory or equipment
+        if (hasItemInInventoryOrEquipment(client, teleportItemIds)) {
+            return null;
+        }
+
+        // Check if in bank
+        if (hasItemInBank(bank, teleportItemIds)) {
+            String displayInfo = transport.getDisplayInfo();
+            if (displayInfo != null) {
+                // Extract just the item name (before the colon)
+                int colonIndex = displayInfo.indexOf(':');
+                if (colonIndex > 0) {
+                    return displayInfo.substring(0, colonIndex).trim();
+                }
+                return displayInfo;
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean hasItemInInventoryOrEquipment(Client client, int[] itemIds) {
+        ItemContainer inventory = client.getItemContainer(InventoryID.INV);
+        if (inventory != null) {
+            for (Item item : inventory.getItems()) {
+                for (int itemId : itemIds) {
+                    if (item.getId() == itemId) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
+        if (equipment != null) {
+            for (Item item : equipment.getItems()) {
+                for (int itemId : itemIds) {
+                    if (item.getId() == itemId) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean hasItemInBank(ItemContainer bank, int[] itemIds) {
+        for (Item bankItem : bank.getItems()) {
+            for (int itemId : itemIds) {
+                if (bankItem.getId() == itemId && bankItem.getQuantity() > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/shortestpath/transport/Transport.java
+++ b/src/main/java/shortestpath/transport/Transport.java
@@ -205,6 +205,13 @@ public class Transport {
     }
 
     /**
+     * Whether this transport can be used at the given wilderness level.
+     */
+    public boolean isUsableAtWildernessLevel(int wildernessLevel) {
+        return !type.isTeleport() || wildernessLevel <= maxWildernessLevel;
+    }
+
+    /**
      * Gets varbit requirements (filtered from varRequirements).
      * For backward compatibility with code that needs separate varbit access.
      */

--- a/src/test/java/shortestpath/TestShortestPathConfig.java
+++ b/src/test/java/shortestpath/TestShortestPathConfig.java
@@ -1,0 +1,46 @@
+package shortestpath;
+
+public class TestShortestPathConfig implements ShortestPathConfig {
+    private int calculationCutoff = 5;
+    private TeleportationItem useTeleportationItems = TeleportationItem.INVENTORY_NON_CONSUMABLE;
+    private String builtTeleportationBoxes = "";
+    private String builtTeleportationPortalsPoh = "";
+
+    public void setCalculationCutoffValue(int calculationCutoff) {
+        this.calculationCutoff = calculationCutoff;
+    }
+
+    @Override
+    public int calculationCutoff() {
+        return calculationCutoff;
+    }
+
+    public void setUseTeleportationItemsValue(TeleportationItem useTeleportationItems) {
+        this.useTeleportationItems = useTeleportationItems;
+    }
+
+    @Override
+    public TeleportationItem useTeleportationItems() {
+        return useTeleportationItems;
+    }
+
+    @Override
+    public void setBuiltTeleportationBoxes(String content) {
+        builtTeleportationBoxes = content;
+    }
+
+    @Override
+    public String builtTeleportationBoxes() {
+        return builtTeleportationBoxes;
+    }
+
+    @Override
+    public void setBuiltTeleportationPortalsPoh(String content) {
+        builtTeleportationPortalsPoh = content;
+    }
+
+    @Override
+    public String builtTeleportationPortalsPoh() {
+        return builtTeleportationPortalsPoh;
+    }
+}

--- a/src/test/java/shortestpath/pathfinder/PathfinderResultTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderResultTest.java
@@ -1,0 +1,58 @@
+package shortestpath.pathfinder;
+
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Skill;
+import org.junit.Test;
+import shortestpath.TeleportationItem;
+import shortestpath.TestShortestPathConfig;
+import shortestpath.WorldPointUtil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PathfinderResultTest {
+    @Test
+    public void reachedTargetProducesReachedResult() {
+        Pathfinder pathfinder = new Pathfinder(configWithCutoff(100), point(3200, 3200), Set.of(point(3201, 3200)));
+
+        pathfinder.run();
+        PathfinderResult result = pathfinder.getResult();
+
+        assertTrue(result.isReached());
+        assertEquals(PathTerminationReason.TARGET_REACHED, result.getTerminationReason());
+    }
+
+    @Test
+    public void zeroCutoffProducesCutoffResult() {
+        Pathfinder pathfinder = new Pathfinder(configWithCutoff(0), point(3200, 3200), Set.of(point(3300, 3300)));
+
+        pathfinder.run();
+        PathfinderResult result = pathfinder.getResult();
+
+        assertEquals(PathTerminationReason.CUTOFF_REACHED, result.getTerminationReason());
+    }
+
+    private static PathfinderConfig configWithCutoff(int cutoffTicks) {
+        Client client = mock(Client.class);
+        TestShortestPathConfig config = new TestShortestPathConfig();
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.getClientThread()).thenReturn(Thread.currentThread());
+        when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+        when(client.getTotalLevel()).thenReturn(2277);
+        config.setCalculationCutoffValue(cutoffTicks);
+        config.setUseTeleportationItemsValue(TeleportationItem.ALL);
+
+        PathfinderConfig pathfinderConfig = new TestPathfinderConfig(client, config);
+        pathfinderConfig.refresh();
+        return pathfinderConfig;
+    }
+
+    private static int point(int x, int y) {
+        return WorldPointUtil.packWorldPoint(x, y, 0);
+    }
+}

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -3,14 +3,13 @@ package shortestpath.pathfinder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
-import net.runelite.api.Quest;
 import net.runelite.api.QuestState;
 import net.runelite.api.Skill;
 import org.junit.Before;
@@ -20,10 +19,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import shortestpath.ItemVariations;
-import shortestpath.ShortestPathConfig;
 import shortestpath.ShortestPathPlugin;
 import shortestpath.TeleportationItem;
 import shortestpath.WorldPointUtil;
+import shortestpath.ShortestPathConfig;
 import shortestpath.transport.Transport;
 import shortestpath.transport.requirement.TransportItems;
 import shortestpath.transport.TransportLoader;
@@ -34,7 +33,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -563,22 +561,36 @@ public class PathfinderTest {
         }
     }
 
+    // Setup a configuration with
+    // * A fixed QuestState for all quests
+    // * A fixed skill level for all skills
+    // * A toggle about wheher to use teleportation items.
     private void setupConfig(QuestState questState, int skillLevel, TeleportationItem useTeleportationItems) {
-        pathfinderConfig = spy(new PathfinderConfig(client, config));
+        // NOTE: Not mocked since PathfinderConfig is repeatedly queried in the hot loop.
+        pathfinderConfig = new TestPathfinderConfig(client, config, questState
+                                                                  , true // Ignore Varbit checks
+                                                                  , true // Ignore Varplayer checks
+                                                                  );
 
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
         when(client.getClientThread()).thenReturn(Thread.currentThread());
         when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(skillLevel);
         when(config.useTeleportationItems()).thenReturn(useTeleportationItems);
-        doReturn(true).when(pathfinderConfig).varbitChecks(any(Transport.class));
-        doReturn(true).when(pathfinderConfig).varPlayerChecks(any(Transport.class));
-        doReturn(questState).when(pathfinderConfig).getQuestState(any(Quest.class));
 
         pathfinderConfig.refresh();
     }
 
+    // Setup a configuration with
+    // * A fixed QuestState for all quests
+    // * A fixed skill level for all skills
+    // * A toggle about wheher to use teleportation items.
+    // * Fixed set of varbit values
     private void setupConfig(QuestState questState, int skillLevel, TeleportationItem useTeleportationItems, Map<Integer, Integer> varbitValues) {
-        pathfinderConfig = spy(new PathfinderConfig(client, config));
+        // NOTE: Not mocked since PathfinderConfig is repeatedly queried in the hot loop.
+        pathfinderConfig = new TestPathfinderConfig(client, config, questState
+                                                                  , false // Use proper varbit checking
+                                                                  , true  // Ignore varplayer checks
+                                                                  );
 
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
         when(client.getClientThread()).thenReturn(Thread.currentThread());
@@ -587,8 +599,6 @@ public class PathfinderTest {
         for (Map.Entry<Integer, Integer> entry : varbitValues.entrySet()) {
             when(client.getVarbitValue(entry.getKey())).thenReturn(entry.getValue());
         }
-        doReturn(true).when(pathfinderConfig).varPlayerChecks(any(Transport.class));
-        doReturn(questState).when(pathfinderConfig).getQuestState(any(Quest.class));
 
         pathfinderConfig.refresh();
     }

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import shortestpath.ItemVariations;
-import shortestpath.ShortestPathPlugin;
 import shortestpath.TeleportationItem;
 import shortestpath.WorldPointUtil;
 import shortestpath.ShortestPathConfig;
@@ -49,9 +48,6 @@ public class PathfinderTest {
 
     @Mock
     ItemContainer equipment;
-
-    @Mock
-    ShortestPathPlugin plugin;
 
     @Mock
     ShortestPathConfig config;
@@ -677,7 +673,7 @@ public class PathfinderTest {
     }
 
     private int calculatePathLength(int origin, int destination) {
-        Pathfinder pathfinder = new Pathfinder(plugin, pathfinderConfig, origin, Set.of(destination));
+        Pathfinder pathfinder = new Pathfinder(pathfinderConfig, origin, Set.of(destination));
         pathfinder.run();
         return pathfinder.getPath().size();
     }

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -633,26 +633,19 @@ public class PathfinderTest {
         TeleportationItem useTeleportationItems) {
         setupConfig(questState, skillLevel, useTeleportationItems);
 
-        // Cap the number of pathfinder runs per transport type to avoid excessive test runtime.
-        // Running pathfinder for every transport (e.g. hundreds of fairy rings) is very slow.
-        final int maxPathfinderRuns = 50;
         int counter = 0;
-        int totalMatched = 0;
         Map<Integer, Set<Transport>> activeTransports = pathfinderConfig.getTransports();
         for (int origin : activeTransports.keySet()) {
             for (Transport transport : activeTransports.get(origin)) {
                 if (transportType.equals(transport.getType())) {
-                    totalMatched++;
-                    if (counter < maxPathfinderRuns) {
-                        counter++;
-                        assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
-                    }
+                    counter++;
+                    assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
                 }
             }
         }
 
         assertTrue("No tests were performed", counter > 0);
-        System.out.println(String.format("Successfully completed %d/%d " + transportType + " transport length tests", counter, totalMatched));
+        System.out.println(String.format("Successfully completed %d " + transportType + " transport length tests", counter));
     }
 
     private void testTransportMinimumLength(int minimumLength, int origin, int destination) {

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -7,32 +7,32 @@ import net.runelite.api.GameState;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.QuestState;
+import net.runelite.api.Skill;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
-import net.runelite.api.QuestState;
-import net.runelite.api.Skill;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
-
 import shortestpath.ItemVariations;
 import shortestpath.TeleportationItem;
 import shortestpath.WorldPointUtil;
 import shortestpath.ShortestPathConfig;
 import shortestpath.transport.Transport;
-import shortestpath.transport.requirement.TransportItems;
 import shortestpath.transport.TransportLoader;
 import shortestpath.transport.TransportType;
-import shortestpath.transport.parser.VarRequirement;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import shortestpath.transport.requirement.TransportItems;
+import shortestpath.ShortestPathPlugin;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PathfinderTest {
@@ -48,6 +48,9 @@ public class PathfinderTest {
 
     @Mock
     ItemContainer equipment;
+
+    @Mock
+    ItemContainer bank;
 
     @Mock
     ShortestPathConfig config;
@@ -77,6 +80,25 @@ public class PathfinderTest {
     }
 
     @Test
+    public void testGrappleBranchDoesNotLeakBankedMithGrapple() {
+        // The crossbow is already on hand, but the mith grapple is only in the bank.
+        // This should expose any branch leakage where one explored bank path makes the
+        // grapple shortcut appear usable on a different branch that never banked.
+        when(config.useGrappleShortcuts()).thenReturn(true);
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.useAgilityShortcuts()).thenReturn(true);
+        setupInventory(new Item(ItemID.XBOWS_CROSSBOW_ADAMANTITE, 1));
+        setupEquipment();
+        setupConfigWithBank(new Item(ItemID.XBOWS_GRAPPLE_TIP_BOLT_MITHRIL_ROPE, 1));
+
+        assertScenarioPathLength(
+            "Banked mith grapple should not leak to non-bank grapple branch",
+            66, 
+            WorldPointUtil.packWorldPoint(3025, 3365, 0),
+            WorldPointUtil.packWorldPoint(3026, 3393, 0));
+    }
+
+    @Test
     public void testBoats() {
         when(config.useBoats()).thenReturn(true);
         setupInventory(
@@ -100,6 +122,44 @@ public class PathfinderTest {
     }
 
     @Test
+    public void testCatherbyCharterReusedAfterBankVisitWithBankedCoins() {
+        // Start on the Catherby charter tile with no coins on hand. The route must bank,
+        // then come back and reuse that same charter origin tile once coins are available.
+        int catherbyCharter = WorldPointUtil.packWorldPoint(2792, 3414, 0);
+        int musaPointCharter = WorldPointUtil.packWorldPoint(2954, 3158, 0);
+
+        when(config.useCharterShips()).thenReturn(true);
+        when(config.includeBankPath()).thenReturn(true);
+        setupInventory();
+        setupEquipment();
+        setupConfigWithBank(new Item(ItemID.COINS, 10000));
+
+        assertScenarioPathLength(
+            "Catherby charter tile reuse -> bank -> Musa Point with banked coins",
+            78, // Fill in the precise length after running locally.
+            catherbyCharter,
+            musaPointCharter);
+    }
+
+    @Test
+    public void testCatherbyBankBranchDoesNotLeakCoinsToCharterBranch() {
+        // Start near Catherby bank rather than on the dock itself. One search branch can touch
+        // the bank, while another heads straight to the charter ship. Banked coins must not leak
+        // from the bank branch into the non-bank charter branch.
+        when(config.useCharterShips()).thenReturn(true);
+        when(config.includeBankPath()).thenReturn(true);
+        setupInventory();
+        setupEquipment();
+        setupConfigWithBank(new Item(ItemID.COINS, 10000));
+
+        assertScenarioPathLength(
+            "Catherby bank branch should not leak coins to charter branch",
+            46, // Fill in the precise length after running locally.
+            WorldPointUtil.packWorldPoint(2807, 3435, 0),
+            WorldPointUtil.packWorldPoint(2954, 3158, 0));
+    }
+
+    @Test
     public void testShips() {
         when(config.useShips()).thenReturn(true);
         setupInventory(new Item(ItemID.COINS, 10000));
@@ -111,7 +171,19 @@ public class PathfinderTest {
         when(config.useFairyRings()).thenReturn(true);
         setupInventory(new Item(ItemID.DRAMEN_STAFF, 1));
         when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
-        testTransportLength(2, TransportType.FAIRY_RING);
+
+        // Verify ALL fairy ring transports are available, but only calculate one path
+        testAllTransportsAvailableWithSinglePath(TransportType.FAIRY_RING);
+    }
+
+    @Test
+    public void testLunarStaffFairyRings() {
+        when(config.useFairyRings()).thenReturn(true);
+        setupInventory(new Item(ItemID.LUNAR_MOONCLAN_LIMINAL_STAFF, 1));
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+
+        // Verify ALL fairy ring transports are available, but only calculate one path
+        testAllTransportsAvailableWithSinglePath(TransportType.FAIRY_RING);
     }
 
     @Test
@@ -133,6 +205,23 @@ public class PathfinderTest {
     }
 
     @Test
+    public void testFairyRingsNotUsedWithoutQuestProgressOrEliteDiary() {
+        when(config.useFairyRings()).thenReturn(true);
+        setupInventory(new Item(ItemID.DRAMEN_STAFF, 1));
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(0);
+        when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(0);
+
+        setupConfig(QuestState.NOT_STARTED, 99, TeleportationItem.NONE);
+
+        for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
+            for (Transport t : set) {
+                assertTrue("Fairy ring used unexpectedly without quest progress or diary: " + t,
+                    !TransportType.FAIRY_RING.equals(t.getType()));
+            }
+        }
+    }
+
+    @Test
     public void testFairyRingsUsedWithLumbridgeDiaryCompleteWithoutDramenStaff() {
         when(config.useFairyRings()).thenReturn(true);
         // No Dramen staff in inventory or equipment
@@ -141,8 +230,7 @@ public class PathfinderTest {
         when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
         when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(1);
 
-        // Use the existing test helper which will refresh config and run checks for all fairy ring transports
-        testTransportLength(2, TransportType.FAIRY_RING);
+        testSingleTransportScenario("Fairy ring with Lumbridge diary and no Dramen staff", 2, TransportType.FAIRY_RING);
     }
 
     @Test
@@ -153,7 +241,374 @@ public class PathfinderTest {
 
         when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
 
-        testTransportLength(2, TransportType.FAIRY_RING);
+        testSingleTransportScenario("Fairy ring with Dramen staff worn", 2, TransportType.FAIRY_RING);
+    }
+
+    @Test
+    public void testTeleportItemsAndFairyRingsAvailableAfterBankVisit() {
+        // Test scenario: Both Dramen staff AND Ardougne cloak are in the bank
+        // After visiting a bank, both fairy rings AND teleport items should be available
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        setupInventory();
+        setupEquipment();
+
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+
+        setupConfigWithBank(TeleportationItem.INVENTORY_AND_BANK,
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(ItemID.ARDY_CAPE_ELITE, 1)
+        );
+
+        // With per-path filtering, fairy rings ARE in the transport map
+        // but filtered at runtime based on whether the path visited a bank
+        boolean hasFairyRing = false;
+        for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
+            for (Transport t : set) {
+                if (TransportType.FAIRY_RING.equals(t.getType())) {
+                    hasFairyRing = true;
+                    break;
+                }
+            }
+            if (hasFairyRing) break;
+        }
+        assertTrue("Fairy ring transports should be in map (filtered per-path)", hasFairyRing);
+
+    }
+
+    /**
+     * Debug test: Compare paths from Castle Wars to AKQ fairy ring
+     * with staff in inventory vs staff in bank.
+     * Both should use fairy rings if that's the optimal path.
+     */
+    @Test
+    public void testCastleWarsToAKQWithStaffInInventory() {
+        int castleWars = WorldPointUtil.packWorldPoint(2442, 3083, 0);
+        int akqFairyRing = WorldPointUtil.packWorldPoint(2324, 3619, 0);
+
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        when(config.costConsumableTeleportationItems()).thenReturn(50);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+
+        setupInventory(new Item(ItemID.DRAMEN_STAFF, 1));
+        setupEquipment();
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.INVENTORY_AND_BANK);
+
+        Pathfinder pathfinderWithStaff = runScenario("Castle Wars -> AKQ with staff in inventory",
+            castleWars, akqFairyRing);
+
+        assertTrue("Fairy ring should be used when staff is in inventory",
+            usedTransportType(pathfinderWithStaff, TransportType.FAIRY_RING));
+    }
+
+    @Test
+    public void testCastleWarsToAKQWithStaffInBank() {
+        int castleWars = WorldPointUtil.packWorldPoint(2442, 3083, 0);
+        int akqFairyRing = WorldPointUtil.packWorldPoint(2324, 3619, 0);
+
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        when(config.costConsumableTeleportationItems()).thenReturn(50);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        when(config.includeBankPath()).thenReturn(true);
+        setupInventory();
+        setupEquipment();
+        setupConfigWithBank(
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(ItemID.ARDY_CAPE_MEDIUM, 1),
+            new Item(ItemID.NECKLACE_OF_PASSAGE_5, 1)
+        );
+
+        Pathfinder pathfinderWithBankStaff = runScenario("Castle Wars -> AKQ with staff in bank",
+            castleWars, akqFairyRing);
+
+        assertTrue("Fairy ring should be used when staff is in bank with includeBankPath",
+            usedTransportType(pathfinderWithBankStaff, TransportType.FAIRY_RING));
+    }
+
+    /**
+     * Diagnose the issue: targeting DJP fairy ring works, but targeting AKQ does not.
+     * When staff is in bank and target is DJP - uses Ardougne cloak correctly.
+     * When staff is in bank and target is AKQ - incorrectly uses necklace of passage.
+     */
+    @Test
+    public void testBankPathDJPvsAKQTarget() {
+        int castleWars = WorldPointUtil.packWorldPoint(2442, 3083, 0);
+        int djpFairyRing = WorldPointUtil.packWorldPoint(2658, 3230, 0); // Near Kandarin Monastery
+        int akqFairyRing = WorldPointUtil.packWorldPoint(2319, 3619, 0); // AKQ destination
+
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.costConsumableTeleportationItems()).thenReturn(50);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        setupInventory();
+        setupEquipment();
+
+        // Both paths share the same config — bank contains: Dramen staff, Ardougne cloak, necklace
+        setupConfigWithBank(
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(ItemID.ARDY_CAPE_ELITE, 1),
+            new Item(ItemID.NECKLACE_OF_PASSAGE_1, 1)
+        );
+
+        Pathfinder pathfinderToDJP = runScenario("Castle Wars -> DJP", castleWars, djpFairyRing);
+
+        // PathfinderConfig is not mutated between runs; reuse the same config for the second path
+        Pathfinder pathfinderToAKQ = runScenario("Castle Wars -> AKQ", castleWars, akqFairyRing);
+
+        assertTrue("Should use Ardougne cloak to DJP",
+            usedTransportWithDisplayInfo(pathfinderToDJP, TransportType.TELEPORTATION_ITEM, "Ardougne"));
+        assertFalse("Should NOT use necklace to DJP",
+            usedTransportWithDisplayInfo(pathfinderToDJP, TransportType.TELEPORTATION_ITEM, "Necklace"));
+
+        assertTrue("Should use fairy ring to reach AKQ",
+            usedTransportType(pathfinderToAKQ, TransportType.FAIRY_RING));
+        assertTrue("Should use Ardougne cloak to reach AKQ via fairy ring",
+            usedTransportWithDisplayInfo(pathfinderToAKQ, TransportType.TELEPORTATION_ITEM, "Ardougne"));
+        assertFalse("Should NOT use necklace to AKQ",
+            usedTransportWithDisplayInfo(pathfinderToAKQ, TransportType.TELEPORTATION_ITEM, "Necklace"));
+    }
+
+    /**
+     * Test scenario: Player has Ardougne cloak in INVENTORY, Dramen staff in BANK.
+     * Route should be: walk to nearest bank → pick up staff → use cloak → fairy ring.
+     * Should NOT suggest picking up a necklace from bank instead.
+     */
+    @Test
+    public void testArdougneCloakInInventoryWithStaffInBank() {
+        int castleWars = WorldPointUtil.packWorldPoint(2442, 3083, 0);
+        int akqFairyRing = WorldPointUtil.packWorldPoint(2319, 3619, 0);
+
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.costConsumableTeleportationItems()).thenReturn(50);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(0);
+
+        // Ardougne cloak already in INVENTORY; staff and (penalised) necklace only in bank
+        setupInventory(new Item(ItemID.ARDY_CAPE_ELITE, 1));
+        setupEquipment();
+        setupConfigWithBank(
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(ItemID.NECKLACE_OF_PASSAGE_5, 1)
+        );
+
+        Pathfinder pathfinder = runScenario("Castle Wars -> AKQ with cloak inventory/staff bank",
+            castleWars, akqFairyRing);
+
+        assertTrue("Should use Ardougne cloak (it's in inventory, non-consumable)",
+            usedTransportWithDisplayInfo(pathfinder, TransportType.TELEPORTATION_ITEM, "Ardougne"));
+        assertFalse("Should NOT use necklace (it's consumable with penalty)",
+            usedTransportWithDisplayInfo(pathfinder, TransportType.TELEPORTATION_ITEM, "Necklace"));
+        assertTrue("Should use fairy ring to reach destination",
+            usedTransportType(pathfinder, TransportType.FAIRY_RING));
+    }
+
+    /**
+     * Test that when Dramen staff is only in the bank, fairy rings are in the transport map
+     * with the bank-only staff case gated by the explicit bankVisited search state.
+     * This ensures paths that don't visit a bank won't use fairy rings.
+     */
+    @Test
+    public void testFairyRingNotUsedAfterTeleportWithoutBankVisit() {
+        // Enable fairy rings and teleport items
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        when(config.includeBankPath()).thenReturn(true);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(0); // No diary
+
+        // Ring of Wealth in inventory, but Dramen staff only in bank
+        setupInventory(new Item(ItemID.RING_OF_WEALTH_1, 1));
+        setupEquipment();
+
+        setupConfigWithBank(TeleportationItem.INVENTORY_AND_BANK,
+            new Item(ItemID.DRAMEN_STAFF, 1));
+
+        // With per-path filtering, fairy rings ARE in the transport map
+        // but filtered at runtime based on whether the path visited a bank
+        boolean hasFairyRing = false;
+        for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
+            for (Transport t : set) {
+                if (TransportType.FAIRY_RING.equals(t.getType())) {
+                    hasFairyRing = true;
+                    break;
+                }
+            }
+            if (hasFairyRing) break;
+        }
+        assertTrue("Fairy rings should be in transport map (filtered per-path)", hasFairyRing);
+
+        runScenario("Fairy ring remains gated before bank visit",
+            WorldPointUtil.packWorldPoint(2442, 3096, 0),
+            WorldPointUtil.packWorldPoint(3162, 3489, 0));
+    }
+
+    @Test
+    public void testTeleportItemInInventoryUsableBeforeFirstBankVisit() {
+        // A bank-only Dramen staff should not suppress a teleport item that is already on hand.
+        // The route is allowed to spend the Ring of wealth before it reaches the first bank.
+        int castleWars = WorldPointUtil.packWorldPoint(2442, 3096, 0);
+        int grandExchangeBank = WorldPointUtil.packWorldPoint(3162, 3489, 0);
+
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+        when(config.includeBankPath()).thenReturn(true);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(0);
+
+        // The ring is already on hand; only the fairy ring staff is banked.
+        setupInventory(new Item(ItemID.RING_OF_WEALTH_1, 1));
+        setupEquipment();
+        setupConfigWithBank(TeleportationItem.INVENTORY_AND_BANK,
+            new Item(ItemID.DRAMEN_STAFF, 1));
+
+        Pathfinder pathfinder = runScenario("Castle Wars -> Grand Exchange bank with on-hand ring",
+            castleWars, grandExchangeBank);
+
+        assertTrue("Ring of wealth should remain usable before the first bank visit",
+            usedTransportWithDisplayInfoBeforeFirstBank(pathfinder, TransportType.TELEPORTATION_ITEM, "Ring of wealth"));
+    }
+
+    /**
+     * Test that fairy rings are only used when the path actually visits a bank.
+     * When the Dramen staff is only in the bank, fairy rings should only be available
+     * on paths that go through a bank first.
+     */
+    @Test
+    public void testFairyRingRequiresBankVisitWhenStaffInBank() {
+        // Enable fairy rings
+        when(config.useFairyRings()).thenReturn(true);
+        when(config.includeBankPath()).thenReturn(true);
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(0); // No diary
+
+        // No staff in inventory or equipment - only in bank
+        setupInventory();
+        setupEquipment();
+
+        setupConfigWithBank(new Item(ItemID.DRAMEN_STAFF, 1));
+
+
+        // Test pathfinding: from Al Kharid mine to AKQ fairy ring
+        // The path should NOT use fairy rings directly without going through a bank
+        int alKharidMine = WorldPointUtil.packWorldPoint(3298, 3290, 0);
+        int akqFairyRing = WorldPointUtil.packWorldPoint(2319, 3619, 0);
+
+        Pathfinder pathfinder = runScenario("Al Kharid mine -> AKQ with staff only in bank",
+            alKharidMine, akqFairyRing);
+
+        boolean usedFairyRing = usedTransportType(pathfinder, TransportType.FAIRY_RING);
+
+        // If fairy rings are used, the path must have gone through a bank
+        if (usedFairyRing) {
+            assertTrue("If fairy ring is used, path must visit a bank first to pick up Dramen staff",
+                pathfinder.getPath().stream().anyMatch(PathStep::isBankVisited));
+        }
+        // If no fairy ring was used, that's also acceptable (walking path)
+    }
+
+    @Test
+    public void testGreatConchBankToMcGruborsWoodMaximumLength() {
+        // Baseline bank-enabled Great Conch route: fairy rings and a combat bracelet are only
+        // available from the bank, so the chosen path should reflect those post-bank unlocks.
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.useAgilityShortcuts()).thenReturn(true);
+        when(config.useFairyRings()).thenReturn(true);
+        setupInventory();
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+
+        assertScenarioPathLengthWithBank(
+            "Great Conch -> McGrubor's Wood with banked staff and bracelet",
+            54,
+            WorldPointUtil.packWorldPoint(3180, 2419, 0),
+            WorldPointUtil.packWorldPoint(2652, 3485, 0),
+            TeleportationItem.INVENTORY_AND_BANK,
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(11118, 1));
+    }
+
+    @Test
+    public void testGreatConchTileReuseToMcGruborsWoodWithBankedStaff() {
+        // Target the tile-reuse case directly: the path re-enters the same corridor after banking,
+        // and only the post-bank revisit has access to the banked Dramen staff route options.
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.useAgilityShortcuts()).thenReturn(true);
+        when(config.useFairyRings()).thenReturn(true);
+        setupInventory();
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+
+        assertScenarioPathLengthWithBank(
+            "Great Conch tile reuse -> McGrubor's Wood with banked Dramen staff",
+            78,
+            WorldPointUtil.packWorldPoint(3181, 2437, 0),
+            WorldPointUtil.packWorldPoint(2652, 3485, 0),
+            TeleportationItem.INVENTORY_AND_BANK,
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(11118, 1));
+    }
+
+    @Test
+    public void testGreatConchToMcGruborsWoodMaximumLengthWithoutBanking() {
+        // Non-bank baseline for the same route family. The Dramen staff starts in inventory, so
+        // the path can use fairy rings immediately without any bank visit or post-bank unlock.
+        when(config.useAgilityShortcuts()).thenReturn(true);
+        when(config.useFairyRings()).thenReturn(true);
+        setupInventory(new Item(ItemID.DRAMEN_STAFF, 1));
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+        assertScenarioPathLength(
+            "Great Conch -> McGrubor's Wood with inventory Dramen staff",
+            50,
+            WorldPointUtil.packWorldPoint(3180, 2419, 0),
+            WorldPointUtil.packWorldPoint(2652, 3485, 0));
+    }
+
+    @Test
+    public void testFairyRingBranchDoesNotLeakBankedDramenStaff() {
+        // Start near a bank branch and a fairy-ring branch. The Dramen staff is only in the bank,
+        // so a branch that has not banked must not gain fairy-ring access just because another
+        // explored branch touched a bank.
+        when(config.includeBankPath()).thenReturn(true);
+        when(config.useFairyRings()).thenReturn(true);
+        setupInventory();
+        setupEquipment();
+        when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
+        when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(0);
+        setupConfigWithBank(new Item(ItemID.DRAMEN_STAFF, 1));
+
+        assertScenarioPathLength(
+            "Banked Dramen staff should not leak to non-bank fairy-ring branch",
+            127,
+            WorldPointUtil.packWorldPoint(3134, 3503, 0),
+            WorldPointUtil.packWorldPoint(2652, 3485, 0));
+    }
+
+    @Test
+    public void testCowbellAmuletInBankUsedAfterBankVisit() {
+        // A teleport item that exists only in the bank should become usable after the route banks.
+        // This checks the positive side of the bank-state transition for teleport items.
+        when(config.includeBankPath()).thenReturn(true);
+        setupInventory();
+        setupEquipment();
+        setupConfigWithBank(TeleportationItem.INVENTORY_AND_BANK,
+            new Item(33104, 1));
+
+        Pathfinder pathfinder = assertScenarioPathLengthAndGet(
+            "Varrock centre -> Cowbell amulet destination with amulet in bank",
+            36,
+            WorldPointUtil.packWorldPoint(3213, 3424, 0),
+            WorldPointUtil.packWorldPoint(3259, 3277, 0));
+
+        assertTrue("Cowbell amulet should be used after visiting a bank",
+            usedTransportWithDisplayInfoAfterFirstBank(pathfinder, TransportType.TELEPORTATION_ITEM, "Cowbell amulet"));
+        assertFalse("Cowbell amulet should not be used before the first bank visit",
+            usedTransportWithDisplayInfoBeforeFirstBank(pathfinder, TransportType.TELEPORTATION_ITEM, "Cowbell amulet"));
     }
 
     @Test
@@ -253,14 +708,35 @@ public class PathfinderTest {
         int shayzienWest = WorldPointUtil.packWorldPoint(1415, 3577, 0);
         int arceuus = WorldPointUtil.packWorldPoint(1670, 3833, 0);
 
-        assertTrue("Reverse Lovakengj minecart route should not be directly usable without coins before quest",
-            calculatePathLength(shayzienWest, arceuus) > 2);
+        assertScenarioMinimumPathLength("Lovakengj reverse minecart without coins", 3, shayzienWest, arceuus);
     }
 
     @Test
     public void testQuetzals() {
         when(config.useQuetzals()).thenReturn(true);
         testTransportLength(2, TransportType.QUETZAL);
+    }
+
+    /**
+     * Tests that the Primio quetzal (Varrock ↔ Civitas) works correctly.
+     * This is a fixed route NOT accessible by the whistle.
+     */
+    @Test
+    public void testPrimioQuetzal() {
+        when(config.useQuetzals()).thenReturn(true);
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+
+        // Varrock Primio platform to Civitas
+        int varrockPrimio = WorldPointUtil.packWorldPoint(3280, 3412, 0);
+        int civitasPrimio = WorldPointUtil.packWorldPoint(1700, 3141, 0);
+
+        assertEquals(2, calculatePathLength(varrockPrimio, civitasPrimio));
+
+        // Civitas Primio platform to Varrock
+        int civitasPrimioOrigin = WorldPointUtil.packWorldPoint(1703, 3140, 0);
+        int varrockPrimioDest = WorldPointUtil.packWorldPoint(3280, 3412, 0);
+
+        assertEquals(2, calculatePathLength(civitasPrimioOrigin, varrockPrimioDest));
     }
 
     @Test
@@ -380,7 +856,8 @@ public class PathfinderTest {
         // 5 tiles is using the stepping stones
         // ~40 tiles is using the combat bracelet teleport to Champions Guild
         // >100 tiles is walking around the river via Barbarian Village
-        testTransportLength(6,
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.ALL);
+        assertScenarioPathLength("Draynor Manor stepping stones vs combat bracelet", 6,
             WorldPointUtil.packWorldPoint(3149, 3363, 0),
             WorldPointUtil.packWorldPoint(3154, 3363, 0));
     }
@@ -388,34 +865,34 @@ public class PathfinderTest {
     @Test
     public void testChronicle() {
         // South of river south of Champions Guild to Chronicle teleport destination
-        testTransportLength(2,
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.ALL);
+        assertEquals(2, calculatePathLength(
             WorldPointUtil.packWorldPoint(3199, 3336, 0),
-            WorldPointUtil.packWorldPoint(3200, 3355, 0),
-            TeleportationItem.ALL);
+            WorldPointUtil.packWorldPoint(3200, 3355, 0)));
     }
 
     @Test
     public void testVarrockTeleport() {
-        // West of Varrock teleport destination to Varrock teleport destination
+        // Test that Varrock Teleport is used when it's cheaper than walking
         when(config.useTeleportationSpells()).thenReturn(true);
 
-        // With magic level 1 and no item requirements
-        testTransportLength(4,
+        // Test 1: Without magic level (can't cast spell) - should walk
+        setupConfig(QuestState.FINISHED, 1, TeleportationItem.NONE);
+        assertScenarioPathLength("Varrock teleport too low magic level", 4,
             WorldPointUtil.packWorldPoint(3216, 3424, 0),
-            WorldPointUtil.packWorldPoint(3213, 3424, 0),
-            TeleportationItem.NONE,
-            1);
+            WorldPointUtil.packWorldPoint(3213, 3424, 0));
 
-        // With magic level 99 and magic runes
+        // Test 2: With magic level and runes, starting far enough that teleport is cheaper
         setupInventory(
-            new Item(ItemID.LAWRUNE, 1),
-            new Item(ItemID.AIRRUNE, 3),
-            new Item(ItemID.FIRERUNE, 1));
-        testTransportLength(2,
-            WorldPointUtil.packWorldPoint(3216, 3424, 0),
-            WorldPointUtil.packWorldPoint(3213, 3424, 0),
-            TeleportationItem.INVENTORY,
-            99);
+                new Item(ItemID.LAWRUNE, 1),
+                new Item(ItemID.AIRRUNE, 3),
+                new Item(ItemID.FIRERUNE, 1));
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.INVENTORY);
+
+        // Starting 10 tiles away - teleport (4 ticks) is definitely cheaper than walking (10 ticks)
+        assertScenarioPathLength("Varrock teleport with runes and magic level", 2,
+            WorldPointUtil.packWorldPoint(3223, 3424, 0),
+            WorldPointUtil.packWorldPoint(3213, 3424, 0));
     }
 
     @Test
@@ -448,13 +925,14 @@ public class PathfinderTest {
     public void testPathViaOtherPlane() {
         // Shortest path from east to west Keldagrim is via the first floor
         // of the Keldagrim Palace, and not via the bridge to the north
-        testTransportLength(64,
-            WorldPointUtil.packWorldPoint(2894, 10199, 0), // east
-            WorldPointUtil.packWorldPoint(2864, 10199, 0)); // west
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+        assertScenarioPathLength("Keldagrim east -> west via other plane", 64,
+            WorldPointUtil.packWorldPoint(2894, 10199, 0),
+            WorldPointUtil.packWorldPoint(2864, 10199, 0));
 
-        testTransportLength(64,
-            WorldPointUtil.packWorldPoint(2864, 10199, 0), // west
-            WorldPointUtil.packWorldPoint(2894, 10199, 0)); // east
+        assertScenarioPathLength("Keldagrim west -> east via other plane", 64,
+            WorldPointUtil.packWorldPoint(2864, 10199, 0),
+            WorldPointUtil.packWorldPoint(2894, 10199, 0));
     }
 
     @Test
@@ -464,6 +942,7 @@ public class PathfinderTest {
         when(config.useCharterShips()).thenReturn(true);
         setupInventory(new Item(ItemID.COINS, 1000000));
 
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.ALL);
         testTransportMinimumLength(3,
             WorldPointUtil.packWorldPoint(1455, 2968, 0), // Aldarin
             WorldPointUtil.packWorldPoint(1514, 2971, 0)); // Sunset Coast
@@ -654,6 +1133,77 @@ public class PathfinderTest {
         System.out.println(String.format("Successfully completed %d " + transportType + " transport length tests", counter));
     }
 
+    /**
+     * Tests a single transport of the given type for efficiency.
+     * Unlike testTransportLength which tests all transports of a type,
+     * this only tests the first matching transport found.
+     */
+    private void testSingleTransport(int expectedLength, TransportType transportType) {
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+
+        for (int origin : transports.keySet()) {
+            for (Transport transport : transports.get(origin)) {
+                if (transportType.equals(transport.getType())) {
+                    // Skip POH transports
+                    int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
+                    int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
+                    if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
+                        continue;
+                    }
+                    assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
+                    return; // Only test one transport
+                }
+            }
+        }
+        fail("No transport of type " + transportType + " found");
+    }
+
+    /**
+     * Verifies that ALL transports of the given type are present in the usable transports,
+     * but only calculates a path for one of them (for efficiency).
+     * This provides comprehensive coverage that all transports are enabled while being fast.
+     */
+    private void testAllTransportsAvailableWithSinglePath(TransportType transportType) {
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+
+        // Count expected transports from the full transport list
+        int expectedCount = 0;
+        Transport sampleTransport = null;
+        for (int origin : transports.keySet()) {
+            for (Transport transport : transports.get(origin)) {
+                if (transportType.equals(transport.getType())) {
+                    int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
+                    int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
+                    if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
+                        continue;
+                    }
+                    expectedCount++;
+                    if (sampleTransport == null) {
+                        sampleTransport = transport;
+                    }
+                }
+            }
+        }
+
+        // Count actual transports in the configured (usable) transports
+        int actualCount = 0;
+        for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
+            for (Transport t : set) {
+                if (transportType.equals(t.getType())) {
+                    actualCount++;
+                }
+            }
+        }
+
+        assertEquals("All " + transportType + " transports should be available", expectedCount, actualCount);
+        assertTrue("At least one transport should exist", expectedCount > 0);
+
+        // Test path calculation on just one transport to verify pathfinding works
+        if (sampleTransport != null) {
+            assertEquals(sampleTransport.toString(), 2, calculateTransportLength(sampleTransport));
+        }
+    }
+
     private void testTransportMinimumLength(int minimumLength, int origin, int destination) {
         setupConfig(QuestState.FINISHED, 99, TeleportationItem.ALL);
         int actualLength = calculatePathLength(origin, destination);
@@ -672,10 +1222,91 @@ public class PathfinderTest {
         return calculatePathLength(transport.getOrigin(), transport.getDestination());
     }
 
+    private void testSingleTransportScenario(String label, int expectedLength, TransportType transportType) {
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+        Transport transport = findSampleTransport(transportType);
+        assertScenarioPathLength(label, expectedLength, transport.getOrigin(), transport.getDestination());
+    }
+
+    private void testConfiguredTransportScenario(String label, int expectedLength, TransportType transportType) {
+        Transport transport = findConfiguredTransport(transportType);
+        assertScenarioPathLength(label, expectedLength, transport.getOrigin(), transport.getDestination());
+    }
+
+    // A "scenario" is a single, named pathfinding example with a fixed origin and
+    // destination that demonstrates a meaningful routing behaviour or regression.
+    // Scenarios are intended for the debugging dashboard, so they should be cases
+    // worth visualising: bank-state transitions, branch-leak regressions,
+    // transport-vs-walking choices, tile/plane reuse, or other route-selection
+    // behaviours. Broad transport coverage, static connectivity smoke tests, and
+    // feature-availability checks are not scenarios even if they use coordinates.
+    private void assertScenarioPathLength(String label, int expectedLength, int origin, int destination) {
+        assertScenarioPathLengthAndGet(label, expectedLength, origin, destination);
+    }
+
+    private Pathfinder assertScenarioPathLengthAndGet(String label, int expectedLength, int origin, int destination) {
+        Pathfinder pathfinder = runScenario(label, origin, destination);
+        int actualLength = pathfinder.getPath().size();
+        assertEquals(label, expectedLength, actualLength);
+        return pathfinder;
+    }
+
+    private void assertScenarioMinimumPathLength(String label, int minimumLength, int origin, int destination) {
+        Pathfinder pathfinder = runScenario(label, origin, destination);
+        int actualLength = pathfinder.getPath().size();
+        assertTrue("Scenario " + label + " had length " + actualLength + " < " + minimumLength, actualLength >= minimumLength);
+    }
+
+    private void assertScenarioPathLengthWithBank(String label, int expectedLength, int origin, int destination,
+                                                  TeleportationItem useTeleportationItems, Item... bankItems) {
+        setupConfigWithBank(useTeleportationItems, bankItems);
+        assertScenarioPathLength(label, expectedLength, origin, destination);
+    }
+
+    private Transport findSampleTransport(TransportType transportType) {
+        for (int origin : transports.keySet()) {
+            for (Transport transport : transports.get(origin)) {
+                if (transportType.equals(transport.getType())) {
+                    int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
+                    int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
+                    if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
+                        continue;
+                    }
+                    return transport;
+                }
+            }
+        }
+        fail("No transport of type " + transportType + " found");
+        return null;
+    }
+
+    private Transport findConfiguredTransport(TransportType transportType) {
+        for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
+            for (Transport transport : set) {
+                if (transportType.equals(transport.getType())) {
+                    return transport;
+                }
+            }
+        }
+        fail("No configured transport of type " + transportType + " found");
+        return null;
+    }
+
     private int calculatePathLength(int origin, int destination) {
+        Pathfinder pathfinder = runPathfinder(origin, destination);
+        return pathfinder.getPath().size();
+    }
+
+    private Pathfinder runPathfinder(int origin, int destination) {
         Pathfinder pathfinder = new Pathfinder(pathfinderConfig, origin, Set.of(destination));
         pathfinder.run();
-        return pathfinder.getPath().size();
+        return pathfinder;
+    }
+    
+    // In a future commit, these tests will be rendered onto a debugging dashboard.
+    private Pathfinder runScenario(String label, int origin, int destination) {
+        Pathfinder pathfinder = runPathfinder(origin, destination);
+        return pathfinder;
     }
 
     private boolean hasTransportWithRequiredItem(Map<Integer, Set<Transport>> transports, int[] variationIds) {
@@ -709,7 +1340,7 @@ public class PathfinderTest {
         int count = 0;
         for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
             for (Transport t : set) {
-                if (TransportType.MINECART.equals(t.getType()) && hasVarbit(t, 7796)) {
+                if (t.isType(TransportType.MINECART) && t.hasVarbit(7796)) {
                     count++;
                 }
             }
@@ -717,12 +1348,83 @@ public class PathfinderTest {
         return count;
     }
 
-    private boolean hasVarbit(Transport transport, int varbitId) {
-        for (VarRequirement varbit : transport.getVarbits()) {
-            if (varbit.getId() == varbitId) {
-                return true;
+    private void setupConfigWithBank(Item... bankItems) {
+        setupConfigWithBank(TeleportationItem.INVENTORY_AND_BANK, bankItems);
+    }
+
+    private void setupConfigWithBank(TeleportationItem useTeleportationItems, Item... bankItems) {
+        pathfinderConfig = new TestPathfinderConfig(client, config, QuestState.FINISHED, true, true);
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.getClientThread()).thenReturn(Thread.currentThread());
+        when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+        when(config.useTeleportationItems()).thenReturn(useTeleportationItems);
+        when(config.usePoh()).thenReturn(false);
+        doReturn(bankItems).when(bank).getItems();
+        pathfinderConfig.bank = bank;
+        pathfinderConfig.refresh();
+    }
+
+    /** Returns true if the given transport type was used anywhere along the path. */
+    private boolean usedTransportType(Pathfinder pathfinder, TransportType type) {
+        for (int i = 1; i < pathfinder.getPath().size(); i++) {
+            PathStep originStep = pathfinder.getPath().get(i - 1);
+            int origin = originStep.getPackedPosition();
+            int dest = pathfinder.getPath().get(i).getPackedPosition();
+
+            Set<Transport> stepTransports = transportsForStep(origin, originStep.isBankVisited());
+            for (Transport t : stepTransports) {
+                if (t.getDestination() == dest && t.isType(type)) {
+                    return true;
+                }
             }
         }
         return false;
     }
-}
+
+    /**
+     * Returns true if a transport of the given type whose displayInfo contains the given
+     * substring was used anywhere along the path.
+     */
+    private boolean usedTransportWithDisplayInfo(Pathfinder pathfinder, TransportType type, String displayInfoSubstring) {
+        return usedTransportWithDisplayInfo(pathfinder, type, displayInfoSubstring, false, false);
+    }
+
+    private boolean usedTransportWithDisplayInfoAfterFirstBank(Pathfinder pathfinder, TransportType type, String displayInfoSubstring) {
+        return usedTransportWithDisplayInfo(pathfinder, type, displayInfoSubstring, false, true);
+    }
+
+    private boolean usedTransportWithDisplayInfoBeforeFirstBank(Pathfinder pathfinder, TransportType type, String displayInfoSubstring) {
+        return usedTransportWithDisplayInfo(pathfinder, type, displayInfoSubstring, true, false);
+    }
+
+    private boolean usedTransportWithDisplayInfo(Pathfinder pathfinder, TransportType type, String displayInfoSubstring,
+        boolean stopAtFirstBank, boolean startAfterFirstBank) {
+        for (int i = 1; i < pathfinder.getPath().size(); i++) {
+            PathStep originStep = pathfinder.getPath().get(i - 1);
+            PathStep destStep = pathfinder.getPath().get(i);
+            boolean bankVisited = destStep.isBankVisited();
+            int origin = originStep.getPackedPosition();
+            if (stopAtFirstBank && bankVisited) {
+                return false;
+            }
+            if (startAfterFirstBank && !bankVisited) {
+                continue;
+            }
+
+            for (Transport t : transportsForStep(origin, bankVisited)) {
+                if (t.getDestination() == destStep.getPackedPosition() && t.isType(type) && t.hasDisplayInfo(displayInfoSubstring)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Set<Transport> transportsForStep(int origin, boolean bankVisited) {
+        Set<Transport> stepTransports = new java.util.HashSet<>(
+            pathfinderConfig.getTransportsPacked(bankVisited).getOrDefault(origin, Set.of()));
+        stepTransports.addAll(pathfinderConfig.getUsableTeleports(bankVisited));
+        return stepTransports;
+    }
+
+  }

--- a/src/test/java/shortestpath/pathfinder/TestPathfinderConfig.java
+++ b/src/test/java/shortestpath/pathfinder/TestPathfinderConfig.java
@@ -1,0 +1,49 @@
+package shortestpath.pathfinder;
+
+import net.runelite.api.Client;
+import net.runelite.api.Quest;
+import net.runelite.api.QuestState;
+import shortestpath.ShortestPathConfig;
+import shortestpath.transport.Transport;
+
+// This subclass is used to provide mocked implementations of methods from the normal
+// PathfinderConfig. CRUCIAL: Not implemented via Mockito as these methods are called
+// many times in the inner pathfinding loop.
+//
+// In particular, at the moment you can provide default values for:
+//  * getQuestState: Whether all quests are completed or not started.
+//  * varbitChecks: Ignore any varbitChecks.
+//  * varPlayerChecks: Ignore any varPlayerChecks.
+// Other methods are delegated to a normal PathfinderConfig.
+public class TestPathfinderConfig extends PathfinderConfig {
+    private final QuestState questState;
+    private final boolean bypassVarbitChecks;
+    private final boolean bypassVarPlayerChecks;
+
+    public TestPathfinderConfig(Client client, ShortestPathConfig config) {
+        this(client, config, QuestState.FINISHED, true, true);
+    }
+
+    public TestPathfinderConfig(Client client, ShortestPathConfig config, QuestState questState,
+        boolean bypassVarbitChecks, boolean bypassVarPlayerChecks) {
+        super(client, config);
+        this.questState = questState;
+        this.bypassVarbitChecks = bypassVarbitChecks;
+        this.bypassVarPlayerChecks = bypassVarPlayerChecks;
+    }
+
+    @Override
+    public QuestState getQuestState(Quest quest) {
+        return questState;
+    }
+
+    @Override
+    public boolean varbitChecks(Transport transport) {
+        return bypassVarbitChecks || super.varbitChecks(transport);
+    }
+
+    @Override
+    public boolean varPlayerChecks(Transport transport) {
+        return bypassVarPlayerChecks || super.varPlayerChecks(transport);
+    }
+}


### PR DESCRIPTION
Takes the changes from #422 and supersedes the implementation in #403 . #422 needs to be merged first before this one.

Adds a display hint for picking up required items at a bank for the shortest path.
Added an option to toggle the behaviour of the display hint. When enabled, it fully replaces the display hint for the next destination on the path with the pick up info. Need to test what would be the preferred option. I feel overriding the display hint would lead to less people making a potential mistake when picking up the items before continuing the path by before picking up all items, but it might be too much hand holding.