### PR TITLE
Add a configurable hotkey to clear/reset current path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,10 @@ root = true
 [*]
 insert_final_newline = true
 
+[*.java]
+indent_style = space
+indent_size = 4
+
 [*.tsv]
 indent_style = tab
 trim_trailing_whitespace = false

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -14,15 +14,6 @@ public interface ShortestPathConfig extends Config {
     String sectionSettings = "sectionSettings";
 
     @ConfigItem(
-            keyName = "clearPathHotkey",
-            name = "Clear path hotkey",
-            description = "Hotkey to clear the current path",
-            position = 0,
-            section = sectionSettings
-    )
-    default Keybind clearPathHotkey() { return Keybind.NOT_SET; };
-
-    @ConfigItem(
         keyName = "avoidWilderness",
         name = "Avoid wilderness",
         description = "Whether the wilderness should be avoided if possible<br>" +
@@ -985,9 +976,25 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigSection(
+            name = "Hotkeys",
+            description = "Options for keyboard shortcuts",
+            position = 75
+    )
+    String sectionHotkeys = "sectionHotkeys";
+
+    @ConfigItem(
+            keyName = "clearPathHotkey",
+            name = "Clear current path",
+            description = "Hotkey to clear the current path",
+            position = 76,
+            section = sectionHotkeys
+    )
+    default Keybind clearPathHotkey() { return Keybind.NOT_SET; };
+
+    @ConfigSection(
         name = "Debug Options",
         description = "Various options for debugging",
-        position = 75,
+        position = 77,
         closedByDefault = true
     )
     String sectionDebug = "sectionDebug";
@@ -996,7 +1003,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawTransports",
         name = "Draw transports",
         description = "Whether transports should be drawn",
-        position = 76,
+        position = 78,
         section = sectionDebug
     )
     default boolean drawTransports() {
@@ -1007,7 +1014,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawCollisionMap",
         name = "Draw collision map",
         description = "Whether the collision map should be drawn",
-        position = 77,
+        position = 79,
         section = sectionDebug
     )
     default boolean drawCollisionMap() {
@@ -1018,7 +1025,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "drawDebugPanel",
         name = "Show debug panel",
         description = "Toggles displaying the pathfinding debug stats panel",
-        position = 78,
+        position = 80,
         section = sectionDebug
     )
     default boolean drawDebugPanel() {
@@ -1029,7 +1036,7 @@ public interface ShortestPathConfig extends Config {
         keyName = "postTransports",
         name = "Post transports",
         description = "Whether to post the transports used in the current path as a PluginMessage event",
-        position = 79,
+        position = 81,
         section = sectionDebug
     )
     default boolean postTransports() {

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -1,13 +1,8 @@
 package shortestpath;
 
 import java.awt.Color;
-import net.runelite.client.config.Alpha;
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.ConfigSection;
-import net.runelite.client.config.Range;
-import net.runelite.client.config.Units;
+
+import net.runelite.client.config.*;
 
 @ConfigGroup(ShortestPathPlugin.CONFIG_GROUP)
 public interface ShortestPathConfig extends Config {
@@ -17,6 +12,15 @@ public interface ShortestPathConfig extends Config {
         position = 0
     )
     String sectionSettings = "sectionSettings";
+
+    @ConfigItem(
+            keyName = "clearPathHotkey",
+            name = "Clear path hotkey",
+            description = "Hotkey to clear the current path",
+            position = 0,
+            section = sectionSettings
+    )
+    default Keybind clearPathHotkey() { return Keybind.NOT_SET; };
 
     @ConfigItem(
         keyName = "avoidWilderness",

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -989,7 +989,9 @@ public interface ShortestPathConfig extends Config {
             position = 76,
             section = sectionHotkeys
     )
-    default Keybind clearPathHotkey() { return Keybind.NOT_SET; };
+    default Keybind clearPathHotkey() {
+        return Keybind.NOT_SET;
+    };
 
     @ConfigSection(
         name = "Debug Options",

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -982,18 +982,18 @@ public interface ShortestPathConfig extends Config {
     }
 
     @ConfigSection(
-            name = "Hotkeys",
-            description = "Options for keyboard shortcuts",
-            position = 75
+        name = "Hotkeys",
+        description = "Options for keyboard shortcuts",
+        position = 75
     )
     String sectionHotkeys = "sectionHotkeys";
 
-    @ConfigItem(
-            keyName = "clearPathHotkey",
-            name = "Clear current path",
-            description = "Hotkey to clear the current path",
-            position = 76,
-            section = sectionHotkeys
+  @ConfigItem(
+        keyName = "clearPathHotkey",
+        name = "Clear current path",
+        description = "Hotkey to clear the current path",
+          position = 76,
+        section = sectionHotkeys
     )
     default Keybind clearPathHotkey() {
         return Keybind.NOT_SET;

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -1,8 +1,14 @@
 package shortestpath;
 
 import java.awt.Color;
-
-import net.runelite.client.config.*;
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+import net.runelite.client.config.Units;
+import net.runelite.client.config.Keybind;
 
 @ConfigGroup(ShortestPathPlugin.CONFIG_GROUP)
 public interface ShortestPathConfig extends Config {

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -7,6 +7,7 @@ import java.awt.Color;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.Shape;
+import java.awt.event.KeyEvent;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
@@ -53,6 +54,8 @@ import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.PluginMessage;
 import net.runelite.client.game.SpriteManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.JagexColors;
@@ -136,6 +139,9 @@ public class ShortestPathPlugin extends Plugin {
     @Inject
     private WorldMapPointManager worldMapPointManager;
 
+    @Inject
+    private KeyManager keyManager;
+
     boolean drawCollisionMap;
     boolean drawMap;
     boolean drawMinimap;
@@ -197,6 +203,8 @@ public class ShortestPathPlugin extends Plugin {
         if (config.drawDebugPanel()) {
             overlayManager.add(debugOverlayPanel);
         }
+
+        keyManager.registerKeyListener(clearPathKeylistener);
     }
 
     @Override
@@ -211,6 +219,8 @@ public class ShortestPathPlugin extends Plugin {
             pathfindingExecutor.shutdownNow();
             pathfindingExecutor = null;
         }
+
+        keyManager.unregisterKeyListener(clearPathKeylistener);
     }
 
     public void restartPathfinding(int start, Set<Integer> ends, boolean canReviveFiltered) {
@@ -537,6 +547,23 @@ public class ShortestPathPlugin extends Plugin {
             }
         }
     }
+
+    private final KeyListener clearPathKeylistener = new KeyListener() {
+        @Override
+        public void keyTyped(KeyEvent e) {
+        }
+
+        @Override
+        public void keyPressed(KeyEvent e) {
+            if(config.clearPathHotkey().matches(e)){
+                setTarget(WorldPointUtil.UNDEFINED);
+            }
+        }
+
+        @Override
+        public void keyReleased(KeyEvent e) {
+        }
+    };
 
     private static final Pattern SPIRIT_TREE_LABEL_PATTERN_MENU = Pattern.compile("<col=735a28>(.+)</col>: (<col=5f5f5f>)?(.+)");
     private static final Pattern SPIRIT_TREE_LABEL_PATTERN_MENU_NEW = Pattern.compile("<col=ffffff>(.+)</col>: (<col=5f5f5f>)?(.+)");

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -174,6 +174,23 @@ public class ShortestPathPlugin extends Plugin {
     private Future<?> pathfinderFuture;
     private final Object pathfinderMutex = new Object();
     private static final Map<String, Object> configOverride = new HashMap<>(50);
+    private final KeyListener clearPathKeylistener = new KeyListener() {
+        @Override
+        public void keyTyped(KeyEvent e) {
+        }
+
+        @Override
+        public void keyPressed(KeyEvent e) {
+            if(config.clearPathHotkey().matches(e)){
+                setTarget(WorldPointUtil.UNDEFINED);
+            }
+        }
+
+        @Override
+        public void keyReleased(KeyEvent e) {
+        }
+    };
+
     @Getter
     private Pathfinder pathfinder;
     @Getter
@@ -547,23 +564,6 @@ public class ShortestPathPlugin extends Plugin {
             }
         }
     }
-
-    private final KeyListener clearPathKeylistener = new KeyListener() {
-        @Override
-        public void keyTyped(KeyEvent e) {
-        }
-
-        @Override
-        public void keyPressed(KeyEvent e) {
-            if(config.clearPathHotkey().matches(e)){
-                setTarget(WorldPointUtil.UNDEFINED);
-            }
-        }
-
-        @Override
-        public void keyReleased(KeyEvent e) {
-        }
-    };
 
     private static final Pattern SPIRIT_TREE_LABEL_PATTERN_MENU = Pattern.compile("<col=735a28>(.+)</col>: (<col=5f5f5f>)?(.+)");
     private static final Pattern SPIRIT_TREE_LABEL_PATTERN_MENU_NEW = Pattern.compile("<col=ffffff>(.+)</col>: (<col=5f5f5f>)?(.+)");


### PR DESCRIPTION
This PR adds a configurable hotkey that allows you to easily clear/reset the current path.

<img width="234" height="580" alt="image" src="https://github.com/user-attachments/assets/7c2de58b-bfa8-441d-bc9e-eb0beaa8eed7" />


The hotkey is disabled by default; to enable, just change the setting to your preferred hotkey.