### PR TITLE
Align linting with RuneLite.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+name: Lint
+
+# Runs `./gradlew check` and uploads the Checkstyle reports.
+# Non-blocking for now since the project is not conformant.
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Gradle Check (Java 11)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "11"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run checkstyle
+        continue-on-error: true
+        run: ./gradlew check --stacktrace
+        shell: bash
+
+      - name: Upload Checkstyle HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-html
+          path: build/reports/checkstyle
+          if-no-files-found: warn
+
+      - name: Upload Checkstyle XML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-xml
+          path: build/reports/checkstyle/*.xml
+          if-no-files-found: warn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run checkstyle
         continue-on-error: true
-        run: ./gradlew check
+        run: ./gradlew checkstyleMain checkstyleTest
         shell: bash
 
       - name: Upload Checkstyle HTML report

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run checkstyle
         continue-on-error: true
-        run: ./gradlew check --stacktrace
+        run: ./gradlew check
         shell: bash
 
       - name: Upload Checkstyle HTML report

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group = 'shortestpath'
-version = '1.18.0'
+version = '1.19.0'
 sourceCompatibility = '1.11'
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'me.champeau.jmh' version '0.7.2'
+    id 'checkstyle'
 }
 
 repositories {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!-- This file should be kept in sync with RuneLite's checkstyle.xml file. -->
+<!-- https://github.com/runelite/runelite/blob/master/config/checkstyle/checkstyle.xml -->
+<!DOCTYPE module PUBLIC
+	"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+	"https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+	<property name="charset" value="UTF-8"/>
+	<module name="TreeWalker">
+		<module name="LeftCurly">
+			<property name="option" value="nl"/>
+		</module>
+		<module name="RightCurly">
+			<property name="option" value="alone"/>
+		</module>
+		<!-- require tabs for indenting - https://stackoverflow.com/a/28550141 -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\t* "/>
+			<property name="message" value="Indent must use tab characters"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="RegexpSinglelineJava">
+			<property name="format" value=".*\s+$"/>
+			<property name="message" value="No trailing whitespace"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="WhitespaceAround"/>
+		<module name="WhitespaceAfter">
+			<property name="tokens" value="COMMA"/>
+		</module>
+		<module name="UnusedImports"/>
+		<module name="SuppressionCommentFilter"/>
+	</module>
+	<module name="RegexpMultiline">
+		<property name="format" value="else[ \t]*[\r\n]+[ \t]*if"/>
+		<property name="message" value="Newline should not be between else and if"/>
+	</module>
+	<module name="SuppressionFilter">
+		<property name="file" value="${config_loc}/suppressions.xml"/>
+	</module>
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+	"-//Checkstyle//DTD SuppressionFilter Configuration 1.1//EN"
+	"https://checkstyle.org/dtds/suppressions_1_1.dtd">
+<suppressions>
+</suppressions>

--- a/config/intellij/runelite-codestyle.xml
+++ b/config/intellij/runelite-codestyle.xml
@@ -1,0 +1,63 @@
+<code_scheme name="RuneLite" version="173">
+  <option name="AUTODETECT_INDENTS" value="false" />
+  <option name="OTHER_INDENT_OPTIONS">
+    <value>
+      <option name="USE_TAB_CHARACTER" value="true" />
+    </value>
+  </option>
+  <option name="LINE_SEPARATOR" value="&#10;" />
+  <JavaCodeStyleSettings>
+    <option name="LAYOUT_STATIC_IMPORTS_SEPARATELY" value="false" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+      <value />
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="false" />
+      </value>
+    </option>
+  </JavaCodeStyleSettings>
+  <XML>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <codeStyleSettings language="JAVA">
+    <option name="BRACE_STYLE" value="2" />
+    <option name="CLASS_BRACE_STYLE" value="2" />
+    <option name="METHOD_BRACE_STYLE" value="2" />
+    <option name="ELSE_ON_NEW_LINE" value="true" />
+    <option name="CATCH_ON_NEW_LINE" value="true" />
+    <option name="FINALLY_ON_NEW_LINE" value="true" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="USE_TAB_CHARACTER" value="true" />
+    </indentOptions>
+    <arrangement>
+      <groups>
+        <group>
+          <type>GETTERS_AND_SETTERS</type>
+          <order>KEEP</order>
+        </group>
+        <group>
+          <type>OVERRIDDEN_METHODS</type>
+          <order>BY_NAME</order>
+        </group>
+      </groups>
+    </arrangement>
+  </codeStyleSettings>
+  <codeStyleSettings language="Python">
+    <indentOptions>
+      <option name="USE_TAB_CHARACTER" value="true" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <indentOptions>
+      <option name="USE_TAB_CHARACTER" value="true" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
This change adds `checkstyle` to the project along with a GitHub workflow to invoke it on pull requests to the default branch. Currently, this workflow is allowed to fail as we have to make some substantial changes to the repo. This includes replacing all indents - which should probably wait until after some of the new features and fixes have merge so as not to make an existing job harder.