### PR TITLE
Add Ring of Shadows to Ladder requirement.

### DIFF
--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -5321,10 +5321,10 @@
 2786 3772 0	2794 3719 0	Slide Slope 5015		4084=1	Troll Romance			30	
 
 # Shadow Dungeon									
-2547 3422 0	2630 5071 0	Climb-down Ladder 6560		4657=1	Desert Treasure I				
-2546 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1	Desert Treasure I				
-2548 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1	Desert Treasure I				
-2547 3420 0	2630 5071 0	Climb-down Ladder 6560		4657=1	Desert Treasure I				
+2547 3422 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I
+2546 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I
+2548 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I
+2547 3420 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I				
 2629 5073 0	2547 3422 0	Climb-up Ladder 6450			Desert Treasure I				
 2628 5072 0	2547 3422 0	Climb-up Ladder 6450			Desert Treasure I				
 2630 5072 0	2547 3422 0	Climb-up Ladder 6450			Desert Treasure I				

--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -5321,9 +5321,9 @@
 2786 3772 0	2794 3719 0	Slide Slope 5015		4084=1	Troll Romance			30	
 
 # Shadow Dungeon									
-2547 3422 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I
-2546 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I
-2548 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I
+2547 3422 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I				
+2546 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I				
+2548 3421 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I				
 2547 3420 0	2630 5071 0	Climb-down Ladder 6560		4657=1|28329=1|28327=1	Desert Treasure I				
 2629 5073 0	2547 3422 0	Climb-up Ladder 6450			Desert Treasure I				
 2628 5072 0	2547 3422 0	Climb-up Ladder 6450			Desert Treasure I				


### PR DESCRIPTION
<img width="1309" height="982" alt="image" src="https://github.com/user-attachments/assets/a56c5aa4-346e-4ce6-8739-17a7bd7ef5d6" />

Originally this ladder was added only with Ring of Visibility. Ring of Shadows should be included here.

There is an issue where it will not go route you to the bank to pick it up, but that is fixed with #422.


The PR includes both charged and uncharged versions of ring of shadows.