### PR TITLE
Add an 'unreachable' color + threshold

### DIFF
--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -95,7 +95,7 @@ public class PathMapOverlay extends Overlay {
         }
 
         if (plugin.getPathfinder() != null) {
-            Color colour = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
+            Color colour = plugin.getPathColor();
             PrimitiveIntList path = plugin.getPathfinder().getPath();
             Point cursorPos = client.getMouseCanvasPosition();
             for (int i = 0; i < path.size(); i++) {

--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -7,8 +7,6 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.Area;
-import java.util.Map;
-import java.util.Set;
 import java.util.HashSet;
 import net.runelite.api.Client;
 import net.runelite.api.Point;
@@ -97,7 +95,7 @@ public class PathMapOverlay extends Overlay {
         }
 
         if (plugin.getPathfinder() != null) {
-            Color colour = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
+			Color colour = plugin.getPathColor();
             java.util.List<PathStep> path = plugin.getPathfinder().getPath();
             Point cursorPos = client.getMouseCanvasPosition();
             for (int i = 0; i < path.size(); i++) {

--- a/src/main/java/shortestpath/PathMinimapOverlay.java
+++ b/src/main/java/shortestpath/PathMinimapOverlay.java
@@ -42,7 +42,7 @@ public class PathMinimapOverlay extends Overlay {
         graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 
         PrimitiveIntList pathPoints = plugin.getPathfinder().getPath();
-        Color pathColor = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
+        Color pathColor = plugin.getPathColor();
         for (int i = 0; i < pathPoints.size(); i++) {
             int pathPoint = pathPoints.get(i);
             if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {

--- a/src/main/java/shortestpath/PathMinimapOverlay.java
+++ b/src/main/java/shortestpath/PathMinimapOverlay.java
@@ -43,7 +43,7 @@ public class PathMinimapOverlay extends Overlay {
         graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 
         java.util.List<PathStep> pathPoints = plugin.getPathfinder().getPath();
-        Color pathColor = plugin.getPathfinder().isDone() ? plugin.colourPath : plugin.colourPathCalculating;
+		Color pathColor = plugin.getPathColor();
         for (int i = 0; i < pathPoints.size(); i++) {
             int pathPoint = pathPoints.get(i).getPackedPosition();
             if (WorldPointUtil.unpackWorldPlane(pathPoint) != client.getPlane()) {

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -338,6 +338,7 @@ public class PathTileOverlay extends Overlay {
     private void drawTransportInfo(Graphics2D graphics, PathStep currentStep, PathStep nextStep, java.util.List<PathStep> path, int pathIndex) {
 		int location = currentStep.getPackedPosition();
 		if (nextStep == null || !plugin.showTransportInfo || plugin.isPathUnreachable() ||
+			!plugin.getPathfinder().isDone() ||
 			WorldPointUtil.unpackWorldPlane(location) != client.getTopLevelWorldView().getPlane()) {
             return;
         }

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -27,6 +27,8 @@ public class PathTileOverlay extends Overlay {
     private final Client client;
     private final ShortestPathPlugin plugin;
     private static final int TRANSPORT_LABEL_GAP = 3;
+    private static final String UNREACHABLE_TEXT = "Destination could not be reached";
+    private int playerTileLabelOffset = 0;
 
     @Inject
     public PathTileOverlay(Client client, ShortestPathPlugin plugin) {
@@ -126,6 +128,8 @@ public class PathTileOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
+        playerTileLabelOffset = 0;
+
         if (plugin.drawTransports) {
             renderTransports(graphics);
         }
@@ -175,6 +179,10 @@ public class PathTileOverlay extends Overlay {
                         drawTile(graphics, target, colorCalculating, -1, showTiles);
                     }
                 }
+            }
+
+            if (plugin.isPathUnreachable()) {
+                playerTileLabelOffset += drawLabelOnPlayerTile(graphics, UNREACHABLE_TEXT, playerTileLabelOffset);
             }
         }
 
@@ -300,6 +308,32 @@ public class PathTileOverlay extends Overlay {
                     counterText,
                     (int) (x - graphics.getFontMetrics().getStringBounds(counterText, graphics).getWidth() / 2), (int) y);
         }
+    }
+
+    private int drawLabelAtCanvasPoint(Graphics2D graphics, Point point, String text, int verticalOffset) {
+        if (point == null || text == null || text.isEmpty()) {
+            return 0;
+        }
+
+        Rectangle2D textBounds = graphics.getFontMetrics().getStringBounds(text, graphics);
+        double height = textBounds.getHeight();
+        int x = (int) (point.getX() - textBounds.getWidth() / 2);
+        int y = (int) (point.getY() - height) - verticalOffset;
+        graphics.setColor(Color.BLACK);
+        graphics.drawString(text, x + 1, y + 1);
+        graphics.setColor(plugin.colourText);
+        graphics.drawString(text, x, y);
+
+        return (int) height + TRANSPORT_LABEL_GAP;
+    }
+
+    private int drawLabelOnPlayerTile(Graphics2D graphics, String text, int verticalOffset) {
+        if (client.getLocalPlayer() == null) {
+            return 0;
+        }
+
+        Point playerPoint = Perspective.localToCanvas(client, client.getLocalPlayer().getLocalLocation(), client.getPlane());
+        return drawLabelAtCanvasPoint(graphics, playerPoint, text, verticalOffset);
     }
 
     private void drawTransportInfo(Graphics2D graphics, PathStep currentStep, PathStep nextStep, java.util.List<PathStep> path, int pathIndex) {
@@ -428,16 +462,7 @@ public class PathTileOverlay extends Overlay {
                     continue;
                 }
 
-                Rectangle2D textBounds = graphics.getFontMetrics().getStringBounds(text, graphics);
-                double height = textBounds.getHeight();
-                int x = (int) (p.getX() - textBounds.getWidth() / 2);
-                int y = (int) (p.getY() - height) - vertical_offset;
-                graphics.setColor(Color.BLACK);
-                graphics.drawString(text, x + 1, y + 1);
-                graphics.setColor(plugin.colourText);
-                graphics.drawString(text, x, y);
-
-                vertical_offset += (int) height + TRANSPORT_LABEL_GAP;
+                playerTileLabelOffset += drawLabelAtCanvasPoint(graphics, p, text, playerTileLabelOffset);
             }
         }
     }

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -137,13 +137,12 @@ public class PathTileOverlay extends Overlay {
                 plugin.colourPathCalculating.getGreen(),
                 plugin.colourPathCalculating.getBlue(),
                 plugin.colourPathCalculating.getAlpha() / 2);
-            Color color = plugin.getPathfinder().isDone()
-                ? new Color(
-                    plugin.colourPath.getRed(),
-                    plugin.colourPath.getGreen(),
-                    plugin.colourPath.getBlue(),
-                    plugin.colourPath.getAlpha() / 2)
-                : colorCalculating;
+            Color pathColor = plugin.getPathColor();
+            Color color = new Color(
+                pathColor.getRed(),
+                pathColor.getGreen(),
+                pathColor.getBlue(),
+                pathColor.getAlpha() / 2);
 
             PrimitiveIntList path = plugin.getPathfinder().getPath();
             int counter = 0;

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -136,17 +136,16 @@ public class PathTileOverlay extends Overlay {
 
         if (plugin.drawTiles && plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null) {
             Color colorCalculating = new Color(
-                    plugin.colourPathCalculating.getRed(),
-                    plugin.colourPathCalculating.getGreen(),
-                    plugin.colourPathCalculating.getBlue(),
-                    plugin.colourPathCalculating.getAlpha() / 2);
-            Color color = plugin.getPathfinder().isDone()
-                    ? new Color(
-                    plugin.colourPath.getRed(),
-                    plugin.colourPath.getGreen(),
-                    plugin.colourPath.getBlue(),
-                    plugin.colourPath.getAlpha() / 2)
-                    : colorCalculating;
+                plugin.colourPathCalculating.getRed(),
+                plugin.colourPathCalculating.getGreen(),
+                plugin.colourPathCalculating.getBlue(),
+                plugin.colourPathCalculating.getAlpha() / 2);
+            Color pathColor = plugin.getPathColor();
+            Color color = new Color(
+                pathColor.getRed(),
+                pathColor.getGreen(),
+                pathColor.getBlue(),
+                pathColor.getAlpha() / 2);
 
             java.util.List<PathStep> path = plugin.getPathfinder().getPath();
             int counter = 0;

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -24,6 +24,8 @@ public class PathTileOverlay extends Overlay {
     private final Client client;
     private final ShortestPathPlugin plugin;
     private static final int TRANSPORT_LABEL_GAP = 3;
+    private static final String UNREACHABLE_TEXT = "Destination could not be reached";
+    private int playerTileLabelOffset = 0;
 
     @Inject
     public PathTileOverlay(Client client, ShortestPathPlugin plugin) {
@@ -123,6 +125,8 @@ public class PathTileOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
+        playerTileLabelOffset = 0;
+
         if (plugin.drawTransports) {
             renderTransports(graphics);
         }
@@ -161,13 +165,22 @@ public class PathTileOverlay extends Overlay {
                         drawTile(graphics, path.get(i), color, counter, showTiles);
                     }
                     counter++;
-                    drawTransportInfo(graphics, path.get(i), (i + 1 == path.size()) ? WorldPointUtil.UNDEFINED : path.get(i + 1), path, i);
+                    drawTransportInfo(
+                        graphics,
+                        path.get(i),
+                        (i + 1 == path.size()) ? WorldPointUtil.UNDEFINED : path.get(i + 1),
+                        path,
+                        i);
                 }
                 for (int target : plugin.getPathfinder().getTargets()) {
                     if (path.size() > 0 && target != path.get(path.size() - 1)) {
                         drawTile(graphics, target, colorCalculating, -1, showTiles);
                     }
                 }
+            }
+
+            if (plugin.isPathUnreachable()) {
+                playerTileLabelOffset += drawLabelOnPlayerTile(graphics, UNREACHABLE_TEXT, playerTileLabelOffset);
             }
         }
 
@@ -295,6 +308,32 @@ public class PathTileOverlay extends Overlay {
         }
     }
 
+    private int drawLabelAtCanvasPoint(Graphics2D graphics, Point point, String text, int verticalOffset) {
+        if (point == null || text == null || text.isEmpty()) {
+            return 0;
+        }
+
+        Rectangle2D textBounds = graphics.getFontMetrics().getStringBounds(text, graphics);
+        double height = textBounds.getHeight();
+        int x = (int) (point.getX() - textBounds.getWidth() / 2);
+        int y = (int) (point.getY() - height) - verticalOffset;
+        graphics.setColor(Color.BLACK);
+        graphics.drawString(text, x + 1, y + 1);
+        graphics.setColor(plugin.colourText);
+        graphics.drawString(text, x, y);
+
+        return (int) height + TRANSPORT_LABEL_GAP;
+    }
+
+    private int drawLabelOnPlayerTile(Graphics2D graphics, String text, int verticalOffset) {
+        if (client.getLocalPlayer() == null) {
+            return 0;
+        }
+
+        Point playerPoint = Perspective.localToCanvas(client, client.getLocalPlayer().getLocalLocation(), client.getPlane());
+        return drawLabelAtCanvasPoint(graphics, playerPoint, text, verticalOffset);
+    }
+
     private void drawTransportInfo(Graphics2D graphics, int location, int locationEnd, PrimitiveIntList path, int pathIndex) {
         if (locationEnd == WorldPointUtil.UNDEFINED || !plugin.showTransportInfo ||
             WorldPointUtil.unpackWorldPlane(location) != client.getPlane()) {
@@ -332,20 +371,7 @@ public class PathTileOverlay extends Overlay {
                 return;
             }
             text = text + " (Exit: " + pohExitInfo + ")";
-
-            Point p = Perspective.localToCanvas(client, playerLocalPoint, client.getPlane());
-            if (p == null) {
-                return;
-            }
-
-            Rectangle2D textBounds = graphics.getFontMetrics().getStringBounds(text, graphics);
-            double height = textBounds.getHeight();
-            int x = (int) (p.getX() - textBounds.getWidth() / 2);
-            int y = (int) (p.getY() - height);
-            graphics.setColor(Color.BLACK);
-            graphics.drawString(text, x + 1, y + 1);
-            graphics.setColor(plugin.colourText);
-            graphics.drawString(text, x, y);
+            playerTileLabelOffset += drawLabelOnPlayerTile(graphics, text, playerTileLabelOffset);
             return;
         }
 
@@ -378,16 +404,7 @@ public class PathTileOverlay extends Overlay {
                     continue;
                 }
 
-                Rectangle2D textBounds = graphics.getFontMetrics().getStringBounds(text, graphics);
-                double height = textBounds.getHeight();
-                int x = (int) (p.getX() - textBounds.getWidth() / 2);
-                int y = (int) (p.getY() - height) - vertical_offset;
-                graphics.setColor(Color.BLACK);
-                graphics.drawString(text, x + 1, y + 1);
-                graphics.setColor(plugin.colourText);
-                graphics.drawString(text, x, y);
-
-                vertical_offset += (int) height + TRANSPORT_LABEL_GAP;
+                playerTileLabelOffset += drawLabelAtCanvasPoint(graphics, p, text, playerTileLabelOffset);
             }
         }
     }

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -27,7 +27,6 @@ public class PathTileOverlay extends Overlay {
     private final Client client;
     private final ShortestPathPlugin plugin;
     private static final int TRANSPORT_LABEL_GAP = 3;
-    private static final String UNREACHABLE_TEXT = "Destination could not be reached";
     private int playerTileLabelOffset = 0;
 
     @Inject
@@ -182,7 +181,7 @@ public class PathTileOverlay extends Overlay {
             }
 
             if (plugin.isPathUnreachable()) {
-                playerTileLabelOffset += drawLabelOnPlayerTile(graphics, UNREACHABLE_TEXT, playerTileLabelOffset);
+                playerTileLabelOffset += drawLabelOnPlayerTile(graphics, plugin.unreachableText, playerTileLabelOffset);
             }
         }
 
@@ -337,9 +336,9 @@ public class PathTileOverlay extends Overlay {
     }
 
     private void drawTransportInfo(Graphics2D graphics, PathStep currentStep, PathStep nextStep, java.util.List<PathStep> path, int pathIndex) {
-        int location = currentStep.getPackedPosition();
-        if (nextStep == null || !plugin.showTransportInfo ||
-            WorldPointUtil.unpackWorldPlane(location) != client.getTopLevelWorldView().getPlane()) {
+		int location = currentStep.getPackedPosition();
+		if (nextStep == null || !plugin.showTransportInfo || plugin.isPathUnreachable() ||
+			WorldPointUtil.unpackWorldPlane(location) != client.getTopLevelWorldView().getPlane()) {
             return;
         }
         int locationEnd = nextStep.getPackedPosition();

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -339,11 +339,27 @@ public interface ShortestPathConfig extends Config {
         return 5;
     }
 
+    @Range(
+        min = 0,
+        max = 20000
+    )
+    @ConfigItem(
+        keyName = "unreachableTargetDistanceThreshold",
+        name = "Unreachable target distance",
+        description = "Distance from the target at which a finished path is considered not to reach the target." +
+        "<br>Useful for determining if a path is potentially invalid.",
+        position = 28,
+        section = sectionSettings
+    )
+    default int unreachableTargetDistance() {
+        return 20;
+    }
+
     @ConfigItem(
         keyName = "showTileCounter",
         name = "Show tile counter",
         description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-        position = 28,
+        position = 29,
         section = sectionSettings
     )
     default TileCounter showTileCounter() {
@@ -354,7 +370,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "tileCounterStep",
         name = "Tile counter step",
         description = "The number of tiles between the displayed tile counter numbers",
-        position = 29,
+        position = 30,
         section = sectionSettings
     )
     default int tileCounterStep()
@@ -374,7 +390,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculation cutoff",
         description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
             "made towards the path target before the calculation will be stopped",
-        position = 30,
+        position = 31,
         section = sectionSettings
     )
     default int calculationCutoff()
@@ -386,7 +402,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "showTransportInfo",
         name = "Show transport info",
         description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-        position = 31,
+        position = 32,
         section = sectionSettings
     )
     default boolean showTransportInfo() {
@@ -946,10 +962,22 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
+        keyName = "colourPathUnreachable",
+        name = "Unreachable",
+        description = "Colour of the path tiles when pathfinding has finished but the target is still too far away",
+        position = 72,
+        section = sectionColours
+    )
+    default Color colourPathUnreachable() {
+        return new Color(200, 40, 240);
+    }
+
+    @Alpha
+    @ConfigItem(
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 72,
+        position = 73,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -961,7 +989,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 73,
+        position = 74,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -973,7 +1001,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 74,
+        position = 75,
         section = sectionColours
     )
     default Color colourText() {

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -353,7 +353,7 @@ public interface ShortestPathConfig extends Config {
         section = sectionSettings
     )
     default int unreachableTargetDistance() {
-        return 20;
+        return 2;
     }
 
     @ConfigItem(

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -1107,6 +1107,16 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigItem(
+        keyName = "unreachableText",
+        name = "",
+        description = "Text shown on the player tile when the destination cannot be reached",
+        hidden = true
+    )
+    default String unreachableText() {
+        return "Destination could not be reached";
+    }
+
+    @ConfigItem(
         keyName = "builtTeleportationBoxes",
         name = "",
         description = "ID=X Y Z;ID=X Y Z;ID=X Y Z",

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -340,11 +340,27 @@ public interface ShortestPathConfig extends Config {
         return 5;
     }
 
+    @Range(
+        min = 0,
+        max = 20000
+    )
+    @ConfigItem(
+        keyName = "unreachableTargetDistanceThreshold",
+        name = "Unreachable target distance",
+        description = "Distance from the target at which a finished path is considered not to reach the target." +
+        "<br>Useful for determining if a path is potentially invalid.",
+        position = 28,
+        section = sectionSettings
+    )
+    default int unreachableTargetDistance() {
+        return 20;
+    }
+
     @ConfigItem(
         keyName = "showTileCounter",
         name = "Show tile counter",
         description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-        position = 28,
+        position = 29,
         section = sectionSettings
     )
     default TileCounter showTileCounter() {
@@ -355,7 +371,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "tileCounterStep",
         name = "Tile counter step",
         description = "The number of tiles between the displayed tile counter numbers",
-        position = 29,
+        position = 30,
         section = sectionSettings
     )
     default int tileCounterStep()
@@ -375,7 +391,7 @@ public interface ShortestPathConfig extends Config {
         name = "Calculation cutoff",
         description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
             "made towards the path target before the calculation will be stopped",
-        position = 30,
+        position = 31,
         section = sectionSettings
     )
     default int calculationCutoff()
@@ -387,7 +403,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "showTransportInfo",
         name = "Show transport info",
         description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-        position = 31,
+        position = 32,
         section = sectionSettings
     )
     default boolean showTransportInfo() {
@@ -974,10 +990,22 @@ public interface ShortestPathConfig extends Config {
 
     @Alpha
     @ConfigItem(
+        keyName = "colourPathUnreachable",
+        name = "Unreachable",
+        description = "Colour of the path tiles when pathfinding has finished but the target is still too far away",
+        position = 72,
+        section = sectionColours
+    )
+    default Color colourPathUnreachable() {
+        return new Color(200, 40, 240);
+    }
+
+    @Alpha
+    @ConfigItem(
         keyName = "colourTransports",
         name = "Transports",
         description = "Colour of the transport tiles",
-        position = 74,
+        position = 73,
         section = sectionColours
     )
     default Color colourTransports() {
@@ -989,7 +1017,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourCollisionMap",
         name = "Collision map",
         description = "Colour of the collision map tiles",
-        position = 75,
+        position = 74,
         section = sectionColours
     )
     default Color colourCollisionMap() {
@@ -1001,7 +1029,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "colourText",
         name = "Text",
         description = "Colour of the text of the tile counter and fairy ring codes",
-        position = 76,
+        position = 75,
         section = sectionColours
     )
     default Color colourText() {

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -352,7 +352,7 @@ public interface ShortestPathConfig extends Config {
         section = sectionSettings
     )
     default int unreachableTargetDistance() {
-        return 20;
+        return 2;
     }
 
     @ConfigItem(

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -161,6 +161,7 @@ public class ShortestPathPlugin extends Plugin {
     Color colourTransports;
     int tileCounterStep;
     int unreachableTargetDistance;
+    String unreachableText;
     TileCounter showTileCounter;
     TileStyle pathStyle;
 
@@ -300,7 +301,7 @@ public class ShortestPathPlugin extends Plugin {
             return colourPathCalculating;
         }
 
-        PrimitiveIntList path = pathfinder.getPath();
+        List<PathStep> path = pathfinder.getPath();
         if (path == null || path.isEmpty() || pathfinder.getTargets().isEmpty()) {
             return colourPath;
         }
@@ -317,12 +318,12 @@ public class ShortestPathPlugin extends Plugin {
             return false;
         }
 
-        PrimitiveIntList path = pathfinder.getPath();
+        List<PathStep> path = pathfinder.getPath();
         if (path == null || path.isEmpty() || pathfinder.getTargets().isEmpty()) {
             return false;
         }
 
-        int endPoint = path.get(path.size() - 1);
+        int endPoint = path.get(path.size() - 1).getPackedPosition();
         int closestTargetDistance = Integer.MAX_VALUE;
         for (int target : pathfinder.getTargets()) {
             closestTargetDistance = Math.min(closestTargetDistance, WorldPointUtil.distanceBetween(target, endPoint));
@@ -1064,6 +1065,7 @@ public class ShortestPathPlugin extends Plugin {
 
         tileCounterStep = override("tileCounterStep", config.tileCounterStep());
         unreachableTargetDistance = override("unreachableTargetDistanceThreshold", config.unreachableTargetDistance());
+        unreachableText = config.unreachableText();
 
         showTileCounter = override("showTileCounter", config.showTileCounter());
         pathStyle = override("pathStyle", config.pathStyle());

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -305,17 +305,30 @@ public class ShortestPathPlugin extends Plugin {
             return colourPath;
         }
 
+        if (isPathUnreachable()) {
+            return colourPathUnreachable;
+        }
+
+        return colourPath;
+    }
+
+    public boolean isPathUnreachable() {
+        if (pathfinder == null || !pathfinder.isDone()) {
+            return false;
+        }
+
+        PrimitiveIntList path = pathfinder.getPath();
+        if (path == null || path.isEmpty() || pathfinder.getTargets().isEmpty()) {
+            return false;
+        }
+
         int endPoint = path.get(path.size() - 1);
         int closestTargetDistance = Integer.MAX_VALUE;
         for (int target : pathfinder.getTargets()) {
             closestTargetDistance = Math.min(closestTargetDistance, WorldPointUtil.distanceBetween(target, endPoint));
         }
 
-        if (closestTargetDistance > unreachableTargetDistance) {
-            return colourPathUnreachable;
-        }
-
-        return colourPath;
+        return closestTargetDistance > unreachableTargetDistance;
     }
 
     @Subscribe

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -156,9 +156,11 @@ public class ShortestPathPlugin extends Plugin {
     Color colourCollisionMap;
     Color colourPath;
     Color colourPathCalculating;
+    Color colourPathUnreachable;
     Color colourText;
     Color colourTransports;
     int tileCounterStep;
+    int unreachableTargetDistance;
     TileCounter showTileCounter;
     TileStyle pathStyle;
 
@@ -291,6 +293,29 @@ public class ShortestPathPlugin extends Plugin {
         }
 
         return false;
+    }
+
+    public Color getPathColor() {
+        if (pathfinder == null || !pathfinder.isDone()) {
+            return colourPathCalculating;
+        }
+
+        PrimitiveIntList path = pathfinder.getPath();
+        if (path == null || path.isEmpty() || pathfinder.getTargets().isEmpty()) {
+            return colourPath;
+        }
+
+        int endPoint = path.get(path.size() - 1);
+        int closestTargetDistance = Integer.MAX_VALUE;
+        for (int target : pathfinder.getTargets()) {
+            closestTargetDistance = Math.min(closestTargetDistance, WorldPointUtil.distanceBetween(target, endPoint));
+        }
+
+        if (closestTargetDistance > unreachableTargetDistance) {
+            return colourPathUnreachable;
+        }
+
+        return colourPath;
     }
 
     @Subscribe
@@ -1020,10 +1045,12 @@ public class ShortestPathPlugin extends Plugin {
         colourCollisionMap = override("colourCollisionMap", config.colourCollisionMap());
         colourPath = override("colourPath", config.colourPath());
         colourPathCalculating = override("colourPathCalculating", config.colourPathCalculating());
+        colourPathUnreachable = override("colourPathUnreachable", config.colourPathUnreachable());
         colourText = override("colourText", config.colourText());
         colourTransports = override("colourTransports", config.colourTransports());
 
         tileCounterStep = override("tileCounterStep", config.tileCounterStep());
+        unreachableTargetDistance = override("unreachableTargetDistanceThreshold", config.unreachableTargetDistance());
 
         showTileCounter = override("showTileCounter", config.showTileCounter());
         pathStyle = override("pathStyle", config.pathStyle());

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -76,7 +76,7 @@ import shortestpath.transport.TransportType;
 )
 public class ShortestPathPlugin extends Plugin {
     protected static final String CONFIG_GROUP = "shortestpath";
-    
+
     // POH (Player Owned House) bounds for detecting when path goes through POH
     // Note: POH_MIN_X is 1856 to exclude the Daddy's Home miniquest area
     private static final int POH_MIN_X = 1856;
@@ -145,9 +145,11 @@ public class ShortestPathPlugin extends Plugin {
     Color colourCollisionMap;
     Color colourPath;
     Color colourPathCalculating;
+    Color colourPathUnreachable;
     Color colourText;
     Color colourTransports;
     int tileCounterStep;
+    int unreachableTargetDistance;
     TileCounter showTileCounter;
     TileStyle pathStyle;
 
@@ -258,6 +260,29 @@ public class ShortestPathPlugin extends Plugin {
         }
 
         return false;
+    }
+
+    public Color getPathColor() {
+        if (pathfinder == null || !pathfinder.isDone()) {
+            return colourPathCalculating;
+        }
+
+        PrimitiveIntList path = pathfinder.getPath();
+        if (path == null || path.isEmpty() || pathfinder.getTargets().isEmpty()) {
+            return colourPath;
+        }
+
+        int endPoint = path.get(path.size() - 1);
+        int closestTargetDistance = Integer.MAX_VALUE;
+        for (int target : pathfinder.getTargets()) {
+            closestTargetDistance = Math.min(closestTargetDistance, WorldPointUtil.distanceBetween(target, endPoint));
+        }
+
+        if (closestTargetDistance > unreachableTargetDistance) {
+            return colourPathUnreachable;
+        }
+
+        return colourPath;
     }
 
     @Subscribe
@@ -701,10 +726,10 @@ public class ShortestPathPlugin extends Plugin {
         if (path == null || currentIndex < 0) {
             return null;
         }
-        
+
         int destX = WorldPointUtil.unpackWorldX(destination);
         int destY = WorldPointUtil.unpackWorldY(destination);
-        
+
         // Check if destination is inside POH
         if (!isInsidePoh(destX, destY)) {
             return null;
@@ -717,16 +742,16 @@ public class ShortestPathPlugin extends Plugin {
         for (int i = currentIndex + 1; i < path.size() - 1; i++) {
             int stepLocation = path.get(i);
             int nextLocation = path.get(i + 1);
-            
+
             int stepX = WorldPointUtil.unpackWorldX(stepLocation);
             int stepY = WorldPointUtil.unpackWorldY(stepLocation);
             int nextX = WorldPointUtil.unpackWorldX(nextLocation);
             int nextY = WorldPointUtil.unpackWorldY(nextLocation);
-            
+
             // Check if this step is inside POH but next step is outside (exit transport)
             boolean stepInsidePoh = isInsidePoh(stepX, stepY);
             boolean nextInsidePoh = isInsidePoh(nextX, nextY);
-            
+
             if (stepInsidePoh && !nextInsidePoh) {
                 pohExitIndex = i + 1; // Index of the first step outside POH
                 // Found the exit transport - get its display info
@@ -765,13 +790,13 @@ public class ShortestPathPlugin extends Plugin {
                 }
                 break;
             }
-            
+
             // If we've left POH without finding a transport, stop looking
             if (!stepInsidePoh) {
                 break;
             }
         }
-        
+
         return immediateExitInfo;
     }
 
@@ -884,10 +909,12 @@ public class ShortestPathPlugin extends Plugin {
         colourCollisionMap = override("colourCollisionMap", config.colourCollisionMap());
         colourPath = override("colourPath", config.colourPath());
         colourPathCalculating = override("colourPathCalculating", config.colourPathCalculating());
+        colourPathUnreachable = override("colourPathUnreachable", config.colourPathUnreachable());
         colourText = override("colourText", config.colourText());
         colourTransports = override("colourTransports", config.colourTransports());
 
         tileCounterStep = override("tileCounterStep", config.tileCounterStep());
+        unreachableTargetDistance = override("unreachableTargetDistanceThreshold", config.unreachableTargetDistance());
 
         showTileCounter = override("showTileCounter", config.showTileCounter());
         pathStyle = override("pathStyle", config.pathStyle());

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -272,17 +272,30 @@ public class ShortestPathPlugin extends Plugin {
             return colourPath;
         }
 
+        if (isPathUnreachable()) {
+            return colourPathUnreachable;
+        }
+
+        return colourPath;
+    }
+
+    public boolean isPathUnreachable() {
+        if (pathfinder == null || !pathfinder.isDone()) {
+            return false;
+        }
+
+        PrimitiveIntList path = pathfinder.getPath();
+        if (path == null || path.isEmpty() || pathfinder.getTargets().isEmpty()) {
+            return false;
+        }
+
         int endPoint = path.get(path.size() - 1);
         int closestTargetDistance = Integer.MAX_VALUE;
         for (int target : pathfinder.getTargets()) {
             closestTargetDistance = Math.min(closestTargetDistance, WorldPointUtil.distanceBetween(target, endPoint));
         }
 
-        if (closestTargetDistance > unreachableTargetDistance) {
-            return colourPathUnreachable;
-        }
-
-        return colourPath;
+        return closestTargetDistance > unreachableTargetDistance;
     }
 
     @Subscribe


### PR DESCRIPTION
This allows a visual indication of a path that wasn't able to get within X tiles of the target (and so is potentially invalid due to collision maps, transports, teleports, etc).

<img width="838" height="482" alt="CleanShot 2026-04-16 at 08 56 48@2x" src="https://github.com/user-attachments/assets/6a1e08d4-2e62-4748-ab7e-b073593d4785" />
<img width="1014" height="702" alt="CleanShot 2026-04-16 at 09 04 02@2x" src="https://github.com/user-attachments/assets/3a6f7c58-e9da-417d-b222-27896b5e276d" />
