### PR TITLE
dashboard: Add pathfinder profiler and dashboard CI pipeline

### DIFF
--- a/.github/workflows/dashboard-pages.yml
+++ b/.github/workflows/dashboard-pages.yml
@@ -36,6 +36,10 @@ jobs:
         run: ./gradlew dashboard -PdashboardDataset=/reachability/routes.csv -PdashboardProfile=true --stacktrace
         shell: bash
 
+      - name: Build quetzal whistle routes dashboard
+        run: ./gradlew dashboard -PdashboardDataset=/reachability/quetzal_whistle_routes.csv -PdashboardProfile=true --stacktrace
+        shell: bash
+
       - name: Upload dashboard bundle artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dashboard-pages.yml
+++ b/.github/workflows/dashboard-pages.yml
@@ -32,6 +32,10 @@ jobs:
         run: ./gradlew clean dashboardSite -PclueStepsDashboardDataset=/reachability/clue_locations_full.csv -PtargetsDashboardDataset=/reachability/targets.csv --stacktrace
         shell: bash
 
+      - name: Build profiled routes dashboard
+        run: ./gradlew dashboard -PdashboardDataset=/reachability/routes.csv -PdashboardProfile=true --stacktrace
+        shell: bash
+
       - name: Upload dashboard bundle artifact
         uses: actions/upload-artifact@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
+    id 'me.champeau.jmh' version '0.7.2'
 }
 
 repositories {
@@ -19,7 +20,6 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.6'
-    testImplementation 'org.apache.commons:commons-csv:1.11.0'
     testImplementation 'com.google.code.gson:gson:2.10.1'
     testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
     testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
@@ -34,10 +34,18 @@ tasks.withType(JavaCompile) {
 }
 
 def dashboardOutputRoot = layout.buildDirectory.dir('reports/pathfinder-dashboard')
-def clueStepsDashboardDataset = providers.gradleProperty('clueStepsDashboardDataset')
-    .orElse('/reachability/clue_locations_full.csv')
-def targetsDashboardDataset = providers.gradleProperty('targetsDashboardDataset')
-    .orElse('/reachability/targets.csv')
+def dashboardDataset = providers.gradleProperty('dashboardDataset')
+    .orElse('/reachability/routes.csv')
+def dashboardScenario = providers.gradleProperty('dashboardScenario')
+    .orElse('')
+def dashboardTitle = providers.gradleProperty('dashboardTitle')
+    .orElse('Pathfinder Dashboard')
+def dashboardSubtitle = providers.gradleProperty('dashboardSubtitle')
+    .orElse('')
+def dashboardProfile = providers.gradleProperty('dashboardProfile')
+    .orElse('true')
+def dashboardBundle = providers.gradleProperty('dashboardBundle')
+    .orElse('routes')
 
 def logDashboardLocation = { String taskName ->
     File dashboardDir = dashboardOutputRoot.get().asFile
@@ -51,9 +59,59 @@ test {
     jvmArgs = ['-Xms1g', '-Xmx8g']
 }
 
+tasks.register('dashboard', Test) {
+    group = 'verification'
+    description = 'Builds the pathfinder dashboard. Use -PdashboardDataset=... to set the input file, -PdashboardScenario=profiler for profiling.'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnit()
+    include 'shortestpath/reachability/ReachabilityDashboardTest.class'
+    ignoreFailures = true
+    systemProperty 'runReachabilityVerification', 'true'
+    systemProperty 'reachability.dataset', dashboardDataset.get()
+    systemProperty 'reachability.reportTitle', dashboardTitle.get()
+    systemProperty 'reachability.reportSubtitle', dashboardSubtitle.get()
+    systemProperty 'reachability.profile', dashboardProfile.get()
+    systemProperty 'dashboard.outputRoot', dashboardOutputRoot.get().asFile.absolutePath
+    def scenarioValue = dashboardScenario.get()
+    if (scenarioValue && !scenarioValue.isEmpty()) {
+        systemProperty 'reachability.scenario', scenarioValue
+    }
+    systemProperty 'dashboard.bundleName', dashboardBundle.get()
+    jvmArgs = ['-Xms1g', '-Xmx8g']
+    testLogging {
+        showStandardStreams = true
+    }
+    doLast {
+        logDashboardLocation(name)
+    }
+}
+
+tasks.register('scenarioDashboard', Test) {
+    group = 'verification'
+    description = 'Builds the pathfinder scenario dashboard from PathfinderTest'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnit()
+    include 'shortestpath/pathfinder/PathfinderTest.class'
+    ignoreFailures = true
+    systemProperty 'dashboard.outputRoot', dashboardOutputRoot.get().asFile.absolutePath
+    systemProperty 'dashboard.bundleName', 'pathfinder-tests'
+    jvmArgs = ['-Xms1g', '-Xmx8g']
+    doLast {
+        logDashboardLocation(name)
+    }
+}
+
+// Convenience task properties for multi-bundle builds
+def clueStepsDashboardDataset = providers.gradleProperty('clueStepsDashboardDataset')
+    .orElse('/reachability/clue_locations_full.csv')
+def targetsDashboardDataset = providers.gradleProperty('targetsDashboardDataset')
+    .orElse('/reachability/targets.tsv')
+
 tasks.register('clueStepsDashboard', Test) {
     group = 'verification'
-    description = 'Builds the clue steps dashboard bundle'
+    description = 'Builds the clue-steps dashboard bundle'
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
     useJUnit()
@@ -61,10 +119,11 @@ tasks.register('clueStepsDashboard', Test) {
     ignoreFailures = true
     systemProperty 'runReachabilityVerification', 'true'
     systemProperty 'reachability.dataset', clueStepsDashboardDataset.get()
-    systemProperty 'reachability.bundleId', 'clue-steps-default'
-    systemProperty 'reachability.reportTitle', 'Clue Steps'
+    systemProperty 'reachability.reportTitle', 'Clue Steps Default'
     systemProperty 'reachability.reportSubtitle', 'Clue steps sweep from bank start'
+    systemProperty 'reachability.profile', 'false'
     systemProperty 'dashboard.outputRoot', dashboardOutputRoot.get().asFile.absolutePath
+    systemProperty 'dashboard.bundleName', 'clue-steps-default'
     jvmArgs = ['-Xms1g', '-Xmx8g']
     doLast {
         logDashboardLocation(name)
@@ -73,7 +132,7 @@ tasks.register('clueStepsDashboard', Test) {
 
 tasks.register('targetsDashboard', Test) {
     group = 'verification'
-    description = 'Builds the lightweight reported-targets dashboard bundle'
+    description = 'Builds the reported-targets dashboard bundle'
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
     useJUnit()
@@ -81,25 +140,11 @@ tasks.register('targetsDashboard', Test) {
     ignoreFailures = true
     systemProperty 'runReachabilityVerification', 'true'
     systemProperty 'reachability.dataset', targetsDashboardDataset.get()
-    systemProperty 'reachability.bundleId', 'reported-targets'
     systemProperty 'reachability.reportTitle', 'Reported Targets'
-    systemProperty 'reachability.reportSubtitle', 'Lightweight regression targets from targets.csv'
+    systemProperty 'reachability.reportSubtitle', 'Lightweight regression list from targets.tsv'
+    systemProperty 'reachability.profile', 'false'
     systemProperty 'dashboard.outputRoot', dashboardOutputRoot.get().asFile.absolutePath
-    jvmArgs = ['-Xms1g', '-Xmx8g']
-    doLast {
-        logDashboardLocation(name)
-    }
-}
-
-tasks.register('scenarioDashboard', Test) {
-    group = 'verification'
-    description = 'Builds the pathfinder scenario dashboard bundle'
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    useJUnit()
-    include 'shortestpath/pathfinder/PathfinderTest.class'
-    ignoreFailures = true
-    systemProperty 'dashboard.outputRoot', dashboardOutputRoot.get().asFile.absolutePath
+    systemProperty 'dashboard.bundleName', 'reported-targets'
     jvmArgs = ['-Xms1g', '-Xmx8g']
     doLast {
         logDashboardLocation(name)
@@ -108,10 +153,8 @@ tasks.register('scenarioDashboard', Test) {
 
 tasks.register('dashboardSite') {
     group = 'verification'
-    description = 'Builds the shared dashboard site containing all dashboard bundles'
-    dependsOn tasks.named('scenarioDashboard')
-    dependsOn tasks.named('clueStepsDashboard')
-    dependsOn tasks.named('targetsDashboard')
+    description = 'Builds the shared dashboard site with all bundles'
+    dependsOn 'scenarioDashboard', 'clueStepsDashboard', 'targetsDashboard'
     doLast {
         logDashboardLocation(name)
     }
@@ -139,4 +182,18 @@ tasks.register('runelite', JavaExec) {
     mainClass.set('shortestpath.ShortestPathPluginTest')
     jvmArgs '-ea'
     args '--developer-mode'
+}
+
+jmh {
+    warmupIterations = 3
+    iterations = 5
+    fork = 2
+    jvmArgs = ['-Xms2g', '-Xmx8g']
+    resultFormat = 'JSON'
+    resultsFile = layout.buildDirectory.file('reports/jmh/results.json')
+}
+
+dependencies {
+    jmhImplementation sourceSets.test.output
+    jmhImplementation sourceSets.test.runtimeClasspath
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,14 +38,22 @@ def dashboardDataset = providers.gradleProperty('dashboardDataset')
     .orElse('/reachability/routes.csv')
 def dashboardScenario = providers.gradleProperty('dashboardScenario')
     .orElse('')
-def dashboardTitle = providers.gradleProperty('dashboardTitle')
-    .orElse('Pathfinder Dashboard')
 def dashboardSubtitle = providers.gradleProperty('dashboardSubtitle')
     .orElse('')
 def dashboardProfile = providers.gradleProperty('dashboardProfile')
     .orElse('true')
+// Derive bundle name and title from the dataset filename + profile flag.
+// e.g. /reachability/clue_locations_full.csv -PdashboardProfile=true
+//   → bundle: clue-locations-full-profiled, title: Clue Locations Full Profiled
+// Override either with -PdashboardBundle=... or -PdashboardTitle=...
+def _filename = dashboardDataset.get().tokenize('/').last()
+def _stem     = _filename.contains('.') ? _filename.substring(0, _filename.lastIndexOf('.')) : _filename
+def _slug     = _stem.replace('_', '-').toLowerCase()
+def _profiled  = dashboardProfile.get() == 'true'
 def dashboardBundle = providers.gradleProperty('dashboardBundle')
-    .orElse('routes')
+    .orElse(_profiled ? "${_slug}-profiled" : _slug)
+def dashboardTitle = providers.gradleProperty('dashboardTitle')
+    .orElse(_stem.tokenize('_').collect { it.capitalize() }.join(' ') + (_profiled ? ' Profiled' : ''))
 
 def logDashboardLocation = { String taskName ->
     File dashboardDir = dashboardOutputRoot.get().asFile
@@ -61,7 +69,7 @@ test {
 
 tasks.register('dashboard', Test) {
     group = 'verification'
-    description = 'Builds the pathfinder dashboard. Use -PdashboardDataset=... to set the input file, -PdashboardScenario=profiler for profiling.'
+    description = 'Builds the pathfinder dashboard. Required: -PdashboardDataset=... (default: /reachability/routes.csv), -PdashboardProfile=true|false (default: true). Bundle name and title are derived automatically; override with -PdashboardBundle=... or -PdashboardTitle=...'
     testClassesDirs = sourceSets.test.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath
     useJUnit()

--- a/docs/dashboard-design.md
+++ b/docs/dashboard-design.md
@@ -10,14 +10,17 @@ It exists for cases where a pass/fail assertion is not enough:
 - a route reaches the target but uses the wrong transport
 - a bank-state transition happens in the wrong place
 - a user reports a bad destination and we want a lightweight regression case
+- profiling data needs visual inspection (phase timings, heatmaps, queue sizes)
 
 Instead of looking only at a failing JUnit assertion, the dashboard lets you inspect:
 
-- the rendered route
-- path statistics
-- transports used
+- the rendered route on a Leaflet map
+- path statistics (nodes checked, transports checked, elapsed time)
+- transports used along the path
 - where banked state begins
-- multiple datasets through one shared UI
+- profiler phase breakdowns, sub-phase timings, and time-series charts
+- tile visit heatmaps showing search distribution
+- multiple datasets through one shared UI with a bundle selector
 
 ## Site Model
 
@@ -31,106 +34,159 @@ It contains one shared frontend plus multiple report bundles:
 build/reports/pathfinder-dashboard/
   index.html
   app.js
+  profiler.js
   styles.css
   bundles/
     index.json
-    pathfinder-tests/
+    <bundle-name>/
       report.json
-    clue-steps-default/
-      report.json
-    reported-targets/
-      report.json
+      heatmaps/
+        <run-name>.json     (tile visit counts, one per route)
 ```
 
-`bundles/index.json` is the registry the frontend reads first. Each bundle is just a `report.json` plus metadata in the shared index.
+`bundles/index.json` is the registry the frontend reads first. Each bundle directory contains a `report.json` with all route results and, when profiling is enabled, a `heatmaps/` directory with per-route tile visit count data.
 
-## Current Datasets
+## Profiler
 
-### `pathfinder-tests`
+### Architecture
 
-Source:
-- `PathfinderTest`
+The profiler is implemented as a test-only pathfinder that replicates the production search loop with timing instrumentation added at each phase boundary.
 
-Purpose:
-- curated scenario debugging
-- transport-choice regressions
-- bank-state routing regressions
-- interesting hand-authored routes worth visual inspection
+Key files:
 
-When to add here:
-- the behavior is specific to route selection
-- the scenario needs custom setup in test code
-- you want an assertion over exact path length or transport usage
+- `src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java` — mirrors `Pathfinder.java`'s search loop, wrapping each phase in `System.nanoTime()` calls
+- `src/test/java/shortestpath/pathfinder/PathfinderProfile.java` — data class collecting all profiling measurements
+- `src/test/resources/reachability-dashboard/profiler.js` — frontend rendering of profiler data (bar charts, time-series, heatmap overlay)
 
-Built by:
-- `./gradlew scenarioDashboard`
+### What It Measures
 
-### `clue-steps-default`
+**Top-level phases** (accumulated nanos per search loop iteration):
+- `queueSelection` — dequeuing the next node from the priority queue
+- `addNeighbors` — expanding tile and transport neighbors
+- `targetCheck` — checking if the current node is a target
+- `wildernessCheck` — wilderness level boundary handling
+- `cutoffCheck` — cost cutoff evaluation
+- `bookkeeping` — iteration counter updates and sampling
 
-Source:
-- `src/test/resources/reachability/clue_locations_full.csv`
+**Sub-phases within addNeighbors**:
+- `bankCheck` — checking bank proximity for state transitions
+- `transportLookup` — looking up transports at the current position
+- `collisionCheck` — collision map queries
+- `walkableTile` — processing walkable tile neighbors
+- `blockedTileTransport` — checking transports on blocked tiles
+- `abstractNode` — abstract node expansion
 
-Purpose:
-- broad sweep over the larger clue-step dataset
-- catch systemic reachability problems
-- understand coverage and performance on a realistic batch of targets
+**Counters**:
+- `tileNeighborsAdded`, `transportNeighborsAdded` — neighbor counts (match `nodesChecked`/`transportsChecked` in `PathfinderResult`)
+- `visitedSkipped` — nodes skipped because already visited
+- `transportEvaluations` — total transport evaluations attempted
+- `blockedTileTransportChecks` — blocked-tile transport lookups
+- `bankTransitions`, `wildernessLevelChanges` — state change counts
+- `peakBoundarySize`, `peakPendingSize` — high-water marks for queue sizes
 
-When to use:
-- after changing pathfinding behavior broadly
-- when validating transport availability changes
-- when you want confidence over the full clue-step corpus
+**Time series** (sampled every 2000 iterations):
+- boundary queue size, pending queue size, current cost, elapsed nanos
 
-Built by:
-- `./gradlew clueStepsDashboard`
+**Heatmap**:
+- sparse map of `packedPosition → visitCount` for every tile visited during search
 
-### `reported-targets`
+### Keeping the Profiler in Sync
 
-Source:
-- `src/test/resources/reachability/targets.csv`
+`PathfinderTest.profilingDoesNotAffectResults` verifies that `ProfilingPathfinder` produces identical results to `Pathfinder` across multiple route types. It checks:
 
-Purpose:
-- lightweight regression list
-- easy contributor workflow for reported unreachable destinations
-- small, reviewable target set that runs cheaply in CI
+- path equality (every step's position and bank-visited flag)
+- result metadata (reached, terminationReason, nodesChecked, transportsChecked)
+- profiling data validity (phase nanos > 0, sub-phase nanos > 0, counter consistency, heatmap non-empty, elapsed nanos > 0)
 
-When to add here:
-- a user reports a single unreachable destination
-- you want a small PR that adds coordinates without editing Java code
-- the case does not need bespoke scenario setup
+This test catches any drift between the production pathfinder and the profiling replica. When modifying `Pathfinder.java`'s search loop, run this test to confirm the profiler still mirrors it faithfully.
 
-Built by:
-- `./gradlew targetsDashboard`
+## Datasets
+
+### Named Convenience Tasks
+
+These tasks have fixed bundle names and are used for standard workflows:
+
+#### `pathfinder-tests` — `./gradlew scenarioDashboard`
+
+Source: `PathfinderTest` (curated scenarios in Java)
+
+Use for: transport-choice regressions, bank-state routing, hand-authored routes needing visual inspection and JUnit assertions.
+
+#### `clue-steps-default` — `./gradlew clueStepsDashboard`
+
+Source: `src/test/resources/reachability/clue_locations_full.csv`
+
+Use for: broad reachability sweeps over the clue-step corpus after changing pathfinding behavior. Profiling is **off** by default.
+
+#### `reported-targets` — `./gradlew targetsDashboard`
+
+Source: `src/test/resources/reachability/targets.tsv`
+
+Use for: lightweight regression list of user-reported unreachable destinations.
+
+#### `dashboardSite` — `./gradlew dashboardSite`
+
+Builds all three named bundles above into one site.
+
+### Generic `dashboard` Task
+
+The `dashboard` task is the flexible entry point for ad-hoc runs with custom datasets, bundle names, and profiling:
+
+```bash
+./gradlew dashboard \
+  -PdashboardDataset=/reachability/clue_locations_full.csv \
+  -PdashboardBundle=clue-steps-profiled \
+  -PdashboardTitle="Clue Steps Profiled" \
+  -PdashboardProfile=true
+```
+
+Properties:
+
+| Property | Default | Description |
+|---|---|---|
+| `dashboardDataset` | `/reachability/routes.csv` | Classpath resource for the input CSV/TSV |
+| `dashboardBundle` | `routes` | Bundle directory name |
+| `dashboardTitle` | `Pathfinder Dashboard` | Title shown in the UI |
+| `dashboardSubtitle` | *(empty)* | Subtitle shown in the UI |
+| `dashboardProfile` | `true` | Enable profiling (heatmaps, phase timings) |
+| `dashboardScenario` | *(empty)* | Set to `profiler` for profiler-specific scenario mode |
+
+Profiling is **on** by default for the generic task, and **off** for `clueStepsDashboard` and `targetsDashboard` (to keep those runs fast).
+
+### Profiled Runs
+
+For profiled variants of the standard datasets, use the generic task with explicit bundle names:
+
+```bash
+# Profiled clue steps
+./gradlew dashboard \
+  -PdashboardDataset=/reachability/clue_locations_full.csv \
+  -PdashboardBundle=clue-steps-profiled \
+  -PdashboardTitle="Clue Steps Profiled"
+
+# Profiled routes
+./gradlew dashboard \
+  -PdashboardBundle=routes-profiled \
+  -PdashboardTitle="Routes Profiled"
+```
+
+These produce bundles with heatmaps and full profiler data, suitable for performance analysis.
 
 ## How To Choose A Dataset
 
-Use `targets.csv` first if the problem is “this destination should be reachable”.
+Use `targets.tsv` first if the problem is "this destination should be reachable".
 
 Use `PathfinderTest` if the problem is about route quality, bank usage, transport choice, or any case that needs custom setup and assertions.
 
 Use the full clue-step CSV when you want a broader sweep after changing core search behavior.
 
-## Local Development
-
-Useful tasks:
-
-- `./gradlew scenarioDashboard`
-- `./gradlew clueStepsDashboard`
-- `./gradlew targetsDashboard`
-- `./gradlew dashboardSite`
-
-`dashboardSite` builds the shared site with all current bundles.
-
-All dashboard tasks write into the same root, controlled by:
-
-`-Ddashboard.outputRoot=...`
-
-The dashboard-specific tasks use `ignoreFailures = true`, so a failing scenario can still emit a report bundle for inspection.
+Use a profiled run when you need to understand performance characteristics — where time is spent, which tiles are visited most, how queue sizes evolve.
 
 ## Suggested Workflow
 
 For a reported unreachable destination:
 
-1. Add the coordinate to `src/test/resources/reachability/targets.csv`.
+1. Add the coordinate to `src/test/resources/reachability/targets.tsv`.
 2. Run `./gradlew targetsDashboard`.
 3. Serve the output directory locally.
 4. Inspect the route in the dashboard.
@@ -142,29 +198,40 @@ For a routing regression:
 2. Run `./gradlew scenarioDashboard`.
 3. Inspect the route and confirm the assertion still matches the intended behavior.
 
+For profiling after a pathfinder change:
+
+1. Run profiled bundles for the datasets you care about.
+2. Compare heatmaps and phase breakdowns against the pre-change baselines.
+3. Use `scripts/analyze_heatmap_counts.py` to get distribution statistics.
+
 ## Serving The Site
 
 Open the generated site through a local webserver, not `file://`, because the frontend loads bundle JSON dynamically.
-
-Example:
 
 ```bash
 python -m http.server --directory build/reports/pathfinder-dashboard 8000
 ```
 
-Then open:
+Then open `http://localhost:8000`.
 
-`http://localhost:8000`
+## Scripts
+
+Helper scripts in `scripts/`:
+
+| Script | Purpose |
+|---|---|
+| `analyze_heatmap_counts.py` | Analyze tile visit count distributions from heatmap JSON files in a bundle |
+| `check_tsv.py` | Validate TSV transport files for format errors |
+| `tsv-lint.sh` | Lint all transport TSV files |
+| `compute_changed_coordinates.sh` | Diff coordinate changes between branches |
+| `diff_coordinate_json.py` | Compare coordinate JSON files |
+| `dump_transport_coordinates.py` | Extract transport coordinates from TSV files |
+| `gen_clue_csv.py` | Generate the clue locations CSV from source data |
 
 ## Implementation Split
 
-The current implementation is split into three parts:
+The implementation is split into:
 
-1. `PathfinderDashboardReportWriter`
-   Builds a report payload.
-2. `DashboardBundlePublisher`
-   Publishes a named bundle into the shared site root and updates `bundles/index.json`.
-3. `PathfinderDashboardAssetWriter`
-   Writes the shared frontend assets.
-
-This keeps data producers separate from the shared dashboard host.
+1. `PathfinderDashboardReportWriter` — builds the report payload (route results, profiler data, metadata)
+2. `DashboardBundlePublisher` — publishes a named bundle into the shared site root and updates `bundles/index.json`
+3. `PathfinderDashboardAssetWriter` — writes the shared frontend assets (`index.html`, `app.js`, `profiler.js`, `styles.css`)

--- a/src/jmh/java/shortestpath/pathfinder/CollisionMapBenchmark.java
+++ b/src/jmh/java/shortestpath/pathfinder/CollisionMapBenchmark.java
@@ -1,0 +1,86 @@
+package shortestpath.pathfinder;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.QuestState;
+import net.runelite.api.Skill;
+import org.mockito.Mockito;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import shortestpath.TeleportationItem;
+import shortestpath.TestShortestPathConfig;
+import shortestpath.WorldPointUtil;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * JMH benchmarks isolating CollisionMap.getNeighbors() performance.
+ *
+ * <p>Run with: {@code ./gradlew jmh -Pjmh.includes='CollisionMapBenchmark'}
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class CollisionMapBenchmark {
+
+    private CollisionMap map;
+    private VisitedTiles visited;
+    private PathfinderConfig config;
+    private Node openFieldNode;
+    private Node wallAdjacentNode;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        Client client = Mockito.mock(Client.class);
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.getClientThread()).thenReturn(Thread.currentThread());
+        when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+
+        TestShortestPathConfig testConfig = new TestShortestPathConfig();
+        testConfig.setCalculationCutoffValue(500);
+        testConfig.setUseTeleportationItemsValue(TeleportationItem.ALL);
+        testConfig.setIncludeBankPathValue(false);
+
+        config = new TestPathfinderConfig(client, testConfig, QuestState.FINISHED, true, true);
+        config.refresh();
+
+        map = config.getMap();
+        visited = new VisitedTiles(map);
+
+        // Open field in Lumbridge
+        int openPacked = WorldPointUtil.packWorldPoint(3222, 3218, 0);
+        openFieldNode = new Node(openPacked, null, 0, false);
+
+        // Near Varrock castle wall
+        int wallPacked = WorldPointUtil.packWorldPoint(3213, 3428, 0);
+        wallAdjacentNode = new Node(wallPacked, null, 0, false);
+    }
+
+    @Benchmark
+    public void neighborsOpenField(Blackhole bh) {
+        List<Node> neighbors = map.getNeighbors(openFieldNode, visited, config, 0, false);
+        bh.consume(neighbors);
+    }
+
+    @Benchmark
+    public void neighborsWallAdjacent(Blackhole bh) {
+        List<Node> neighbors = map.getNeighbors(wallAdjacentNode, visited, config, 0, false);
+        bh.consume(neighbors);
+    }
+}

--- a/src/jmh/java/shortestpath/pathfinder/PathfinderBenchmark.java
+++ b/src/jmh/java/shortestpath/pathfinder/PathfinderBenchmark.java
@@ -1,0 +1,122 @@
+package shortestpath.pathfinder;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.QuestState;
+import net.runelite.api.Skill;
+import org.mockito.Mockito;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import shortestpath.TeleportationItem;
+import shortestpath.TestShortestPathConfig;
+import shortestpath.WorldPointUtil;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * JMH benchmarks for end-to-end pathfinding.
+ *
+ * <p>Run with: {@code ./gradlew jmh}
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class PathfinderBenchmark {
+
+    private PathfinderConfig configWithTeleports;
+    private PathfinderConfig configWalkOnly;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        Client client = Mockito.mock(Client.class);
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.getClientThread()).thenReturn(Thread.currentThread());
+        when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+
+        // Config with teleports
+        TestShortestPathConfig configAll = new TestShortestPathConfig();
+        configAll.setCalculationCutoffValue(500);
+        configAll.setUseTeleportationItemsValue(TeleportationItem.ALL);
+        configAll.setIncludeBankPathValue(false);
+        configWithTeleports = new TestPathfinderConfig(client, configAll, QuestState.FINISHED, true, true);
+        configWithTeleports.refresh();
+
+        // Config without teleports
+        TestShortestPathConfig configNone = new TestShortestPathConfig();
+        configNone.setCalculationCutoffValue(500);
+        configNone.setUseTeleportationItemsValue(TeleportationItem.NONE);
+        configNone.setIncludeBankPathValue(false);
+        configWalkOnly = new TestPathfinderConfig(client, configNone, QuestState.FINISHED, true, true);
+        configWalkOnly.refresh();
+    }
+
+    @Benchmark
+    public void shortWalk_LumbridgeToVarrock(Blackhole bh) {
+        int start = WorldPointUtil.packWorldPoint(3222, 3218, 0);
+        int target = WorldPointUtil.packWorldPoint(3213, 3428, 0);
+        Pathfinder pf = new Pathfinder(configWithTeleports, start, Set.of(target));
+        pf.run();
+        bh.consume(pf.getResult());
+    }
+
+    @Benchmark
+    public void crossMap_LumbridgeToArdougne(Blackhole bh) {
+        int start = WorldPointUtil.packWorldPoint(3222, 3218, 0);
+        int target = WorldPointUtil.packWorldPoint(2662, 3305, 0);
+        Pathfinder pf = new Pathfinder(configWithTeleports, start, Set.of(target));
+        pf.run();
+        bh.consume(pf.getResult());
+    }
+
+    @Benchmark
+    public void longWalk_LumbridgeToRellekka(Blackhole bh) {
+        int start = WorldPointUtil.packWorldPoint(3222, 3218, 0);
+        int target = WorldPointUtil.packWorldPoint(2660, 3657, 0);
+        Pathfinder pf = new Pathfinder(configWalkOnly, start, Set.of(target));
+        pf.run();
+        bh.consume(pf.getResult());
+    }
+
+    @Benchmark
+    public void teleportHeavy_GEToZulAndra(Blackhole bh) {
+        int start = WorldPointUtil.packWorldPoint(3165, 3487, 0);
+        int target = WorldPointUtil.packWorldPoint(2200, 3056, 0);
+        Pathfinder pf = new Pathfinder(configWithTeleports, start, Set.of(target));
+        pf.run();
+        bh.consume(pf.getResult());
+    }
+
+    @Benchmark
+    public void wilderness_EdgevilleToMageArena(Blackhole bh) {
+        int start = WorldPointUtil.packWorldPoint(3087, 3496, 0);
+        int target = WorldPointUtil.packWorldPoint(3105, 3951, 0);
+        Pathfinder pf = new Pathfinder(configWithTeleports, start, Set.of(target));
+        pf.run();
+        bh.consume(pf.getResult());
+    }
+
+    @Benchmark
+    public void multiPlane_FaladorToWhiteKnight2F(Blackhole bh) {
+        int start = WorldPointUtil.packWorldPoint(2964, 3378, 0);
+        int target = WorldPointUtil.packWorldPoint(2961, 3339, 2);
+        Pathfinder pf = new Pathfinder(configWithTeleports, start, Set.of(target));
+        pf.run();
+        bh.consume(pf.getResult());
+    }
+}

--- a/src/jmh/java/shortestpath/pathfinder/VisitedTilesBenchmark.java
+++ b/src/jmh/java/shortestpath/pathfinder/VisitedTilesBenchmark.java
@@ -1,0 +1,85 @@
+package shortestpath.pathfinder;
+
+import java.util.concurrent.TimeUnit;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.QuestState;
+import net.runelite.api.Skill;
+import org.mockito.Mockito;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import shortestpath.TeleportationItem;
+import shortestpath.TestShortestPathConfig;
+import shortestpath.WorldPointUtil;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * JMH benchmarks for VisitedTiles set/get performance.
+ *
+ * <p>Run with: {@code ./gradlew jmh -Pjmh.includes='VisitedTilesBenchmark'}
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class VisitedTilesBenchmark {
+
+    private CollisionMap map;
+    private VisitedTiles visited;
+    private int counter;
+
+    // Pre-computed valid tile coordinates for set/get
+    private static final int BASE_X = 3136; // Region 50
+    private static final int BASE_Y = 3136;
+
+    @Setup(Level.Invocation)
+    public void setUp() {
+        Client client = Mockito.mock(Client.class);
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.getClientThread()).thenReturn(Thread.currentThread());
+        when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+
+        TestShortestPathConfig config = new TestShortestPathConfig();
+        config.setCalculationCutoffValue(500);
+        config.setUseTeleportationItemsValue(TeleportationItem.NONE);
+        config.setIncludeBankPathValue(false);
+
+        PathfinderConfig pfConfig = new TestPathfinderConfig(client, config, QuestState.FINISHED, true, true);
+        pfConfig.refresh();
+
+        map = pfConfig.getMap();
+        visited = new VisitedTiles(map);
+        counter = 0;
+    }
+
+    @Benchmark
+    public void setAndGet(Blackhole bh) {
+        int x = BASE_X + (counter % 64);
+        int y = BASE_Y + ((counter / 64) % 64);
+        counter++;
+        visited.set(x, y, 0, false);
+        bh.consume(visited.get(x, y, 0, false));
+    }
+
+    @Benchmark
+    public void getMiss(Blackhole bh) {
+        int x = BASE_X + (counter % 64);
+        int y = BASE_Y + ((counter / 64) % 64);
+        counter++;
+        bh.consume(visited.get(x, y, 0, false));
+    }
+}

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -205,6 +205,11 @@ public class CollisionMap {
             if (config.avoidWilderness(sourceTile, transport.getDestination(), targetInWilderness)) {
                 continue;
             }
+            // The differential cost is only used for priority-queue ordering (compareCost), not
+            // propagated as real cost, so applying it unconditionally is safe: a nearby partner
+            // station can still win the dequeue race, and a far-away whistle still resolves as the
+            // cheapest path because no competitor has a lower real cost to the same destination.
+            int differentialCost = delayedVisit ? config.getDifferentialCost(transport) : 0;
             neighbors.add(new TransportNode(
                 transport.getDestination(),
                 node,
@@ -212,7 +217,7 @@ public class CollisionMap {
                 config.getAdditionalTransportCost(transport),
                 node.bankVisited,
                 delayedVisit,
-                delayedVisit ? config.getDifferentialCost(transport) : 0));
+                differentialCost));
         }
         return neighbors;
     }

--- a/src/main/java/shortestpath/pathfinder/Node.java
+++ b/src/main/java/shortestpath/pathfinder/Node.java
@@ -32,7 +32,6 @@ public class Node {
     // Only set for ABSTRACT nodes. TILE nodes leave this null.
     public final AbstractNodeKind abstractKind;
 
-    // A constructor which propagates the previous Node's banked state at the new position.
     public Node(int packedPosition, Node previous, int cost) {
         this(packedPosition, previous, cost, previous != null && previous.bankVisited);
     }

--- a/src/test/java/shortestpath/dashboard/DashboardBundlePublisher.java
+++ b/src/test/java/shortestpath/dashboard/DashboardBundlePublisher.java
@@ -3,22 +3,20 @@ package shortestpath.dashboard;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 public final class DashboardBundlePublisher {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-    // Overrides the root directory where the shared dashboard site and bundle registry are written.
+    private static final Gson GSON_COMPACT = new Gson();
     public static final String OUTPUT_ROOT_PROPERTY = "dashboard.outputRoot";
+    public static final String BUNDLE_NAME_PROPERTY = "dashboard.bundleName";
     public static final Path DEFAULT_OUTPUT_ROOT = Paths.get("build", "reports", "pathfinder-dashboard");
-    private static final String BUNDLES_DIRECTORY = "bundles";
-    private static final String INDEX_FILENAME = "index.json";
 
     private final PathfinderDashboardAssetWriter assetWriter = new PathfinderDashboardAssetWriter();
 
@@ -30,73 +28,107 @@ public final class DashboardBundlePublisher {
         return Paths.get(configured);
     }
 
+    /**
+     * Write a single run's heatmap data to disk immediately, freeing the in-memory tiles.
+     * Call this during the pathfinding loop so only one heatmap is ever resident in memory.
+     * Sets {@code run.heatmapFile} and nulls {@code run.tileHeatmap}.
+     */
+    public void externalizeRunHeatmap(String bundleName, int runIndex,
+            PathfinderDashboardModels.RunRecord run) throws IOException {
+        if (run.tileHeatmap == null || run.tileHeatmap.tiles == null || run.tileHeatmap.tiles.isEmpty()) {
+            return;
+        }
+        Path heatmapDir = getOutputRoot().resolve("bundles").resolve(bundleName).resolve("heatmaps");
+        Files.createDirectories(heatmapDir);
+        String heatmapFileName = runIndex + ".json";
+        writeCompactHeatmap(heatmapDir.resolve(heatmapFileName), run.tileHeatmap.tiles);
+        run.heatmapFile = "heatmaps/" + heatmapFileName;
+        run.tileHeatmap = null;
+    }
+
+    /**
+     * Publish a named bundle. Writes:
+     *   bundles/{name}/report.json     (runs without inline heatmap data)
+     *   bundles/{name}/heatmaps/N.json (one per run whose heatmap was not already externalised)
+     *   bundles/index.json             (updated registry)
+     *
+     * Heatmaps that were already written via {@link #externalizeRunHeatmap} are skipped.
+     */
     public synchronized Path publishBundle(
-        String bundleId,
-        String title,
-        String subtitle,
+        String bundleName,
         PathfinderDashboardModels.Report report
     ) throws IOException {
-        // Each producer writes into the same shared site root. A "bundle" is just one report payload plus
-        // one entry in the shared bundle index that tells the frontend where to find it.
         Path outputRoot = getOutputRoot();
-        Path bundleDirectory = outputRoot.resolve(BUNDLES_DIRECTORY).resolve(bundleId);
-        Path reportPath = bundleDirectory.resolve("report.json");
-
-        // The site shell is shared across all bundles, so every publish ensures the static assets exist before
-        // updating the bundle-specific payload and registry entry.
         assetWriter.writeAssets(outputRoot);
-        Files.createDirectories(bundleDirectory);
+
+        Path bundleDir = outputRoot.resolve("bundles").resolve(bundleName);
+        Path heatmapDir = bundleDir.resolve("heatmaps");
+        Files.createDirectories(bundleDir);
+
+        // Externalise any remaining heatmap data (already-externalised runs have tileHeatmap == null)
+        List<PathfinderDashboardModels.RunRecord> runs = report.runs;
+        if (runs != null) {
+            for (int i = 0; i < runs.size(); i++) {
+                PathfinderDashboardModels.RunRecord run = runs.get(i);
+                if (run.tileHeatmap != null && run.tileHeatmap.tiles != null && !run.tileHeatmap.tiles.isEmpty()) {
+                    Files.createDirectories(heatmapDir);
+                    String heatmapFileName = i + ".json";
+                    writeCompactHeatmap(heatmapDir.resolve(heatmapFileName), run.tileHeatmap.tiles);
+                    run.heatmapFile = "heatmaps/" + heatmapFileName;
+                    run.tileHeatmap = null;
+                }
+            }
+        }
+
+        Path reportPath = bundleDir.resolve("report.json");
         writeJson(reportPath, report);
-        updateBundleIndex(outputRoot, bundleId, title, subtitle, reportPath);
+
+        updateBundleIndex(outputRoot, bundleName, report);
         return reportPath;
     }
 
-    private void updateBundleIndex(
-        Path outputRoot,
-        String bundleId,
-        String title,
-        String subtitle,
-        Path reportPath
-    ) throws IOException {
-        Path indexPath = outputRoot.resolve(BUNDLES_DIRECTORY).resolve(INDEX_FILENAME);
-        PathfinderDashboardModels.BundleIndex index = readIndex(indexPath);
-        String relativeReportPath = outputRoot.relativize(reportPath).toString().replace('\\', '/');
-        String generatedAt = Instant.now().toString();
-
-        PathfinderDashboardModels.BundleManifest replacement = new PathfinderDashboardModels.BundleManifest();
-        replacement.id = bundleId;
-        replacement.title = title;
-        replacement.subtitle = subtitle;
-        replacement.reportPath = relativeReportPath;
-        replacement.generatedAt = generatedAt;
-
-        // Publishing is replace-or-insert by bundle id so repeated runs refresh one bundle without disturbing the
-        // others already present in the shared site.
-        List<PathfinderDashboardModels.BundleManifest> bundles = new ArrayList<>();
-        boolean replaced = false;
-        for (PathfinderDashboardModels.BundleManifest bundle : index.bundles) {
-            if (bundleId.equals(bundle.id)) {
-                bundles.add(replacement);
-                replaced = true;
-            } else {
-                bundles.add(bundle);
+    private void updateBundleIndex(Path outputRoot, String bundleName,
+            PathfinderDashboardModels.Report report) throws IOException {
+        Path indexPath = outputRoot.resolve("bundles").resolve("index.json");
+        PathfinderDashboardModels.BundleIndex index;
+        if (Files.exists(indexPath)) {
+            try (Reader reader = Files.newBufferedReader(indexPath)) {
+                index = GSON.fromJson(reader, PathfinderDashboardModels.BundleIndex.class);
             }
+            if (index == null || index.bundles == null) {
+                index = new PathfinderDashboardModels.BundleIndex();
+                index.bundles = new ArrayList<>();
+            }
+        } else {
+            index = new PathfinderDashboardModels.BundleIndex();
+            index.bundles = new ArrayList<>();
         }
-        if (!replaced) {
-            bundles.add(replacement);
-        }
-        bundles.sort(Comparator.comparing(bundle -> bundle.title));
-        index.bundles = bundles;
+
+        // Replace existing entry or add new
+        index.bundles.removeIf(e -> bundleName.equals(e.name));
+        PathfinderDashboardModels.BundleEntry entry = new PathfinderDashboardModels.BundleEntry();
+        entry.name = bundleName;
+        entry.title = report.title != null ? report.title : bundleName;
+        entry.generatedAt = report.generatedAt;
+        entry.reportPath = bundleName + "/report.json";
+        index.bundles.add(entry);
+
         writeJson(indexPath, index);
     }
 
-    private PathfinderDashboardModels.BundleIndex readIndex(Path indexPath) throws IOException {
-        if (!Files.exists(indexPath)) {
-            PathfinderDashboardModels.BundleIndex index = new PathfinderDashboardModels.BundleIndex();
-            index.bundles = new ArrayList<>();
-            return index;
+    /** Write a flat interleaved array [x1,y1,c1, x2,y2,c2, ...] without pretty-printing. */
+    private void writeCompactHeatmap(Path outputPath, List<PathfinderDashboardModels.TileVisit> tiles) throws IOException {
+        Files.createDirectories(outputPath.getParent());
+        int[] flat = new int[tiles.size() * 3];
+        for (int i = 0; i < tiles.size(); i++) {
+            PathfinderDashboardModels.TileVisit tv = tiles.get(i);
+            flat[i * 3] = tv.x;
+            flat[i * 3 + 1] = tv.y;
+            flat[i * 3 + 2] = tv.count;
         }
-        return GSON.fromJson(Files.readString(indexPath), PathfinderDashboardModels.BundleIndex.class);
+        try (Writer writer = Files.newBufferedWriter(outputPath)) {
+            GSON_COMPACT.toJson(flat, writer);
+        }
     }
 
     private void writeJson(Path outputPath, Object value) throws IOException {

--- a/src/test/java/shortestpath/dashboard/PathfinderDashboardAssetWriter.java
+++ b/src/test/java/shortestpath/dashboard/PathfinderDashboardAssetWriter.java
@@ -10,6 +10,7 @@ public class PathfinderDashboardAssetWriter {
     private static final String[] ASSETS = {
         "/reachability-dashboard/index.html",
         "/reachability-dashboard/app.js",
+        "/reachability-dashboard/profiler.js",
         "/reachability-dashboard/styles.css"
     };
 

--- a/src/test/java/shortestpath/dashboard/PathfinderDashboardModels.java
+++ b/src/test/java/shortestpath/dashboard/PathfinderDashboardModels.java
@@ -115,6 +115,8 @@ public final class PathfinderDashboardModels {
         public int blockedTileTransportChecks;
         public int bankTransitions;
         public int wildernessLevelChanges;
+        public int delayedVisitEnqueued;
+        public int delayedVisitSkipped;
         public int peakBoundarySize;
         public int peakPendingSize;
     }

--- a/src/test/java/shortestpath/dashboard/PathfinderDashboardModels.java
+++ b/src/test/java/shortestpath/dashboard/PathfinderDashboardModels.java
@@ -2,174 +2,151 @@ package shortestpath.dashboard;
 
 import java.util.List;
 
-/**
- * Serializable model types for the static pathfinder dashboard JSON payloads.
- */
 public final class PathfinderDashboardModels {
     private PathfinderDashboardModels() {
     }
 
-    /**
-     * Top-level bundle registry consumed by the shared dashboard frontend.
-     */
-    public static class BundleIndex {
-        /** All published dashboard bundles available for selection. */
-        public List<BundleManifest> bundles;
-    }
-
-    /**
-     * Metadata for one published dashboard bundle.
-     */
-    public static class BundleManifest {
-        /** Stable bundle identifier used as the directory name under `bundles/`. */
-        public String id;
-        /** Human-readable bundle title shown in the dashboard UI. */
-        public String title;
-        /** Short secondary description shown alongside the bundle title. */
-        public String subtitle;
-        /** Relative path from the site root to the bundle's `report.json`. */
-        public String reportPath;
-        /** ISO-8601 timestamp for when this bundle was last generated. */
-        public String generatedAt;
-    }
-
-    /**
-     * Full report payload for one dashboard bundle.
-     */
     public static class Report {
-        /** ISO-8601 timestamp for when this report was generated. */
         public String generatedAt;
-        /** Report title displayed at the top of the dashboard view. */
         public String title;
-        /** Report subtitle displayed under the main title. */
         public String subtitle;
-        /** Aggregate counts and timing information for the report. */
         public Summary summary;
-        /** Optional transport overlay data rendered across the whole map. */
         public List<TransportLayerTransport> transportLayers;
-        /** Per-run records shown in the run list and detail views. */
         public List<RunRecord> runs;
     }
 
-    /**
-     * Aggregate summary for all runs within a report.
-     */
     public static class Summary {
-        /** Total number of recorded runs in the report. */
         public int totalRuns;
-        /** Number of runs that reached their target. */
         public int successfulRuns;
-        /** Number of runs that did not reach their target. */
         public int failedRuns;
-        /** Wall-clock time spent generating the report, in milliseconds. */
         public long elapsedMillis;
     }
 
-    /**
-     * Serialized record for one pathfinder execution.
-     */
     public static class RunRecord {
-        /** Human-readable scenario or dataset entry name. */
         public String name;
-        /** Run grouping label such as `scenario` or `reachability`. */
         public String category;
-        /** Assertion result when the source test had an explicit pass/fail assertion. */
         public Boolean assertionPassed;
-        /** Assertion failure message when `assertionPassed` is false. */
         public String assertionMessage;
-        /** Whether the run reached its intended destination. */
         public boolean reached;
-        /** Pathfinder termination reason enum name. */
         public String terminationReason;
-        /** Start point for the run. */
         public WorldPointJson start;
-        /** Intended target point for the run. */
         public WorldPointJson target;
-        /** Closest point reached when the target was not reached exactly. */
         public WorldPointJson closestReachedPoint;
-        /** Ordered list of path tiles returned by the pathfinder. */
         public List<WorldPointJson> path;
-        /** Pathfinder performance counters for this run. */
         public Stats stats;
-        /** Transport steps inferred from transitions along the path. */
         public List<TransportStep> transports;
-        /** Important map markers such as start, target, and bank transition. */
         public List<Marker> markers;
-        /** Free-form detail strings displayed in the run detail panel. */
         public List<String> details;
+
+        // Optional profiler fields (null when not profiled)
+        public PhaseBreakdown phases;
+        public SubPhaseBreakdown subPhases;
+        public ProfilerCounters counters;
+        public List<TimeSeriesSample> timeSeries;
+        public TileHeatmap tileHeatmap;
+        /** Relative path to a separate heatmap JSON file (set when heatmap is externalised) */
+        public String heatmapFile;
     }
 
-    /**
-     * Performance counters captured for a single run.
-     */
     public static class Stats {
-        /** Number of nodes explored during pathfinding. */
         public int nodesChecked;
-        /** Number of transports considered during pathfinding. */
         public int transportsChecked;
-        /** Pathfinder execution time in nanoseconds. */
         public long elapsedNanos;
     }
 
-    /**
-     * One inferred transport edge used within a path.
-     */
     public static class TransportStep {
-        /** Path index where this transport step lands. */
         public int stepIndex;
-        /** Transport type enum name, or `TRANSPORT` when unspecified. */
         public String type;
-        /** User-facing transport description, when available. */
         public String displayInfo;
-        /** Backing object or interaction description, when available. */
         public String objectInfo;
-        /** Transport origin point. */
         public WorldPointJson origin;
-        /** Transport destination point. */
         public WorldPointJson destination;
     }
 
-    /**
-     * A labeled point rendered as a marker on the dashboard map.
-     */
     public static class Marker {
-        /** Marker kind identifier used for styling and filtering. */
         public String kind;
-        /** Human-readable marker label shown in the UI. */
         public String label;
-        /** Marker location on the world map. */
         public WorldPointJson point;
     }
 
-    /**
-     * One transport entry for the report-wide transport overlay layer.
-     */
     public static class TransportLayerTransport {
-        /** Transport type enum name, or `TRANSPORT` when unspecified. */
         public String type;
-        /** Availability classification such as `INVENTORY_VALID`, `BANK_VALID`, or `INVALID`. */
         public String validity;
-        /** User-facing transport description, when available. */
         public String displayInfo;
-        /** Backing object or interaction description, when available. */
         public String objectInfo;
-        /** Transport origin point, or null for teleports without a concrete origin tile. */
         public WorldPointJson origin;
-        /** Transport destination point. */
         public WorldPointJson destination;
     }
 
-    /**
-     * Serialized world point used across all dashboard payloads.
-     */
     public static class WorldPointJson {
-        /** World X coordinate. */
         public int x;
-        /** World Y coordinate. */
         public int y;
-        /** Plane level. */
         public int plane;
-        /** Whether the path had already visited a bank at this point. */
         public boolean bankVisited;
+    }
+
+    // ── Profiler models (optional per-run data) ─────────────────────
+
+    public static class PhaseBreakdown {
+        public long addNeighborsNanos;
+        public long queueSelectionNanos;
+        public long targetCheckNanos;
+        public long wildernessCheckNanos;
+        public long cutoffCheckNanos;
+        public long bookkeepingNanos;
+        public long otherNanos;
+    }
+
+    public static class SubPhaseBreakdown {
+        public long bankCheckNanos;
+        public long transportLookupNanos;
+        public long collisionCheckNanos;
+        public long walkableTileNanos;
+        public long blockedTileTransportNanos;
+        public long abstractNodeNanos;
+    }
+
+    public static class ProfilerCounters {
+        public int tileNeighborsAdded;
+        public int transportNeighborsAdded;
+        public int visitedSkipped;
+        public int abstractNodesExpanded;
+        public int transportEvaluations;
+        public int blockedTileTransportChecks;
+        public int bankTransitions;
+        public int wildernessLevelChanges;
+        public int peakBoundarySize;
+        public int peakPendingSize;
+    }
+
+    public static class TimeSeriesSample {
+        public int iteration;
+        public int boundarySize;
+        public int pendingSize;
+        public int currentCost;
+        public double elapsedMs;
+    }
+
+    public static class TileHeatmap {
+        public List<TileVisit> tiles;
+    }
+
+    public static class TileVisit {
+        public int x;
+        public int y;
+        public int count;
+    }
+
+    // ── Bundle index (bundles/index.json) ───────────────────────────
+
+    public static class BundleIndex {
+        public List<BundleEntry> bundles;
+    }
+
+    public static class BundleEntry {
+        public String name;
+        public String title;
+        public String generatedAt;
+        public String reportPath;
     }
 }

--- a/src/test/java/shortestpath/dashboard/PathfinderTestDashboardCollector.java
+++ b/src/test/java/shortestpath/dashboard/PathfinderTestDashboardCollector.java
@@ -7,12 +7,9 @@ import shortestpath.pathfinder.PathfinderConfig;
 import shortestpath.pathfinder.PathfinderResult;
 
 public final class PathfinderTestDashboardCollector {
-    private static final String BUNDLE_ID = "pathfinder-tests";
     private static final String OUTPUT_ROOT_PROPERTY = DashboardBundlePublisher.OUTPUT_ROOT_PROPERTY;
     private static final PathfinderDashboardReportWriter REPORT_WRITER = new PathfinderDashboardReportWriter();
-    private static final DashboardBundlePublisher BUNDLE_PUBLISHER = new DashboardBundlePublisher();
-    // Scenario tests append run records incrementally as assertions execute, then rewrite the same bundle so the
-    // dashboard can be inspected even partway through a test run.
+    private static final DashboardBundlePublisher PUBLISHER = new DashboardBundlePublisher();
     private static final List<PathfinderDashboardModels.RunRecord> RUNS = new ArrayList<>();
     private static final long STARTED = System.currentTimeMillis();
 
@@ -54,18 +51,15 @@ public final class PathfinderTestDashboardCollector {
 
     private static void writeReport() {
         try {
-            // PathfinderTest has many different scenario configurations, so its transport overlay is a generic
-            // "show everything" layer rather than one availability snapshot from a single config state.
-            BUNDLE_PUBLISHER.publishBundle(
-                BUNDLE_ID,
+            PathfinderDashboardModels.Report report = REPORT_WRITER.createReport(
                 "Pathfinder Dashboard",
                 "Routes captured from PathfinderTest",
-                REPORT_WRITER.createReport(
-                    "Pathfinder Dashboard",
-                    "Routes captured from PathfinderTest",
-                    System.currentTimeMillis() - STARTED,
-                    RUNS,
-                    REPORT_WRITER.createTransportLayerPointsAlwaysAvailable()));
+                System.currentTimeMillis() - STARTED,
+                RUNS);
+
+            String bundleName = System.getProperty(
+                DashboardBundlePublisher.BUNDLE_NAME_PROPERTY, "pathfinder-tests");
+            PUBLISHER.publishBundle(bundleName, report);
         } catch (IOException e) {
             throw new RuntimeException("Failed to write pathfinder test dashboard", e);
         }

--- a/src/test/java/shortestpath/dashboard/PathfinderTestDashboardCollector.java
+++ b/src/test/java/shortestpath/dashboard/PathfinderTestDashboardCollector.java
@@ -55,7 +55,8 @@ public final class PathfinderTestDashboardCollector {
                 "Pathfinder Dashboard",
                 "Routes captured from PathfinderTest",
                 System.currentTimeMillis() - STARTED,
-                RUNS);
+                RUNS,
+                REPORT_WRITER.createTransportLayerPointsAlwaysAvailable());
 
             String bundleName = System.getProperty(
                 DashboardBundlePublisher.BUNDLE_NAME_PROPERTY, "pathfinder-tests");

--- a/src/test/java/shortestpath/dashboard/ProfilerReportWriter.java
+++ b/src/test/java/shortestpath/dashboard/ProfilerReportWriter.java
@@ -47,6 +47,8 @@ public class ProfilerReportWriter extends PathfinderDashboardReportWriter {
         run.counters.blockedTileTransportChecks = profile.getBlockedTileTransportChecks();
         run.counters.bankTransitions = profile.getBankTransitions();
         run.counters.wildernessLevelChanges = profile.getWildernessLevelChanges();
+        run.counters.delayedVisitEnqueued = profile.getDelayedVisitEnqueued();
+        run.counters.delayedVisitSkipped = profile.getDelayedVisitSkipped();
         run.counters.peakBoundarySize = profile.getPeakBoundarySize();
         run.counters.peakPendingSize = profile.getPeakPendingSize();
 

--- a/src/test/java/shortestpath/dashboard/ProfilerReportWriter.java
+++ b/src/test/java/shortestpath/dashboard/ProfilerReportWriter.java
@@ -1,0 +1,76 @@
+package shortestpath.dashboard;
+
+import java.util.ArrayList;
+import java.util.Map;
+import shortestpath.WorldPointUtil;
+import shortestpath.pathfinder.PathfinderProfile;
+
+public class ProfilerReportWriter extends PathfinderDashboardReportWriter {
+
+    public void populateProfilerData(PathfinderDashboardModels.RunRecord run, PathfinderProfile profile) {
+        if (profile == null) {
+            return;
+        }
+
+        // Phase breakdown
+        run.phases = new PathfinderDashboardModels.PhaseBreakdown();
+        run.phases.addNeighborsNanos = profile.getAddNeighborsNanos();
+        run.phases.queueSelectionNanos = profile.getQueueSelectionNanos();
+        run.phases.targetCheckNanos = profile.getTargetCheckNanos();
+        run.phases.wildernessCheckNanos = profile.getWildernessCheckNanos();
+        run.phases.cutoffCheckNanos = profile.getCutoffCheckNanos();
+        run.phases.bookkeepingNanos = profile.getBookkeepingNanos();
+        long accountedPhaseNanos = profile.getAddNeighborsNanos()
+            + profile.getQueueSelectionNanos()
+            + profile.getTargetCheckNanos()
+            + profile.getWildernessCheckNanos()
+            + profile.getCutoffCheckNanos()
+            + profile.getBookkeepingNanos();
+        run.phases.otherNanos = Math.max(0, run.stats.elapsedNanos - accountedPhaseNanos);
+
+        // Sub-phase breakdown
+        run.subPhases = new PathfinderDashboardModels.SubPhaseBreakdown();
+        run.subPhases.bankCheckNanos = profile.getBankCheckNanos();
+        run.subPhases.transportLookupNanos = profile.getTransportLookupNanos();
+        run.subPhases.collisionCheckNanos = profile.getCollisionCheckNanos();
+        run.subPhases.walkableTileNanos = profile.getWalkableTileNanos();
+        run.subPhases.blockedTileTransportNanos = profile.getBlockedTileTransportNanos();
+        run.subPhases.abstractNodeNanos = profile.getAbstractNodeNanos();
+
+        // Counters
+        run.counters = new PathfinderDashboardModels.ProfilerCounters();
+        run.counters.tileNeighborsAdded = profile.getTileNeighborsAdded();
+        run.counters.transportNeighborsAdded = profile.getTransportNeighborsAdded();
+        run.counters.visitedSkipped = profile.getVisitedSkipped();
+        run.counters.abstractNodesExpanded = profile.getAbstractNodesExpanded();
+        run.counters.transportEvaluations = profile.getTransportEvaluations();
+        run.counters.blockedTileTransportChecks = profile.getBlockedTileTransportChecks();
+        run.counters.bankTransitions = profile.getBankTransitions();
+        run.counters.wildernessLevelChanges = profile.getWildernessLevelChanges();
+        run.counters.peakBoundarySize = profile.getPeakBoundarySize();
+        run.counters.peakPendingSize = profile.getPeakPendingSize();
+
+        // Time series
+        run.timeSeries = new ArrayList<>();
+        for (PathfinderProfile.ProfileSample sample : profile.getSamples()) {
+            PathfinderDashboardModels.TimeSeriesSample s = new PathfinderDashboardModels.TimeSeriesSample();
+            s.iteration = sample.getIteration();
+            s.boundarySize = sample.getBoundarySize();
+            s.pendingSize = sample.getPendingSize();
+            s.currentCost = sample.getCurrentCost();
+            s.elapsedMs = sample.getElapsedNanos() / 1_000_000.0;
+            run.timeSeries.add(s);
+        }
+
+        // Tile heatmap
+        run.tileHeatmap = new PathfinderDashboardModels.TileHeatmap();
+        run.tileHeatmap.tiles = new ArrayList<>();
+        for (Map.Entry<Integer, int[]> entry : profile.getTileVisitCounts().entrySet()) {
+            PathfinderDashboardModels.TileVisit tv = new PathfinderDashboardModels.TileVisit();
+            tv.x = WorldPointUtil.unpackWorldX(entry.getKey());
+            tv.y = WorldPointUtil.unpackWorldY(entry.getKey());
+            tv.count = entry.getValue()[0];
+            run.tileHeatmap.tiles.add(tv);
+        }
+    }
+}

--- a/src/test/java/shortestpath/pathfinder/PathfinderProfile.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderProfile.java
@@ -1,0 +1,126 @@
+package shortestpath.pathfinder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Collects detailed profiling data during a pathfinding run.
+ * This class lives in test only — it is never included in the production build.
+ */
+public class PathfinderProfile {
+    static final int SAMPLE_INTERVAL = 2000;
+
+    // ── Top-level phase timing (accumulated nanos) ──────────────────────
+    long addNeighborsNanos;
+    long queueSelectionNanos;
+    long targetCheckNanos;
+    long wildernessCheckNanos;
+    long cutoffCheckNanos;
+    long bookkeepingNanos;
+
+    // ── Sub-phase timing within addNeighbors / CollisionMap ─────────────
+    long bankCheckNanos;
+    long transportLookupNanos;
+    long collisionCheckNanos;
+    long walkableTileNanos;
+    long blockedTileTransportNanos;
+    long abstractNodeNanos;
+
+    // ── Counters ────────────────────────────────────────────────────────
+    int tileNeighborsAdded;
+    int transportNeighborsAdded;
+    int visitedSkipped;
+    int abstractNodesExpanded;
+    int transportEvaluations;
+    int blockedTileTransportChecks;
+    int bankTransitions;
+    int wildernessLevelChanges;
+    int peakBoundarySize;
+    int peakPendingSize;
+
+    // ── Time series ─────────────────────────────────────────────────────
+    private final List<ProfileSample> samples = new ArrayList<>(400);
+
+    // ── Tile visit heatmap (sparse: packedPosition -> visit count) ────
+    private final Map<Integer, int[]> tileVisitCounts = new HashMap<>();
+
+    public PathfinderProfile() {
+    }
+
+    // ── Sampling ────────────────────────────────────────────────────────
+
+    boolean shouldSample(int iteration) {
+        return iteration % SAMPLE_INTERVAL == 0;
+    }
+
+    void recordSample(int iteration, int boundarySize, int pendingSize, int currentCost, long elapsedNanos) {
+        samples.add(new ProfileSample(iteration, boundarySize, pendingSize, currentCost, elapsedNanos));
+    }
+
+    void updatePeakBoundarySize(int size) {
+        if (size > peakBoundarySize) {
+            peakBoundarySize = size;
+        }
+    }
+
+    void updatePeakPendingSize(int size) {
+        if (size > peakPendingSize) {
+            peakPendingSize = size;
+        }
+    }
+
+    void incrementTileVisit(int packedPosition) {
+        tileVisitCounts.computeIfAbsent(packedPosition, k -> new int[1])[0]++;
+    }
+
+    // ── Getters ─────────────────────────────────────────────────────────
+
+    public long getAddNeighborsNanos() { return addNeighborsNanos; }
+    public long getQueueSelectionNanos() { return queueSelectionNanos; }
+    public long getTargetCheckNanos() { return targetCheckNanos; }
+    public long getWildernessCheckNanos() { return wildernessCheckNanos; }
+    public long getCutoffCheckNanos() { return cutoffCheckNanos; }
+    public long getBookkeepingNanos() { return bookkeepingNanos; }
+    public long getBankCheckNanos() { return bankCheckNanos; }
+    public long getTransportLookupNanos() { return transportLookupNanos; }
+    public long getCollisionCheckNanos() { return collisionCheckNanos; }
+    public long getWalkableTileNanos() { return walkableTileNanos; }
+    public long getBlockedTileTransportNanos() { return blockedTileTransportNanos; }
+    public long getAbstractNodeNanos() { return abstractNodeNanos; }
+    public int getTileNeighborsAdded() { return tileNeighborsAdded; }
+    public int getTransportNeighborsAdded() { return transportNeighborsAdded; }
+    public int getVisitedSkipped() { return visitedSkipped; }
+    public int getAbstractNodesExpanded() { return abstractNodesExpanded; }
+    public int getTransportEvaluations() { return transportEvaluations; }
+    public int getBlockedTileTransportChecks() { return blockedTileTransportChecks; }
+    public int getBankTransitions() { return bankTransitions; }
+    public int getWildernessLevelChanges() { return wildernessLevelChanges; }
+    public int getPeakBoundarySize() { return peakBoundarySize; }
+    public int getPeakPendingSize() { return peakPendingSize; }
+    public List<ProfileSample> getSamples() { return samples; }
+    public Map<Integer, int[]> getTileVisitCounts() { return tileVisitCounts; }
+
+    public static class ProfileSample {
+        private final int iteration;
+        private final int boundarySize;
+        private final int pendingSize;
+        private final int currentCost;
+        private final long elapsedNanos;
+
+        public ProfileSample(int iteration, int boundarySize, int pendingSize, int currentCost, long elapsedNanos) {
+            this.iteration = iteration;
+            this.boundarySize = boundarySize;
+            this.pendingSize = pendingSize;
+            this.currentCost = currentCost;
+            this.elapsedNanos = elapsedNanos;
+        }
+
+        public int getIteration() { return iteration; }
+        public int getBoundarySize() { return boundarySize; }
+        public int getPendingSize() { return pendingSize; }
+        public int getCurrentCost() { return currentCost; }
+        public long getElapsedNanos() { return elapsedNanos; }
+    }
+}

--- a/src/test/java/shortestpath/pathfinder/PathfinderProfile.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderProfile.java
@@ -37,6 +37,8 @@ public class PathfinderProfile {
     int blockedTileTransportChecks;
     int bankTransitions;
     int wildernessLevelChanges;
+    int delayedVisitEnqueued;
+    int delayedVisitSkipped;
     int peakBoundarySize;
     int peakPendingSize;
 
@@ -97,6 +99,8 @@ public class PathfinderProfile {
     public int getBlockedTileTransportChecks() { return blockedTileTransportChecks; }
     public int getBankTransitions() { return bankTransitions; }
     public int getWildernessLevelChanges() { return wildernessLevelChanges; }
+    public int getDelayedVisitEnqueued() { return delayedVisitEnqueued; }
+    public int getDelayedVisitSkipped() { return delayedVisitSkipped; }
     public int getPeakBoundarySize() { return peakBoundarySize; }
     public int getPeakPendingSize() { return peakPendingSize; }
     public List<ProfileSample> getSamples() { return samples; }

--- a/src/test/java/shortestpath/pathfinder/PathfinderProfilerTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderProfilerTest.java
@@ -50,10 +50,14 @@ public class PathfinderProfilerTest {
         int target = WorldPointUtil.packWorldPoint(3213, 3428, 0);
 
         Pathfinder unprofiled = new Pathfinder(pathfinderConfig, start, Set.of(target));
+        long unprofiledStart = System.nanoTime();
         unprofiled.run();
+        long unprofiledNanos = System.nanoTime() - unprofiledStart;
 
         ProfilingPathfinder profiled = new ProfilingPathfinder(pathfinderConfig, start, Set.of(target));
+        long profiledStart = System.nanoTime();
         profiled.run();
+        long profiledNanos = System.nanoTime() - profiledStart;
 
         PathfinderResult unprofiledResult = unprofiled.getResult();
         PathfinderResult profiledResult = profiled.getResult();
@@ -76,5 +80,11 @@ public class PathfinderProfilerTest {
         assertTrue("Should have checked some nodes", profile.getTileNeighborsAdded() > 0);
         assertTrue("addNeighbors time should be positive", profile.getAddNeighborsNanos() > 0);
         assertTrue("Peak boundary size should be positive", profile.getPeakBoundarySize() > 0);
+
+        // Profiling overhead should be reasonable (< 2x unprofiled runtime)
+        assertTrue("Profiling overhead too high: profiled=" + profiledNanos / 1_000_000 +
+            "ms, unprofiled=" + unprofiledNanos / 1_000_000 + "ms (ratio=" +
+            String.format("%.2f", (double) profiledNanos / unprofiledNanos) + "x)",
+            profiledNanos < unprofiledNanos * 2);
     }
 }

--- a/src/test/java/shortestpath/pathfinder/PathfinderProfilerTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderProfilerTest.java
@@ -1,0 +1,80 @@
+package shortestpath.pathfinder;
+
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.QuestState;
+import net.runelite.api.Skill;
+import org.junit.Before;
+import org.junit.Test;
+import shortestpath.TeleportationItem;
+import shortestpath.TestShortestPathConfig;
+import shortestpath.WorldPointUtil;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link ProfilingPathfinder} produces the same results as the
+ * standard {@link Pathfinder}.  Profiler dashboard scenarios are now driven
+ * from the unified {@code ReachabilityDashboardTest} with the {@code profiler}
+ * scenario and the {@code profiler_routes.csv} dataset.
+ */
+public class PathfinderProfilerTest {
+    private Client client;
+    private TestShortestPathConfig config;
+    private PathfinderConfig pathfinderConfig;
+
+    @Before
+    public void setUp() {
+        client = mock(Client.class);
+        config = new TestShortestPathConfig();
+        when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+        when(client.getClientThread()).thenReturn(Thread.currentThread());
+        when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+        config.setCalculationCutoffValue(500);
+        config.setUseTeleportationItemsValue(TeleportationItem.ALL);
+        config.setIncludeBankPathValue(false);
+
+        pathfinderConfig = new TestPathfinderConfig(client, config, QuestState.FINISHED, true, true);
+        pathfinderConfig.refresh();
+    }
+
+    @Test
+    public void profilingDoesNotAffectResults() {
+        // Verify that profiled (ProfilingPathfinder) and unprofiled (Pathfinder) produce identical paths
+        int start = WorldPointUtil.packWorldPoint(3222, 3218, 0);
+        int target = WorldPointUtil.packWorldPoint(3213, 3428, 0);
+
+        Pathfinder unprofiled = new Pathfinder(pathfinderConfig, start, Set.of(target));
+        unprofiled.run();
+
+        ProfilingPathfinder profiled = new ProfilingPathfinder(pathfinderConfig, start, Set.of(target));
+        profiled.run();
+
+        PathfinderResult unprofiledResult = unprofiled.getResult();
+        PathfinderResult profiledResult = profiled.getResult();
+
+        assertNotNull("Unprofiled result should not be null", unprofiledResult);
+        assertNotNull("Profiled result should not be null", profiledResult);
+
+        // Same path length
+        assertTrue("Profiled and unprofiled paths should have same length, got " +
+            unprofiledResult.getPathSteps().size() + " vs " + profiledResult.getPathSteps().size(),
+            unprofiledResult.getPathSteps().size() == profiledResult.getPathSteps().size());
+
+        // Same reached state
+        assertTrue("Profiled and unprofiled should have same reached state",
+            unprofiledResult.isReached() == profiledResult.isReached());
+
+        // Profile has meaningful data
+        PathfinderProfile profile = profiled.getProfile();
+        assertNotNull("Profile data should be present", profile);
+        assertTrue("Should have checked some nodes", profile.getTileNeighborsAdded() > 0);
+        assertTrue("addNeighbors time should be positive", profile.getAddNeighborsNanos() > 0);
+        assertTrue("Peak boundary size should be positive", profile.getPeakBoundarySize() > 0);
+    }
+}

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -1327,6 +1327,7 @@ public class PathfinderTest {
                 break;
             }
         }
+        expected = null;
         if (actual != null) {
             expected = new TransportItems(
                 new int[][]{
@@ -1400,6 +1401,11 @@ public class PathfinderTest {
     }
 
     private void testTransportLength(int expectedLength, int origin, int destination,
+        TeleportationItem useTeleportationItems) {
+        testTransportLength(expectedLength, origin, destination, useTeleportationItems, 99);
+    }
+
+    private void testTransportLength(int expectedLength, int origin, int destination,
         TeleportationItem useTeleportationItems, int skillLevel) {
         setupConfig(QuestState.FINISHED, skillLevel, useTeleportationItems);
         assertEquals(expectedLength, calculatePathLength(origin, destination));
@@ -1435,6 +1441,30 @@ public class PathfinderTest {
         System.out.printf("Successfully completed %d " + transportType + " transport length tests%n", counter);
     }
 
+    /**
+     * Tests a single transport of the given type for efficiency.
+     * Unlike testTransportLength which tests all transports of a type,
+     * this only tests the first matching transport found.
+     */
+    private void testSingleTransport(int expectedLength, TransportType transportType) {
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
+
+        for (int origin : transports.keySet()) {
+            for (Transport transport : transports.get(origin)) {
+                if (transportType.equals(transport.getType())) {
+                    // Skip POH transports
+                    int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
+                    int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
+                    if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
+                        continue;
+                    }
+                    assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
+                    return; // Only test one transport
+                }
+            }
+        }
+        fail("No transport of type " + transportType + " found");
+    }
 
     /**
      * Verifies that ALL transports of the given type are present in the usable transports,
@@ -1565,18 +1595,6 @@ public class PathfinderTest {
         return null;
     }
 
-    private Transport findConfiguredTransport(TransportType transportType) {
-        for (Set<Transport> set : pathfinderConfig.getTransports().values()) {
-            for (Transport transport : set) {
-                if (transportType.equals(transport.getType())) {
-                    return transport;
-                }
-            }
-        }
-        fail("No configured transport of type " + transportType + " found");
-        return null;
-    }
-
     private int calculatePathLength(int origin, int destination) {
         Pathfinder pathfinder = runPathfinder(origin, destination);
         return pathfinder.getPath().size();
@@ -1588,14 +1606,17 @@ public class PathfinderTest {
         return pathfinder;
     }
 
+    // In a future commit, these tests will be rendered onto a debugging dashboard.
     private Pathfinder runScenario(String label, int origin, int destination) {
         Pathfinder pathfinder = runPathfinder(origin, destination);
-        PathfinderTestDashboardCollector.record(
+        if (pathfinder.getResult() != null) {
+            PathfinderTestDashboardCollector.record(
                 label,
                 pathfinder.getResult(),
                 pathfinderConfig,
                 null,
                 null);
+        }
         return pathfinder;
     }
 
@@ -1715,6 +1736,96 @@ public class PathfinderTest {
             pathfinderConfig.getTransportsPacked(bankVisited).getOrDefault(origin, Set.of()));
         stepTransports.addAll(pathfinderConfig.getUsableTeleports(bankVisited));
         return stepTransports;
+    }
+
+    // ── Temporary: verify ProfilingPathfinder mirrors Pathfinder exactly ──
+
+    @Test
+    public void profilingDoesNotAffectResults() {
+        setupConfig(QuestState.FINISHED, 99, TeleportationItem.ALL);
+        setupInventory(
+            new Item(ItemID.COINS, 10000000),
+            new Item(ItemID.DRAMEN_STAFF, 1),
+            new Item(ItemID.ROPE, 1));
+        setupEquipment();
+
+        int[][] routes = {
+            // Short walk (Lumbridge)
+            {WorldPointUtil.packWorldPoint(3222, 3218, 0), WorldPointUtil.packWorldPoint(3233, 3230, 0)},
+            // Medium route with fairy ring (Zanaris entrance -> Edgeville)
+            {WorldPointUtil.packWorldPoint(3201, 3169, 0), WorldPointUtil.packWorldPoint(3094, 3491, 0)},
+            // Cross-map route (Lumbridge -> Ardougne)
+            {WorldPointUtil.packWorldPoint(3222, 3218, 0), WorldPointUtil.packWorldPoint(2662, 3305, 0)},
+        };
+
+        for (int[] route : routes) {
+            int origin = route[0];
+            int destination = route[1];
+
+            Pathfinder pathfinder = new Pathfinder(pathfinderConfig, origin, Set.of(destination));
+            pathfinder.run();
+            PathfinderResult expected = pathfinder.getResult();
+
+            ProfilingPathfinder profiling = new ProfilingPathfinder(pathfinderConfig, origin, Set.of(destination));
+            profiling.run();
+            PathfinderResult actual = profiling.getResult();
+
+            String label = "(" + WorldPointUtil.unpackWorldX(origin) + "," + WorldPointUtil.unpackWorldY(origin) + ")"
+                + " -> (" + WorldPointUtil.unpackWorldX(destination) + "," + WorldPointUtil.unpackWorldY(destination) + ")";
+
+            assertEquals(label + " reached", expected.isReached(), actual.isReached());
+            assertEquals(label + " terminationReason", expected.getTerminationReason(), actual.getTerminationReason());
+            assertEquals(label + " path length", expected.getPathSteps().size(), actual.getPathSteps().size());
+            assertEquals(label + " nodesChecked", expected.getNodesChecked(), actual.getNodesChecked());
+            assertEquals(label + " transportsChecked", expected.getTransportsChecked(), actual.getTransportsChecked());
+
+            for (int i = 0; i < expected.getPathSteps().size(); i++) {
+                PathStep e = expected.getPathSteps().get(i);
+                PathStep a = actual.getPathSteps().get(i);
+                assertEquals(label + " step[" + i + "] position", e.getPackedPosition(), a.getPackedPosition());
+                assertEquals(label + " step[" + i + "] bankVisited", e.isBankVisited(), a.isBankVisited());
+            }
+
+            // Verify profiling produces meaningful timing data
+            PathfinderProfile profile = profiling.getProfile();
+
+            // Top-level phases should all have recorded time for non-trivial routes
+            long totalPhaseNanos = profile.getQueueSelectionNanos()
+                + profile.getAddNeighborsNanos()
+                + profile.getTargetCheckNanos()
+                + profile.getWildernessCheckNanos()
+                + profile.getCutoffCheckNanos()
+                + profile.getBookkeepingNanos();
+            assertTrue(label + " total phase nanos should be > 0", totalPhaseNanos > 0);
+            assertTrue(label + " addNeighbors should dominate (> 0)", profile.getAddNeighborsNanos() > 0);
+            assertTrue(label + " queueSelection should be > 0", profile.getQueueSelectionNanos() > 0);
+            assertTrue(label + " targetCheck should be > 0", profile.getTargetCheckNanos() > 0);
+
+            // Sub-phase timing within addNeighbors
+            long totalSubphaseNanos = profile.getBankCheckNanos()
+                + profile.getTransportLookupNanos()
+                + profile.getCollisionCheckNanos()
+                + profile.getWalkableTileNanos()
+                + profile.getBlockedTileTransportNanos()
+                + profile.getAbstractNodeNanos();
+            assertTrue(label + " sub-phase nanos should be > 0", totalSubphaseNanos > 0);
+            assertTrue(label + " collisionCheck sub-phase should be > 0", profile.getCollisionCheckNanos() > 0);
+            assertTrue(label + " walkableTile sub-phase should be > 0", profile.getWalkableTileNanos() > 0);
+
+            // Counters should be consistent with result
+            assertEquals(label + " tileNeighborsAdded should match nodesChecked",
+                actual.getNodesChecked(), profile.getTileNeighborsAdded());
+            assertEquals(label + " transportNeighborsAdded should match transportsChecked",
+                actual.getTransportsChecked(), profile.getTransportNeighborsAdded());
+            assertTrue(label + " peakBoundarySize should be > 0", profile.getPeakBoundarySize() > 0);
+            assertTrue(label + " transportEvaluations should be > 0", profile.getTransportEvaluations() > 0);
+
+            // Heatmap should have recorded tile visits
+            assertFalse(label + " tile visit heatmap should not be empty", profile.getTileVisitCounts().isEmpty());
+
+            // Elapsed time in the result should be positive
+            assertTrue(label + " elapsed nanos should be > 0", actual.getElapsedNanos() > 0);
+        }
     }
 
 }

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -1401,11 +1401,6 @@ public class PathfinderTest {
     }
 
     private void testTransportLength(int expectedLength, int origin, int destination,
-        TeleportationItem useTeleportationItems) {
-        testTransportLength(expectedLength, origin, destination, useTeleportationItems, 99);
-    }
-
-    private void testTransportLength(int expectedLength, int origin, int destination,
         TeleportationItem useTeleportationItems, int skillLevel) {
         setupConfig(QuestState.FINISHED, skillLevel, useTeleportationItems);
         assertEquals(expectedLength, calculatePathLength(origin, destination));
@@ -1439,31 +1434,6 @@ public class PathfinderTest {
 
         assertTrue("No tests were performed", counter > 0);
         System.out.printf("Successfully completed %d " + transportType + " transport length tests%n", counter);
-    }
-
-    /**
-     * Tests a single transport of the given type for efficiency.
-     * Unlike testTransportLength which tests all transports of a type,
-     * this only tests the first matching transport found.
-     */
-    private void testSingleTransport(int expectedLength, TransportType transportType) {
-        setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE);
-
-        for (int origin : transports.keySet()) {
-            for (Transport transport : transports.get(origin)) {
-                if (transportType.equals(transport.getType())) {
-                    // Skip POH transports
-                    int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
-                    int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
-                    if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
-                        continue;
-                    }
-                    assertEquals(transport.toString(), expectedLength, calculateTransportLength(transport));
-                    return; // Only test one transport
-                }
-            }
-        }
-        fail("No transport of type " + transportType + " found");
     }
 
     /**
@@ -1736,96 +1706,6 @@ public class PathfinderTest {
             pathfinderConfig.getTransportsPacked(bankVisited).getOrDefault(origin, Set.of()));
         stepTransports.addAll(pathfinderConfig.getUsableTeleports(bankVisited));
         return stepTransports;
-    }
-
-    // ── Temporary: verify ProfilingPathfinder mirrors Pathfinder exactly ──
-
-    @Test
-    public void profilingDoesNotAffectResults() {
-        setupConfig(QuestState.FINISHED, 99, TeleportationItem.ALL);
-        setupInventory(
-            new Item(ItemID.COINS, 10000000),
-            new Item(ItemID.DRAMEN_STAFF, 1),
-            new Item(ItemID.ROPE, 1));
-        setupEquipment();
-
-        int[][] routes = {
-            // Short walk (Lumbridge)
-            {WorldPointUtil.packWorldPoint(3222, 3218, 0), WorldPointUtil.packWorldPoint(3233, 3230, 0)},
-            // Medium route with fairy ring (Zanaris entrance -> Edgeville)
-            {WorldPointUtil.packWorldPoint(3201, 3169, 0), WorldPointUtil.packWorldPoint(3094, 3491, 0)},
-            // Cross-map route (Lumbridge -> Ardougne)
-            {WorldPointUtil.packWorldPoint(3222, 3218, 0), WorldPointUtil.packWorldPoint(2662, 3305, 0)},
-        };
-
-        for (int[] route : routes) {
-            int origin = route[0];
-            int destination = route[1];
-
-            Pathfinder pathfinder = new Pathfinder(pathfinderConfig, origin, Set.of(destination));
-            pathfinder.run();
-            PathfinderResult expected = pathfinder.getResult();
-
-            ProfilingPathfinder profiling = new ProfilingPathfinder(pathfinderConfig, origin, Set.of(destination));
-            profiling.run();
-            PathfinderResult actual = profiling.getResult();
-
-            String label = "(" + WorldPointUtil.unpackWorldX(origin) + "," + WorldPointUtil.unpackWorldY(origin) + ")"
-                + " -> (" + WorldPointUtil.unpackWorldX(destination) + "," + WorldPointUtil.unpackWorldY(destination) + ")";
-
-            assertEquals(label + " reached", expected.isReached(), actual.isReached());
-            assertEquals(label + " terminationReason", expected.getTerminationReason(), actual.getTerminationReason());
-            assertEquals(label + " path length", expected.getPathSteps().size(), actual.getPathSteps().size());
-            assertEquals(label + " nodesChecked", expected.getNodesChecked(), actual.getNodesChecked());
-            assertEquals(label + " transportsChecked", expected.getTransportsChecked(), actual.getTransportsChecked());
-
-            for (int i = 0; i < expected.getPathSteps().size(); i++) {
-                PathStep e = expected.getPathSteps().get(i);
-                PathStep a = actual.getPathSteps().get(i);
-                assertEquals(label + " step[" + i + "] position", e.getPackedPosition(), a.getPackedPosition());
-                assertEquals(label + " step[" + i + "] bankVisited", e.isBankVisited(), a.isBankVisited());
-            }
-
-            // Verify profiling produces meaningful timing data
-            PathfinderProfile profile = profiling.getProfile();
-
-            // Top-level phases should all have recorded time for non-trivial routes
-            long totalPhaseNanos = profile.getQueueSelectionNanos()
-                + profile.getAddNeighborsNanos()
-                + profile.getTargetCheckNanos()
-                + profile.getWildernessCheckNanos()
-                + profile.getCutoffCheckNanos()
-                + profile.getBookkeepingNanos();
-            assertTrue(label + " total phase nanos should be > 0", totalPhaseNanos > 0);
-            assertTrue(label + " addNeighbors should dominate (> 0)", profile.getAddNeighborsNanos() > 0);
-            assertTrue(label + " queueSelection should be > 0", profile.getQueueSelectionNanos() > 0);
-            assertTrue(label + " targetCheck should be > 0", profile.getTargetCheckNanos() > 0);
-
-            // Sub-phase timing within addNeighbors
-            long totalSubphaseNanos = profile.getBankCheckNanos()
-                + profile.getTransportLookupNanos()
-                + profile.getCollisionCheckNanos()
-                + profile.getWalkableTileNanos()
-                + profile.getBlockedTileTransportNanos()
-                + profile.getAbstractNodeNanos();
-            assertTrue(label + " sub-phase nanos should be > 0", totalSubphaseNanos > 0);
-            assertTrue(label + " collisionCheck sub-phase should be > 0", profile.getCollisionCheckNanos() > 0);
-            assertTrue(label + " walkableTile sub-phase should be > 0", profile.getWalkableTileNanos() > 0);
-
-            // Counters should be consistent with result
-            assertEquals(label + " tileNeighborsAdded should match nodesChecked",
-                actual.getNodesChecked(), profile.getTileNeighborsAdded());
-            assertEquals(label + " transportNeighborsAdded should match transportsChecked",
-                actual.getTransportsChecked(), profile.getTransportNeighborsAdded());
-            assertTrue(label + " peakBoundarySize should be > 0", profile.getPeakBoundarySize() > 0);
-            assertTrue(label + " transportEvaluations should be > 0", profile.getTransportEvaluations() > 0);
-
-            // Heatmap should have recorded tile visits
-            assertFalse(label + " tile visit heatmap should not be empty", profile.getTileVisitCounts().isEmpty());
-
-            // Elapsed time in the result should be positive
-            assertTrue(label + " elapsed nanos should be > 0", actual.getElapsedNanos() > 0);
-        }
     }
 
 }

--- a/src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java
+++ b/src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java
@@ -238,6 +238,9 @@ public class ProfilingPathfinder {
         subStart = System.nanoTime();
 
         Set<Transport> transports = config.getTransportsPacked(pathBankVisited).getOrDefault(node.packedPosition, Set.of());
+        int inheritedDifferential = (node instanceof TransportNode && ((TransportNode) node).delayedVisit)
+            ? ((TransportNode) node).differentialCost
+            : 0;
         for (Transport transport : transports) {
             profile.transportEvaluations++;
             boolean delayedVisit = transport.getType().sharesDestinationsWith() != null;
@@ -245,9 +248,10 @@ public class ProfilingPathfinder {
                 profile.visitedSkipped++;
                 continue;
             }
+            int chainPenalty = (delayedVisit && inheritedDifferential > 0) ? inheritedDifferential : 0;
             neighbors.add(new TransportNode(
                 transport.getDestination(), node,
-                transport.getDuration(), config.getAdditionalTransportCost(transport),
+                transport.getDuration(), config.getAdditionalTransportCost(transport) + chainPenalty,
                 pathBankVisited,
                 delayedVisit,
                 delayedVisit ? config.getDifferentialCost(transport) : 0));
@@ -354,12 +358,13 @@ public class ProfilingPathfinder {
             if (config.avoidWilderness(sourceTile, transport.getDestination(), targetInWilderness)) {
                 continue;
             }
+            int differentialCost = delayedVisit ? config.getDifferentialCost(transport) : 0;
             neighbors.add(new TransportNode(
                 transport.getDestination(), node,
                 transport.getDuration(), config.getAdditionalTransportCost(transport),
                 node.bankVisited,
                 delayedVisit,
-                delayedVisit ? config.getDifferentialCost(transport) : 0));
+                differentialCost));
         }
         return neighbors;
     }

--- a/src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java
+++ b/src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java
@@ -88,6 +88,7 @@ public class ProfilingPathfinder {
                 // reached by a cheaper path while this node was queued.
                 if (node instanceof TransportNode && ((TransportNode) node).delayedVisit) {
                     if (visited.get(node.packedPosition, node.bankVisited)) {
+                        profile.delayedVisitSkipped++;
                         profile.queueSelectionNanos += System.nanoTime() - phaseStart;
                         continue;
                     }
@@ -192,6 +193,8 @@ public class ProfilingPathfinder {
             // They will be checked and marked when dequeued from pending.
             if (!(neighbor instanceof TransportNode && ((TransportNode) neighbor).delayedVisit)) {
                 visited.set(neighbor);
+            } else {
+                profile.delayedVisitEnqueued++;
             }
             if (neighbor instanceof TransportNode) {
                 pending.add((TransportNode) neighbor);

--- a/src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java
+++ b/src/test/java/shortestpath/pathfinder/ProfilingPathfinder.java
@@ -1,0 +1,408 @@
+package shortestpath.pathfinder;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+
+import shortestpath.WorldPointUtil;
+import shortestpath.transport.Transport;
+
+/**
+ * Test-only pathfinder that replicates the core search loop from {@link Pathfinder}
+ * with full profiling instrumentation. This class never ships in the production build.
+ *
+ * <p>The search algorithm is kept structurally identical to
+ * {@code Pathfinder.run()} so that the {@code profilingDoesNotAffectResults}
+ * test can catch any drift.</p>
+ */
+public class ProfilingPathfinder {
+
+    private final PathfinderConfig config;
+    private final CollisionMap map;
+    private final int start;
+    private final Set<Integer> targets;
+    private final boolean targetInWilderness;
+
+    private final Deque<Node> boundary = new ArrayDeque<>(4096);
+    private final Queue<TransportNode> pending = new PriorityQueue<>(256);
+    private final VisitedTiles visited;
+
+    private PathfinderProfile profile;
+    private PathfinderResult result;
+
+    private Node bestLastNode;
+    private int bestRemainingDistance = Integer.MAX_VALUE;
+    private int bestTravelledDistance = Integer.MAX_VALUE;
+    private int bestX = Integer.MAX_VALUE;
+    private int bestY = Integer.MAX_VALUE;
+    private int reachedTarget = WorldPointUtil.UNDEFINED;
+    private PathTerminationReason terminationReason;
+    private int wildernessLevel;
+
+    private int nodesChecked;
+    private int transportsChecked;
+
+    // Shared neighbor list, matching CollisionMap's single-threaded assumption
+    private final List<Node> neighbors = new ArrayList<>(16);
+    private final boolean[] traversable = new boolean[8];
+    private static final OrdinalDirection[] ORDINAL_VALUES = OrdinalDirection.values();
+
+    public ProfilingPathfinder(PathfinderConfig config, int start, Set<Integer> targets) {
+        this.config = config;
+        this.map = config.getMap();
+        this.start = start;
+        this.targets = targets;
+        this.visited = new VisitedTiles(map);
+        this.targetInWilderness = WildernessChecker.isInWilderness(targets);
+        this.wildernessLevel = 31;
+        this.profile = new PathfinderProfile();
+    }
+
+    /**
+     * Runs the pathfinding algorithm with full profiling. After this method
+     * returns, {@link #getProfile()} and {@link #getResult()} are available.
+     */
+    public void run() {
+        long startNanos = System.nanoTime();
+        boundary.addFirst(new Node(start, null, 0, false));
+
+        long cutoffDurationMillis = config.getCalculationCutoffMillis();
+        long cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
+        int iteration = 0;
+
+        while (!boundary.isEmpty() || !pending.isEmpty()) {
+            // ── Queue selection phase ──
+            long phaseStart = System.nanoTime();
+
+            Node node = boundary.peekFirst();
+            TransportNode p = pending.peek();
+
+            if (p != null && (node == null || p.compareCost() < node.cost)) {
+                node = pending.poll();
+
+                // For delayed-visit nodes, check if the destination was already
+                // reached by a cheaper path while this node was queued.
+                if (node instanceof TransportNode && ((TransportNode) node).delayedVisit) {
+                    if (visited.get(node.packedPosition, node.bankVisited)) {
+                        profile.queueSelectionNanos += System.nanoTime() - phaseStart;
+                        continue;
+                    }
+                    visited.set(node.packedPosition, node.bankVisited);
+                }
+            } else {
+                node = boundary.removeFirst();
+            }
+
+            profile.queueSelectionNanos += System.nanoTime() - phaseStart;
+
+            // ── Wilderness check phase ──
+            if (node.isTile()) {
+                phaseStart = System.nanoTime();
+                updateWildernessLevel(node);
+                profile.wildernessCheckNanos += System.nanoTime() - phaseStart;
+            }
+
+            // ── Target check phase ──
+            phaseStart = System.nanoTime();
+
+            if (node.isTile() && targets.contains(node.packedPosition)) {
+                bestLastNode = node;
+                reachedTarget = node.packedPosition;
+                terminationReason = PathTerminationReason.TARGET_REACHED;
+                profile.targetCheckNanos += System.nanoTime() - phaseStart;
+                break;
+            }
+
+            if (node.isTile() && updateBestPathWhenUnreachable(node)) {
+                cutoffTimeMillis = System.currentTimeMillis() + cutoffDurationMillis;
+            }
+
+            profile.targetCheckNanos += System.nanoTime() - phaseStart;
+
+            // ── Cutoff check phase ──
+            phaseStart = System.nanoTime();
+
+            if (System.currentTimeMillis() > cutoffTimeMillis) {
+                terminationReason = PathTerminationReason.CUTOFF_REACHED;
+                profile.cutoffCheckNanos += System.nanoTime() - phaseStart;
+                break;
+            }
+
+            profile.cutoffCheckNanos += System.nanoTime() - phaseStart;
+
+            // ── addNeighbors phase ──
+            phaseStart = System.nanoTime();
+            addNeighbors(node);
+            profile.addNeighborsNanos += System.nanoTime() - phaseStart;
+
+            // ── Bookkeeping phase ──
+            phaseStart = System.nanoTime();
+
+            profile.updatePeakBoundarySize(boundary.size());
+            profile.updatePeakPendingSize(pending.size());
+            iteration++;
+            if (profile.shouldSample(iteration)) {
+                profile.recordSample(iteration, boundary.size(), pending.size(),
+                    node.cost, System.nanoTime() - startNanos);
+            }
+
+            profile.bookkeepingNanos += System.nanoTime() - phaseStart;
+        }
+
+        if (terminationReason == null) {
+            terminationReason = PathTerminationReason.SEARCH_EXHAUSTED;
+        }
+
+        long elapsedNanos = System.nanoTime() - startNanos;
+
+        boundary.clear();
+        visited.clear();
+        pending.clear();
+
+        boolean reached = reachedTarget != WorldPointUtil.UNDEFINED;
+        int target = reached ? reachedTarget : (targets.isEmpty() ? WorldPointUtil.UNDEFINED : targets.iterator().next());
+        int closestReached = bestLastNode != null ? bestLastNode.getClosestTilePosition() : start;
+        List<PathStep> path = bestLastNode != null ? bestLastNode.getPathSteps() : List.of();
+
+        result = new PathfinderResult(start, target, reached, path, closestReached,
+            nodesChecked, transportsChecked, elapsedNanos, terminationReason);
+    }
+
+    // ── addNeighbors: matches Pathfinder.addNeighbors exactly ───────────
+
+    private void addNeighbors(Node node) {
+        List<Node> nodes;
+        if (node.isTile()) {
+            nodes = getTileNeighbors(node);
+        } else {
+            nodes = getAbstractNodeNeighbors(node);
+        }
+
+        for (Node neighbor : nodes) {
+            if (node.isTile() && neighbor.isTile()
+                && config.avoidWilderness(node.packedPosition, neighbor.packedPosition, targetInWilderness)) {
+                continue;
+            }
+
+            // For delayed-visit nodes (shared destinations), don't mark as visited on enqueue.
+            // They will be checked and marked when dequeued from pending.
+            if (!(neighbor instanceof TransportNode && ((TransportNode) neighbor).delayedVisit)) {
+                visited.set(neighbor);
+            }
+            if (neighbor instanceof TransportNode) {
+                pending.add((TransportNode) neighbor);
+                ++transportsChecked;
+                profile.transportNeighborsAdded++;
+            } else {
+                boundary.addLast(neighbor);
+                ++nodesChecked;
+                profile.tileNeighborsAdded++;
+            }
+        }
+
+        // Tile visit counting for tile nodes
+        if (node.isTile()) {
+            profile.incrementTileVisit(node.packedPosition);
+        }
+    }
+
+    // ── getTileNeighbors: matches CollisionMap.getTileNeighbors ─────────
+    // Only calls visited.get() (never visited.set()), returns the neighbor list.
+
+    private List<Node> getTileNeighbors(Node node) {
+        final int x = WorldPointUtil.unpackWorldX(node.packedPosition);
+        final int y = WorldPointUtil.unpackWorldY(node.packedPosition);
+        final int z = WorldPointUtil.unpackWorldPlane(node.packedPosition);
+
+        neighbors.clear();
+
+        // ── Bank check sub-phase ──
+        long subStart = System.nanoTime();
+
+        boolean pathBankVisited = node.bankVisited
+            || (config.isBankPathEnabled() && config.getDestinations("bank").contains(node.packedPosition));
+
+        profile.bankCheckNanos += System.nanoTime() - subStart;
+        if (pathBankVisited && !node.bankVisited) {
+            profile.bankTransitions++;
+        }
+
+        // ── Transport lookup sub-phase ──
+        subStart = System.nanoTime();
+
+        Set<Transport> transports = config.getTransportsPacked(pathBankVisited).getOrDefault(node.packedPosition, Set.of());
+        for (Transport transport : transports) {
+            profile.transportEvaluations++;
+            boolean delayedVisit = transport.getType().sharesDestinationsWith() != null;
+            if (!delayedVisit && visited.get(transport.getDestination(), pathBankVisited)) {
+                profile.visitedSkipped++;
+                continue;
+            }
+            neighbors.add(new TransportNode(
+                transport.getDestination(), node,
+                transport.getDuration(), config.getAdditionalTransportCost(transport),
+                pathBankVisited,
+                delayedVisit,
+                delayedVisit ? config.getDifferentialCost(transport) : 0));
+        }
+
+        profile.transportLookupNanos += System.nanoTime() - subStart;
+
+        // ── Abstract node sub-phase ──
+        subStart = System.nanoTime();
+
+        Node globalTeleports = Node.abstractNode(AbstractNodeKind.fromWildernessLevel(wildernessLevel), node, pathBankVisited);
+        if (!visited.get(globalTeleports)) {
+            neighbors.add(globalTeleports);
+            profile.abstractNodesExpanded++;
+        }
+
+        profile.abstractNodeNanos += System.nanoTime() - subStart;
+
+        // ── Collision check sub-phase ──
+        subStart = System.nanoTime();
+
+        if (map.isBlocked(x, y, z)) {
+            boolean westBlocked = map.isBlocked(x - 1, y, z);
+            boolean eastBlocked = map.isBlocked(x + 1, y, z);
+            boolean southBlocked = map.isBlocked(x, y - 1, z);
+            boolean northBlocked = map.isBlocked(x, y + 1, z);
+            boolean southWestBlocked = map.isBlocked(x - 1, y - 1, z);
+            boolean southEastBlocked = map.isBlocked(x + 1, y - 1, z);
+            boolean northWestBlocked = map.isBlocked(x - 1, y + 1, z);
+            boolean northEastBlocked = map.isBlocked(x + 1, y + 1, z);
+            traversable[0] = !westBlocked;
+            traversable[1] = !eastBlocked;
+            traversable[2] = !southBlocked;
+            traversable[3] = !northBlocked;
+            traversable[4] = !southWestBlocked && !westBlocked && !southBlocked;
+            traversable[5] = !southEastBlocked && !eastBlocked && !southBlocked;
+            traversable[6] = !northWestBlocked && !westBlocked && !northBlocked;
+            traversable[7] = !northEastBlocked && !eastBlocked && !northBlocked;
+        } else {
+            traversable[0] = map.w(x, y, z);
+            traversable[1] = map.e(x, y, z);
+            traversable[2] = map.s(x, y, z);
+            traversable[3] = map.n(x, y, z);
+            // Diagonals: same logic as CollisionMap's private sw/se/nw/ne methods
+            traversable[4] = map.s(x, y, z) && map.w(x, y - 1, z) && map.w(x, y, z) && map.s(x - 1, y, z);
+            traversable[5] = map.s(x, y, z) && map.e(x, y - 1, z) && map.e(x, y, z) && map.s(x + 1, y, z);
+            traversable[6] = map.n(x, y, z) && map.w(x, y + 1, z) && map.w(x, y, z) && map.n(x - 1, y, z);
+            traversable[7] = map.n(x, y, z) && map.e(x, y + 1, z) && map.e(x, y, z) && map.n(x + 1, y, z);
+        }
+
+        profile.collisionCheckNanos += System.nanoTime() - subStart;
+
+        // ── Walkable tile iteration sub-phase ──
+        subStart = System.nanoTime();
+
+        for (int i = 0; i < traversable.length; i++) {
+            OrdinalDirection d = ORDINAL_VALUES[i];
+            int neighborPacked = WorldPointUtil.packWorldPoint(x + d.x, y + d.y, z);
+            if (visited.get(neighborPacked, pathBankVisited)) continue;
+
+            if (traversable[i]) {
+                neighbors.add(new Node(neighborPacked, node, Node.cost(neighborPacked, node), pathBankVisited));
+            } else if (Math.abs(d.x + d.y) == 1 && map.isBlocked(x + d.x, y + d.y, z)) {
+                // Blocked-tile transport fallback
+                profile.walkableTileNanos += System.nanoTime() - subStart;
+                subStart = System.nanoTime();
+
+                Set<Transport> neighborTransports = config.getTransportsPacked(pathBankVisited).getOrDefault(neighborPacked, Set.of());
+                for (Transport transport : neighborTransports) {
+                    profile.blockedTileTransportChecks++;
+                    if (transport.getOrigin() == Transport.UNDEFINED_ORIGIN
+                        || !transport.isUsableAtWildernessLevel(wildernessLevel)
+                        || visited.get(transport.getOrigin(), pathBankVisited)) {
+                        continue;
+                    }
+                    neighbors.add(new Node(transport.getOrigin(), node, Node.cost(transport.getOrigin(), node), pathBankVisited));
+                }
+
+                profile.blockedTileTransportNanos += System.nanoTime() - subStart;
+                subStart = System.nanoTime();
+            }
+        }
+
+        profile.walkableTileNanos += System.nanoTime() - subStart;
+
+        return neighbors;
+    }
+
+    // ── getAbstractNodeNeighbors: matches CollisionMap.getAbstractNodeNeighbors ──
+
+    private List<Node> getAbstractNodeNeighbors(Node node) {
+        neighbors.clear();
+        int sourceTile = node.getClosestTilePosition();
+        for (Transport transport : config.getUsableTeleports(node.bankVisited)) {
+            profile.transportEvaluations++;
+            boolean delayedVisit = transport.getType().sharesDestinationsWith() != null;
+            if (!delayedVisit && visited.get(transport.getDestination(), node.bankVisited)) {
+                profile.visitedSkipped++;
+                continue;
+            }
+            if (!transport.isUsableAtWildernessLevel(node.abstractKind.maxWildernessLevel())) {
+                continue;
+            }
+            if (config.avoidWilderness(sourceTile, transport.getDestination(), targetInWilderness)) {
+                continue;
+            }
+            neighbors.add(new TransportNode(
+                transport.getDestination(), node,
+                transport.getDuration(), config.getAdditionalTransportCost(transport),
+                node.bankVisited,
+                delayedVisit,
+                delayedVisit ? config.getDifferentialCost(transport) : 0));
+        }
+        return neighbors;
+    }
+
+    private boolean updateBestPathWhenUnreachable(Node node) {
+        boolean update = false;
+        for (int target : targets) {
+            int remainingDistance = WorldPointUtil.distanceBetween(target, node.packedPosition, WorldPointUtil.EUCLIDEAN_SQUARED_DISTANCE_METRIC);
+            int travelledDistance = node.cost;
+            int x = WorldPointUtil.unpackWorldX(node.packedPosition);
+            int y = WorldPointUtil.unpackWorldY(node.packedPosition);
+            if ((remainingDistance < bestRemainingDistance) ||
+                (remainingDistance == bestRemainingDistance && travelledDistance < bestTravelledDistance) ||
+                (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && x < bestX) ||
+                (remainingDistance == bestRemainingDistance && travelledDistance == bestTravelledDistance && x == bestX && y < bestY)) {
+                bestRemainingDistance = remainingDistance;
+                bestTravelledDistance = travelledDistance;
+                bestX = x;
+                bestY = y;
+                bestLastNode = node;
+                update = true;
+            }
+        }
+        return update;
+    }
+
+    private void updateWildernessLevel(Node node) {
+        int previousLevel = wildernessLevel;
+        if (wildernessLevel > 0) {
+            if (wildernessLevel > 30 && !WildernessChecker.isInLevel30Wilderness(node.packedPosition)) {
+                wildernessLevel = 30;
+            }
+            if (wildernessLevel > 20 && !WildernessChecker.isInLevel20Wilderness(node.packedPosition)) {
+                wildernessLevel = 20;
+            }
+            if (wildernessLevel > 0 && !WildernessChecker.isInWilderness(node.packedPosition)) {
+                wildernessLevel = 0;
+            }
+        }
+        if (wildernessLevel != previousLevel) {
+            profile.wildernessLevelChanges++;
+        }
+    }
+
+    public int getStart() { return start; }
+    public Set<Integer> getTargets() { return targets; }
+    public PathfinderProfile getProfile() { return profile; }
+    public PathfinderResult getResult() { return result; }
+}

--- a/src/test/java/shortestpath/reachability/ReachabilityDashboardTest.java
+++ b/src/test/java/shortestpath/reachability/ReachabilityDashboardTest.java
@@ -1,7 +1,6 @@
 package shortestpath.reachability;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -21,11 +20,13 @@ import shortestpath.TestShortestPathConfig;
 import shortestpath.WorldPointUtil;
 import shortestpath.dashboard.DashboardBundlePublisher;
 import shortestpath.dashboard.PathfinderDashboardModels;
-import shortestpath.dashboard.PathfinderDashboardReportWriter;
+import shortestpath.dashboard.ProfilerReportWriter;
 import shortestpath.pathfinder.Pathfinder;
 import shortestpath.pathfinder.PathfinderConfig;
+import shortestpath.pathfinder.PathfinderProfile;
 import shortestpath.pathfinder.PathfinderResult;
 import shortestpath.pathfinder.PathStep;
+import shortestpath.pathfinder.ProfilingPathfinder;
 import shortestpath.pathfinder.TestPathfinderConfig;
 import shortestpath.transport.Transport;
 
@@ -35,24 +36,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ReachabilityDashboardTest {
-    // Overrides the input dataset path. Resource paths start with `/`; other values are filesystem paths.
     private static final String DATASET_PROPERTY = "reachability.dataset";
-    // Overrides the bundle directory name written under `build/reports/pathfinder-dashboard/bundles/`.
-    private static final String BUNDLE_ID_PROPERTY = "reachability.bundleId";
-    // Overrides the human-readable title shown for this dashboard bundle in the UI.
     private static final String REPORT_TITLE_PROPERTY = "reachability.reportTitle";
-    // Overrides the shorter descriptive subtitle shown for this dashboard bundle in the UI.
     private static final String REPORT_SUBTITLE_PROPERTY = "reachability.reportSubtitle";
-    private static final String DEFAULT_DATASET = "/reachability/clue_locations_full.csv";
+    private static final String DEFAULT_DATASET = "/reachability/routes.csv";
     // A very large number of targets will take a long time to run, and sometimes during testing you
     // want to just test rendering etc on fewer targets.
     private static final int MAX_TARGETS = Integer.getInteger("reachability.maxTargets", 10000);
-    // Selects a predefined reachability scenario, which controls the start point and pathfinder setup.
     private static final String SCENARIO_PROPERTY = "reachability.scenario";
+    private static final String PROFILE_PROPERTY = "reachability.profile";
+    private static final String BUNDLE_NAME_PROPERTY = DashboardBundlePublisher.BUNDLE_NAME_PROPERTY;
     private static final ReachabilityScenario DEFAULT_SCENARIO = ReachabilityScenario.DEFAULT;
 
     private final ReachabilityTargetLoader targetLoader = new ReachabilityTargetLoader();
-    private final PathfinderDashboardReportWriter reportWriter = new PathfinderDashboardReportWriter();
+    private final ProfilerReportWriter reportWriter = new ProfilerReportWriter();
     private final DashboardBundlePublisher bundlePublisher = new DashboardBundlePublisher();
 
     private Client client;
@@ -66,11 +63,8 @@ public class ReachabilityDashboardTest {
         config = new TestShortestPathConfig();
         when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
         when(client.getClientThread()).thenReturn(Thread.currentThread());
-        // A maxed account
         when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
         when(client.getTotalLevel()).thenReturn(2277);
-        // With access to fairy rings (this should not be necessary but fairy ring support is globally disabled if
-        // these are not set).
         when(client.getVarbitValue(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE)).thenReturn(1);
         when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
         scenario = ReachabilityScenario.fromSystemProperty(System.getProperty(SCENARIO_PROPERTY));
@@ -84,42 +78,62 @@ public class ReachabilityDashboardTest {
         pathfinderConfig.refresh();
     }
 
-    // Check for each target in the dataset, can we reach it?
     @Test
     public void allTargetsReachableFromBankStart() throws IOException {
         Assume.assumeTrue("Enable with -DrunReachabilityVerification=true",
             Boolean.getBoolean("runReachabilityVerification"));
 
         String dataset = System.getProperty(DATASET_PROPERTY, DEFAULT_DATASET);
+        boolean profile = Boolean.parseBoolean(System.getProperty(PROFILE_PROPERTY, "true"));
+        String bundleName = System.getProperty(BUNDLE_NAME_PROPERTY, "routes");
         List<ReachabilityTarget> allTargets = loadTargets(dataset);
         List<ReachabilityTarget> targets = allTargets.subList(0, Math.min(MAX_TARGETS, allTargets.size()));
         List<PathfinderDashboardModels.RunRecord> runs = new ArrayList<>();
         Map<String, String> routeSummary = new LinkedHashMap<>();
         long started = System.currentTimeMillis();
         Path siteRoot = bundlePublisher.getOutputRoot();
-        String bundleId = System.getProperty(BUNDLE_ID_PROPERTY, scenario.bundleId);
         String reportTitle = System.getProperty(REPORT_TITLE_PROPERTY, scenario.reportTitle);
         String reportSubtitle = System.getProperty(REPORT_SUBTITLE_PROPERTY, scenario.reportSubtitle);
-        Path outputDirectory = siteRoot.resolve("bundles").resolve(bundleId);
-        Path reportPath = outputDirectory.resolve("report.json");
+        Path reportPath = siteRoot.resolve("bundles").resolve(bundleName).resolve("report.json");
 
-        // Reachability is a batch producer: it computes all run records first, then publishes one complete bundle
-        // at the end of the sweep rather than incrementally rewriting the bundle after each target.
+        TeleportationItem currentTeleports = scenario.teleportationItemSetting;
+        int targetIndex = 0;
+
         for (ReachabilityTarget target : targets) {
-            Pathfinder pathfinder = new Pathfinder(
-                pathfinderConfig,
-                scenario.start,
-                Set.of(target.getPackedPoint()),
-                null);
-            pathfinder.run();
-            PathfinderResult result = pathfinder.getResult();
+            targetIndex++;
+            System.out.printf("[%d/%d] %s%n", targetIndex, targets.size(), target.getDescription());
+            System.out.flush();
+            // Reconfigure pathfinder if this target overrides teleport settings
+            if (target.hasTeleportOverride() && target.getTeleportOverride() != currentTeleports) {
+                currentTeleports = target.getTeleportOverride();
+                config.setUseTeleportationItemsValue(currentTeleports);
+                pathfinderConfig = new TestPathfinderConfig(client, config);
+                scenario.configurePathfinder(pathfinderConfig);
+                pathfinderConfig.refresh();
+            }
+
+            int start = target.hasStartPoint() ? target.getStartPoint() : scenario.start;
+            String category = target.getCategory() != null ? target.getCategory() : "reachability";
+
+            PathfinderResult result;
+            PathfinderProfile profileData = null;
+            if (profile) {
+                ProfilingPathfinder profiler = new ProfilingPathfinder(
+                    pathfinderConfig, start, Set.of(target.getPackedPoint()));
+                profiler.run();
+                result = profiler.getResult();
+                profileData = profiler.getProfile();
+            } else {
+                Pathfinder pathfinder = new Pathfinder(
+                    pathfinderConfig, start, Set.of(target.getPackedPoint()));
+                pathfinder.run();
+                result = pathfinder.getResult();
+            }
             List<PathStep> path = result != null ? result.getPathSteps() : List.of();
             int pathLength = path.size();
             double elapsedMillis = result != null ? (result.getElapsedNanos() / 1_000_000.0) : 0.0;
             int nodesChecked = result != null ? result.getNodesChecked() : 0;
             int transportsChecked = result != null ? result.getTransportsChecked() : 0;
-            // TODO: We should really have this logic in the main pathfinder to help with routing to adjacent but
-            // blocked tiles.
             boolean reached = isReachedOrAdjacent(result, target);
 
             routeSummary.put(
@@ -137,39 +151,42 @@ public class ReachabilityDashboardTest {
 
             if (result != null) {
                 List<String> details = List.of(
-                    "Dataset: " + dataset,
+                    "Dataset: " + datasetLabel(dataset),
                     "Description: " + target.getDescription(),
                     "Expected reachable: true");
-                runs.add(reportWriter.createRunRecord(
+                PathfinderDashboardModels.RunRecord run = reportWriter.createRunRecord(
                     target.getDescription(),
-                    "reachability",
+                    category,
                     details,
                     result,
                     pathfinderConfig,
                     reached,
                     null,
-                    null));
+                    null);
+                if (profileData != null) {
+                    reportWriter.populateProfilerData(run, profileData);
+                }
+                bundlePublisher.externalizeRunHeatmap(bundleName, runs.size(), run);
+                runs.add(run);
             }
         }
 
-        Files.createDirectories(outputDirectory);
-        // Publishing updates both `bundles/<bundleId>/report.json` and the shared `bundles/index.json` registry,
-        // which is what makes this report show up in the common dashboard frontend.
-        bundlePublisher.publishBundle(
-            bundleId,
+        PathfinderDashboardModels.Report report = reportWriter.createReport(
             reportTitle,
             reportSubtitle,
-            reportWriter.createReport(
-                "Pathfinder Dashboard",
-                reportSubtitle,
-                System.currentTimeMillis() - started,
-                runs,
-                reportWriter.createTransportLayerPoints(pathfinderConfig)));
+            System.currentTimeMillis() - started,
+            runs,
+            reportWriter.createTransportLayerPoints(pathfinderConfig));
+
+        bundlePublisher.publishBundle(bundleName, report);
 
         System.out.println("Reachability route summary:");
         System.out.println(" - scenario: " + scenario.id);
         System.out.println(" - tested targets: " + targets.size() + "/" + allTargets.size());
         System.out.println(" - dataset: " + dataset);
+        for (Map.Entry<String, String> entry : routeSummary.entrySet()) {
+            System.out.println(" - " + entry.getKey() + ": " + entry.getValue());
+        }
 
         long unreachable = runs.stream().filter(run -> !run.reached).count();
         assertTrue("Unreachable targets found. See " + reportPath + " and " + siteRoot.resolve("index.html"),
@@ -180,10 +197,17 @@ public class ReachabilityDashboardTest {
         if (dataset.startsWith("/")) {
             return targetLoader.loadFromResource(dataset);
         }
-        return targetLoader.loadFromFile(Paths.get(dataset));
+        return targetLoader.loadFromCsv(Paths.get(dataset));
     }
 
-    // This accounts for when the target tile is adjacent to a walkable tile (for instance, a searchable crate).
+    private static String datasetLabel(String dataset) {
+        if (dataset.startsWith("/")) {
+            return dataset;
+        }
+        Path path = Paths.get(dataset);
+        return path.getFileName() != null ? path.getFileName().toString() : dataset;
+    }
+
     static boolean isReachedOrAdjacent(PathfinderResult result, ReachabilityTarget target) {
         if (result == null || result.getPathSteps().isEmpty()) {
             return false;
@@ -232,6 +256,24 @@ public class ReachabilityDashboardTest {
         return null;
     }
 
+    private Transport findTransport(shortestpath.pathfinder.Node source, int sourceTile, int destination, boolean bankVisited) {
+        if (source != null && source.isTile()) {
+            for (Transport transport : pathfinderConfig.getTransportsPacked(bankVisited).getOrDefault(sourceTile, Set.of())) {
+                if (transport.getDestination() == destination) {
+                    return transport;
+                }
+            }
+            return null;
+        }
+
+        for (Transport transport : pathfinderConfig.getUsableTeleports(bankVisited)) {
+            if (transport.getDestination() == destination) {
+                return transport;
+            }
+        }
+        return null;
+    }
+
     private String describeTransport(Transport transport) {
         String displayInfo = transport.getDisplayInfo();
         if (displayInfo != null && !displayInfo.isBlank()) {
@@ -252,33 +294,35 @@ public class ReachabilityDashboardTest {
             WorldPointUtil.unpackWorldY(packedPoint),
             WorldPointUtil.unpackWorldPlane(packedPoint));
     }
-    
-    // Default scenario, a maxed account with all teleports able to be used instantly. Useful for a global reachability check.
     private enum ReachabilityScenario {
         DEFAULT(
             "default",
             WorldPointUtil.packWorldPoint(3185, 3436, 0),
             TeleportationItem.ALL,
             false,
-            "clue-steps-default",
             "Clue Steps Default",
-            "Clue steps sweep from bank start");
+            "Clue steps sweep from bank start"),
+        PROFILER(
+            "profiler",
+            WorldPointUtil.packWorldPoint(3222, 3218, 0),
+            TeleportationItem.ALL,
+            false,
+            "Profiler",
+            "Performance profiling scenarios");
 
         private final String id;
         private final int start;
         private final TeleportationItem teleportationItemSetting;
         private final boolean includeBankPath;
-        private final String bundleId;
         private final String reportTitle;
         private final String reportSubtitle;
 
         ReachabilityScenario(String id, int start, TeleportationItem teleportationItemSetting,
-            boolean includeBankPath, String bundleId, String reportTitle, String reportSubtitle) {
+            boolean includeBankPath, String reportTitle, String reportSubtitle) {
             this.id = id;
             this.start = start;
             this.teleportationItemSetting = teleportationItemSetting;
             this.includeBankPath = includeBankPath;
-            this.bundleId = bundleId;
             this.reportTitle = reportTitle;
             this.reportSubtitle = reportSubtitle;
         }

--- a/src/test/java/shortestpath/reachability/ReachabilityDashboardTest.java
+++ b/src/test/java/shortestpath/reachability/ReachabilityDashboardTest.java
@@ -256,24 +256,6 @@ public class ReachabilityDashboardTest {
         return null;
     }
 
-    private Transport findTransport(shortestpath.pathfinder.Node source, int sourceTile, int destination, boolean bankVisited) {
-        if (source != null && source.isTile()) {
-            for (Transport transport : pathfinderConfig.getTransportsPacked(bankVisited).getOrDefault(sourceTile, Set.of())) {
-                if (transport.getDestination() == destination) {
-                    return transport;
-                }
-            }
-            return null;
-        }
-
-        for (Transport transport : pathfinderConfig.getUsableTeleports(bankVisited)) {
-            if (transport.getDestination() == destination) {
-                return transport;
-            }
-        }
-        return null;
-    }
-
     private String describeTransport(Transport transport) {
         String displayInfo = transport.getDisplayInfo();
         if (displayInfo != null && !displayInfo.isBlank()) {

--- a/src/test/java/shortestpath/reachability/ReachabilityTarget.java
+++ b/src/test/java/shortestpath/reachability/ReachabilityTarget.java
@@ -1,12 +1,25 @@
 package shortestpath.reachability;
 
+import shortestpath.TeleportationItem;
+import shortestpath.WorldPointUtil;
+
 class ReachabilityTarget {
     private final String description;
     private final int packedPoint;
+    private final String category;
+    private final int startPoint;
+    private final TeleportationItem teleportOverride;
 
     ReachabilityTarget(String description, int packedPoint) {
+        this(description, packedPoint, null, WorldPointUtil.UNDEFINED, null);
+    }
+
+    ReachabilityTarget(String description, int packedPoint, String category, int startPoint, TeleportationItem teleportOverride) {
         this.description = description;
         this.packedPoint = packedPoint;
+        this.category = category;
+        this.startPoint = startPoint;
+        this.teleportOverride = teleportOverride;
     }
 
     String getDescription() {
@@ -15,5 +28,25 @@ class ReachabilityTarget {
 
     int getPackedPoint() {
         return packedPoint;
+    }
+
+    String getCategory() {
+        return category;
+    }
+
+    int getStartPoint() {
+        return startPoint;
+    }
+
+    boolean hasStartPoint() {
+        return startPoint != WorldPointUtil.UNDEFINED;
+    }
+
+    TeleportationItem getTeleportOverride() {
+        return teleportOverride;
+    }
+
+    boolean hasTeleportOverride() {
+        return teleportOverride != null;
     }
 }

--- a/src/test/java/shortestpath/reachability/ReachabilityTargetLoader.java
+++ b/src/test/java/shortestpath/reachability/ReachabilityTargetLoader.java
@@ -1,9 +1,7 @@
 package shortestpath.reachability;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
@@ -11,9 +9,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
+import java.util.Scanner;
+import shortestpath.TeleportationItem;
+import shortestpath.Util;
 import shortestpath.WorldPointUtil;
 
 class ReachabilityTargetLoader {
@@ -22,39 +20,61 @@ class ReachabilityTargetLoader {
             if (in == null) {
                 throw new IOException("Missing resource: " + resourcePath);
             }
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
-                return load(reader, resourcePath);
+
+            String contents = new String(Util.readAllBytes(in), StandardCharsets.UTF_8);
+            Scanner scanner = new Scanner(contents);
+
+            if (!scanner.hasNextLine()) {
+                scanner.close();
+                return new ArrayList<>();
             }
+
+            String header = scanner.nextLine();
+            List<ReachabilityTarget> targets;
+            if (header.contains("start_x") && header.contains("teleports")) {
+                targets = parseRouteCsv(scanner, header, resourcePath);
+            } else if (header.contains("clue_type") && header.contains("x") && header.contains("y") && header.contains("plane")) {
+                targets = parseCsv(scanner, header, resourcePath);
+            } else {
+                targets = parseTsv(scanner, header, resourcePath);
+            }
+
+            scanner.close();
+            return targets;
         }
     }
 
-    List<ReachabilityTarget> loadFromFile(Path path) throws IOException {
-        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-            return load(reader, path.toString());
-        }
-    }
-
-    private List<ReachabilityTarget> load(BufferedReader reader, String source) throws IOException {
+    List<ReachabilityTarget> loadFromCsv(Path csvPath) throws IOException {
         Map<Integer, ReachabilityTarget> dedupedTargets = new LinkedHashMap<>();
-        CSVFormat format = CSVFormat.DEFAULT.builder()
-            .setHeader()
-            .setSkipHeaderRecord(true)
-            .setIgnoreEmptyLines(true)
-            .build();
+        try (Scanner scanner = new Scanner(Files.newBufferedReader(csvPath, StandardCharsets.UTF_8))) {
+            if (!scanner.hasNextLine()) {
+                return new ArrayList<>();
+            }
 
-        try (CSVParser parser = new CSVParser(reader, format)) {
-            Map<String, Integer> headers = parser.getHeaderMap();
-            requireHeaders(headers, source, "description", "x", "y", "plane");
+            String[] headers = scanner.nextLine().split(",", -1);
+            int clueTypeIndex = indexOf(headers, "clue_type");
+            int xIndex = indexOf(headers, "x");
+            int yIndex = indexOf(headers, "y");
+            int planeIndex = indexOf(headers, "plane");
+            if (clueTypeIndex < 0 || xIndex < 0 || yIndex < 0 || planeIndex < 0) {
+                throw new IOException("Invalid clue CSV header in " + csvPath);
+            }
 
-            for (CSVRecord record : parser) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.isBlank()) {
+                    continue;
+                }
+
+                String[] fields = line.split(",", 6);
                 int packedPoint = WorldPointUtil.packWorldPoint(
-                    Integer.parseInt(record.get("x")),
-                    Integer.parseInt(record.get("y")),
-                    Integer.parseInt(record.get("plane")));
+                    Integer.parseInt(fields[xIndex]),
+                    Integer.parseInt(fields[yIndex]),
+                    Integer.parseInt(fields[planeIndex]));
                 dedupedTargets.putIfAbsent(
                     packedPoint,
                     new ReachabilityTarget(
-                        formatDescription(record.get("description"), packedPoint),
+                        fields[clueTypeIndex] + " " + formatPoint(packedPoint),
                         packedPoint));
             }
         }
@@ -62,22 +82,141 @@ class ReachabilityTargetLoader {
         return new ArrayList<>(dedupedTargets.values());
     }
 
-    private static void requireHeaders(Map<String, Integer> headers, String source, String... names) throws IOException {
-        for (String name : names) {
-            if (!headers.containsKey(name)) {
-                throw new IOException("Invalid dataset header in " + source + ": missing " + name);
+    private List<ReachabilityTarget> parseCsv(Scanner scanner, String header, String source) throws IOException {
+        String[] headers = header.split(",", -1);
+        int clueTypeIndex = indexOf(headers, "clue_type");
+        int xIndex = indexOf(headers, "x");
+        int yIndex = indexOf(headers, "y");
+        int planeIndex = indexOf(headers, "plane");
+        if (clueTypeIndex < 0 || xIndex < 0 || yIndex < 0 || planeIndex < 0) {
+            throw new IOException("Invalid clue CSV header in " + source);
+        }
+
+        Map<Integer, ReachabilityTarget> dedupedTargets = new LinkedHashMap<>();
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.isBlank()) {
+                continue;
+            }
+
+            String[] fields = line.split(",", 6);
+            int packedPoint = WorldPointUtil.packWorldPoint(
+                Integer.parseInt(fields[xIndex]),
+                Integer.parseInt(fields[yIndex]),
+                Integer.parseInt(fields[planeIndex]));
+            dedupedTargets.putIfAbsent(
+                packedPoint,
+                new ReachabilityTarget(
+                    fields[clueTypeIndex] + " " + formatPoint(packedPoint),
+                    packedPoint));
+        }
+
+        return new ArrayList<>(dedupedTargets.values());
+    }
+
+    private List<ReachabilityTarget> parseRouteCsv(Scanner scanner, String header, String source) throws IOException {
+        String[] headers = header.split(",", -1);
+        int nameIndex = indexOf(headers, "name");
+        int categoryIndex = indexOf(headers, "category");
+        int startXIndex = indexOf(headers, "start_x");
+        int startYIndex = indexOf(headers, "start_y");
+        int startPlaneIndex = indexOf(headers, "start_plane");
+        int xIndex = indexOf(headers, "x");
+        int yIndex = indexOf(headers, "y");
+        int planeIndex = indexOf(headers, "plane");
+        int teleportsIndex = indexOf(headers, "teleports");
+        if (nameIndex < 0 || xIndex < 0 || yIndex < 0 || planeIndex < 0) {
+            throw new IOException("Invalid route CSV header in " + source);
+        }
+
+        List<ReachabilityTarget> targets = new ArrayList<>();
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.isBlank()) {
+                continue;
+            }
+
+            String[] fields = line.split(",", -1);
+            int packedPoint = WorldPointUtil.packWorldPoint(
+                Integer.parseInt(fields[xIndex]),
+                Integer.parseInt(fields[yIndex]),
+                Integer.parseInt(fields[planeIndex]));
+
+            int startPoint = WorldPointUtil.UNDEFINED;
+            if (startXIndex >= 0 && startYIndex >= 0 && startPlaneIndex >= 0
+                && !fields[startXIndex].isEmpty()) {
+                startPoint = WorldPointUtil.packWorldPoint(
+                    Integer.parseInt(fields[startXIndex]),
+                    Integer.parseInt(fields[startYIndex]),
+                    Integer.parseInt(fields[startPlaneIndex]));
+            }
+
+            String category = categoryIndex >= 0 ? fields[categoryIndex] : null;
+
+            TeleportationItem teleportOverride = null;
+            if (teleportsIndex >= 0 && !fields[teleportsIndex].isEmpty()) {
+                teleportOverride = TeleportationItem.valueOf(fields[teleportsIndex]);
+            }
+
+            targets.add(new ReachabilityTarget(
+                fields[nameIndex], packedPoint, category, startPoint, teleportOverride));
+        }
+
+        return targets;
+    }
+
+    private List<ReachabilityTarget> parseTsv(Scanner scanner, String header, String source) throws IOException {
+        List<ReachabilityTarget> targets = new ArrayList<>();
+        String[] headers = normalizeHeader(header).split("\t");
+        int descriptionIndex = indexOf(headers, "Description");
+        int xIndex = indexOf(headers, "X");
+        int yIndex = indexOf(headers, "Y");
+        int planeIndex = indexOf(headers, "Plane");
+        if (descriptionIndex < 0 || xIndex < 0 || yIndex < 0 || planeIndex < 0) {
+            throw new IOException("Invalid target TSV header in " + source);
+        }
+
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.isBlank() || line.startsWith("#")) {
+                continue;
+            }
+
+            String[] fields = line.split("\t", -1);
+            targets.add(new ReachabilityTarget(
+                fields[descriptionIndex],
+                WorldPointUtil.packWorldPoint(
+                    Integer.parseInt(fields[xIndex]),
+                    Integer.parseInt(fields[yIndex]),
+                    Integer.parseInt(fields[planeIndex]))));
+        }
+
+        return targets;
+    }
+
+    private static String normalizeHeader(String header) {
+        if (header.startsWith("# ")) {
+            return header.substring(2);
+        }
+        if (header.startsWith("#")) {
+            return header.substring(1);
+        }
+        return header;
+    }
+
+    private static int indexOf(String[] headers, String name) {
+        for (int i = 0; i < headers.length; i++) {
+            if (name.equals(headers[i])) {
+                return i;
             }
         }
+        return -1;
     }
-    
+
     private static String formatPoint(int packedPoint) {
         return String.format("(%d,%d,%d)",
             WorldPointUtil.unpackWorldX(packedPoint),
             WorldPointUtil.unpackWorldY(packedPoint),
             WorldPointUtil.unpackWorldPlane(packedPoint));
-    }
-
-    private static String formatDescription(String description, int packedPoint) {
-        return description + " " + formatPoint(packedPoint);
     }
 }

--- a/src/test/resources/reachability-dashboard/app.js
+++ b/src/test/resources/reachability-dashboard/app.js
@@ -1,18 +1,48 @@
-// URL configuration and stable DOM references used across the dashboard.
-const params = new URLSearchParams(window.location.search);
-const reportUrl = params.get("report");
-const bundleIdFromQuery = params.get("bundle");
-const bundleIndexUrl = "bundles/index.json";
+// ── Configuration constants ───────────────────────────────────────────
 const tileBaseUrl = "https://maps.runescape.wiki/osrs/versions/2026-03-04_a/tiles/rendered";
 const MAP_ID = -1;
 const MIN_ZOOM = -4;
 const MIN_NATIVE_ZOOM = -2;
 const MAX_ZOOM = 4;
 const MAX_NATIVE_ZOOM = 3;
+
+const TRANSPORT_PALETTE = {
+  entry:    { INVENTORY_VALID: "#2d6a4f", BANK_VALID: "#93c5a2", INVALID: "#6b7280" },
+  exit:     { INVENTORY_VALID: "#d1495b", BANK_VALID: "#f2a6af", INVALID: "#6b7280" },
+  teleport: { INVENTORY_VALID: "#7c3aed", BANK_VALID: "#c4b5fd", INVALID: "#6b7280" }
+};
+
+const MARKER_COLORS = {
+  start: "#1d4ed8",
+  target: "#2d6a4f",
+  closest: "#d97706",
+  bank: "#f59e0b"
+};
+const MARKER_COLOR_DEFAULT = "#475569";
+
+const HIGHLIGHT_STYLE = {
+  radius: 8,
+  color: "#f59e0b",
+  fillColor: "#fde68a",
+  fillOpacity: 0.9,
+  weight: 3
+};
+
+const HOVERED_TILE_STYLE = {
+  color: "#fde047",
+  weight: 1.5,
+  fillColor: "#fde047",
+  fillOpacity: 0.1,
+  interactive: false
+};
+
+// ── DOM references ────────────────────────────────────────────────────
 const summaryEl = document.getElementById("summary");
-const bundleSelectEl = document.getElementById("bundle-select");
 const runListEl = document.getElementById("run-list");
 const runDetailsEl = document.getElementById("run-details");
+const runInfoDetailsEl = document.getElementById("run-info-details");
+const runInfoPanel = document.getElementById("run-info-panel");
+const runInfoToggle = document.getElementById("run-info-toggle");
 const runSearchEl = document.getElementById("run-search");
 const unreachedOnlyEl = document.getElementById("unreached-only");
 const centerTargetEl = document.getElementById("center-target");
@@ -20,21 +50,25 @@ const prevRunEl = document.getElementById("prev-run");
 const nextRunEl = document.getElementById("next-run");
 const mapCoordinatesEl = document.getElementById("map-coordinates");
 const transportInfoEl = document.getElementById("transport-info");
-const mapHelpButtonEl = document.getElementById("map-help-button");
-const mapHelpOverlayEl = document.getElementById("map-help-overlay");
-const mapHelpCloseEl = document.getElementById("map-help-close");
-const mapHelpContentEl = document.getElementById("map-help-content");
+const bundleSelectEl = document.getElementById("bundle-select");
+const sidebarEl = document.getElementById("sidebar");
+const sidebarToggle = document.getElementById("sidebar-toggle");
 
-// Mutable dashboard state shared by rendering and interaction handlers.
+// ── Mutable state ─────────────────────────────────────────────────────
+/** Base URL for the currently loaded bundle (empty string for root report.json) */
+let currentBundleBase = "";
+window.currentBundleBase = currentBundleBase;
+
 let currentPlane = 0;
-let availableBundles = [];
 let selectedRun = null;
 let allRuns = [];
 let reportTransportLayers = [];
 let selectedTransportOverlay = null;
 let hoveredTileOverlay = null;
+let markerLayers = [];
+let transportOverlayLayers = [];
 
-// Leaflet tile setup for the RuneScape Wiki raster format and simple world CRS.
+// ── Map setup ─────────────────────────────────────────────────────────
 const WikiTileLayer = L.TileLayer.extend({
   getTileUrl(coords) {
     return `${tileBaseUrl}/${MAP_ID}/${coords.z}/${currentPlane}_${coords.x}_${-(1 + coords.y)}.png`;
@@ -57,6 +91,7 @@ const map = L.map("map", {
   maxBounds: [[-1000, -1000], [13800, 13800]],
   maxBoundsViscosity: 0.5
 });
+window._dashboardMap = map;
 
 map.attributionControl.addAttribution('&copy; <a href="https://runescape.wiki/">RuneScape Wiki</a>');
 
@@ -75,32 +110,8 @@ const transportLayerState = {
   teleport: false
 };
 
-const mapHelpSections = [
-  {
-    title: "Scenario inspection",
-    items: [
-      "Click a scenario in the left-hand list to draw its route and populate the details panel.",
-      "Use Previous and Next to move through the currently filtered scenario list.",
-      "Center on target recenters the map on the selected run's target tile."
-    ]
-  },
-  {
-    title: "Map interaction",
-    items: [
-      "Move the mouse across the map to preview the hovered tile and read its coordinates.",
-      "Ctrl-click a tile to copy its world coordinate as x, y, plane.",
-      "Click an entry, exit, or teleport overlay marker to highlight that transport and inspect its metadata."
-    ]
-  },
-  {
-    title: "Transport layers",
-    items: [
-      "Use the Transport Layers control in the top-right corner to toggle entries, exits, and teleports.",
-      "Entry and exit overlays are filtered to the currently selected plane.",
-      "Transport colors distinguish inventory-valid, bank-valid, and invalid states."
-    ]
-  }
-];
+// Extension layer toggles registered by plugins (e.g. profiler heatmap)
+const extensionLayerToggles = [];
 
 const TransportLayerControl = L.Control.extend({
   options: {
@@ -109,8 +120,8 @@ const TransportLayerControl = L.Control.extend({
 
   onAdd() {
     const container = L.DomUtil.create("div", "leaflet-bar leaflet-control transport-layer-control");
-    const fieldset = L.DomUtil.create("fieldset", "", container);
-    const legend = L.DomUtil.create("legend", "", fieldset);
+    this._fieldset = L.DomUtil.create("fieldset", "", container);
+    const legend = L.DomUtil.create("legend", "", this._fieldset);
     legend.textContent = "Transport Layers";
 
     [
@@ -118,7 +129,7 @@ const TransportLayerControl = L.Control.extend({
       { key: "exit", label: "Exits" },
       { key: "teleport", label: "Teleports" }
     ].forEach(item => {
-      const label = L.DomUtil.create("label", "", fieldset);
+      const label = L.DomUtil.create("label", "", this._fieldset);
       const input = L.DomUtil.create("input", "", label);
       input.type = "checkbox";
       input.checked = transportLayerState[item.key];
@@ -131,18 +142,46 @@ const TransportLayerControl = L.Control.extend({
       });
     });
 
+    // Add any extension toggles registered before control was created
+    extensionLayerToggles.forEach(toggle => this._addToggle(toggle));
+
     L.DomEvent.disableClickPropagation(container);
     L.DomEvent.disableScrollPropagation(container);
     return container;
+  },
+
+  _addToggle(toggle) {
+    const label = L.DomUtil.create("label", "", this._fieldset);
+    const input = L.DomUtil.create("input", "", label);
+    input.type = "checkbox";
+    input.checked = toggle.checked || false;
+    const text = L.DomUtil.create("span", "", label);
+    text.textContent = toggle.label;
+    L.DomEvent.disableClickPropagation(label);
+    L.DomEvent.on(input, "change", () => {
+      toggle.onChange(input.checked);
+    });
+    toggle._input = input;
+  },
+
+  addToggle(toggle) {
+    if (this._fieldset) {
+      this._addToggle(toggle);
+    }
   }
 });
 
-map.addControl(new TransportLayerControl());
+const transportLayerControl = new TransportLayerControl();
+map.addControl(transportLayerControl);
 
-let markerLayers = [];
-let transportOverlayLayers = [];
+// Public API for extensions to add map layer toggles
+window.addMapLayerToggle = function(toggle) {
+  extensionLayerToggles.push(toggle);
+  transportLayerControl.addToggle(toggle);
+};
 
-// Coordinate helpers translate between world points and Leaflet's simple CRS.
+// ── Coordinate utilities ──────────────────────────────────────────────
+
 function worldToLatLng(point) {
   return [point.y + 0.5, point.x + 0.5];
 }
@@ -165,7 +204,6 @@ function updateMapCoordinates(point, copied = false) {
     : formatCoordinateText(point);
 }
 
-// Overlay helpers manage transient tile highlights and route markers.
 function renderHoveredTile(point) {
   if (hoveredTileOverlay) {
     map.removeLayer(hoveredTileOverlay);
@@ -174,13 +212,7 @@ function renderHoveredTile(point) {
   hoveredTileOverlay = L.rectangle([
     [point.y, point.x],
     [point.y + 1, point.x + 1]
-  ], {
-    color: "#fde047",
-    weight: 1.5,
-    fillColor: "#fde047",
-    fillOpacity: 0.1,
-    interactive: false
-  }).addTo(map);
+  ], HOVERED_TILE_STYLE).addTo(map);
 }
 
 function clearLayers() {
@@ -210,26 +242,8 @@ function addMarker(point, label, color, radius = 6) {
   markerLayers.push(marker);
 }
 
-// Transport overlay rendering turns transport metadata into clickable map affordances.
 function transportLayerColor(kind, validity) {
-  const palette = {
-    entry: {
-      INVENTORY_VALID: "#2d6a4f",
-      BANK_VALID: "#93c5a2",
-      INVALID: "#6b7280"
-    },
-    exit: {
-      INVENTORY_VALID: "#d1495b",
-      BANK_VALID: "#f2a6af",
-      INVALID: "#6b7280"
-    },
-    teleport: {
-      INVENTORY_VALID: "#7c3aed",
-      BANK_VALID: "#c4b5fd",
-      INVALID: "#6b7280"
-    }
-  };
-  return (palette[kind] && palette[kind][validity]) || "#6b7280";
+  return (TRANSPORT_PALETTE[kind] && TRANSPORT_PALETTE[kind][validity]) || "#6b7280";
 }
 
 function transportLayerStyle(validity) {
@@ -277,20 +291,12 @@ function highlightTransport(layer, clickedKind) {
   if (layer.origin) {
     overlayLayers.push(L.circleMarker(worldToLatLng(layer.origin), {
       renderer: transportRenderer,
-      radius: 8,
-      color: "#f59e0b",
-      fillColor: "#fde68a",
-      fillOpacity: 0.9,
-      weight: 3
+      ...HIGHLIGHT_STYLE
     }));
   }
   overlayLayers.push(L.circleMarker(worldToLatLng(layer.destination), {
     renderer: transportRenderer,
-    radius: 8,
-    color: "#f59e0b",
-    fillColor: "#fde68a",
-    fillOpacity: 0.9,
-    weight: 3
+    ...HIGHLIGHT_STYLE
   }));
   if (layer.origin) {
     overlayLayers.push(L.polyline([worldToLatLng(layer.origin), worldToLatLng(layer.destination)], {
@@ -356,7 +362,6 @@ function renderTransportOverlays() {
   });
 }
 
-// Run list and route rendering own the scenario-centric sidebar and path visualization.
 function statusLabel(run) {
   const route = run.reached ? "reached" : "unreached";
   if (run.assertionPassed === true) return `pass, ${route}`;
@@ -369,11 +374,7 @@ function formatPoint(point) {
 }
 
 function markerColor(kind) {
-  if (kind === "start") return "#1d4ed8";
-  if (kind === "target") return "#2d6a4f";
-  if (kind === "closest") return "#d97706";
-  if (kind === "bank") return "#f59e0b";
-  return "#475569";
+  return MARKER_COLORS[kind] || MARKER_COLOR_DEFAULT;
 }
 
 function pathSegmentColor(reached, bankVisited) {
@@ -447,6 +448,14 @@ function buildDetails(run) {
       const label = step.displayInfo || step.objectInfo || step.type;
       details.push(`- step ${step.stepIndex}: ${step.type} -> ${label}`);
     });
+  }
+
+  if (run.collisionWindow) {
+    details.push("");
+    details.push(
+      `Collision window: ${run.collisionWindow.width}x${run.collisionWindow.height}` +
+      ` @ (${run.collisionWindow.originX}, ${run.collisionWindow.originY}, ${run.collisionWindow.plane})`
+    );
   }
 
   return details.join("\n");
@@ -561,7 +570,11 @@ function renderRunList() {
   runs.forEach(run => {
     const item = document.createElement("li");
     const button = document.createElement("button");
-    button.textContent = `[${statusLabel(run)}] ${run.name}`;
+    const dot = document.createElement("span");
+    dot.className = "run-status-dot " + (run.reached ? "run-status-dot--reached" : "run-status-dot--unreached");
+    dot.title = statusLabel(run);
+    button.appendChild(dot);
+    button.appendChild(document.createTextNode(run.name));
     if (selectedRun === run) {
       button.classList.add("selected");
     }
@@ -575,6 +588,10 @@ function renderRunList() {
 
   updateRunNavigation();
 }
+
+// ── Extension hook for optional panels (e.g. profiler) ──────────────
+// Extensions register via window.dashboardExtensions.push({ renderRun: fn })
+window.dashboardExtensions = [];
 
 function renderRun(run) {
   selectedRun = run;
@@ -603,53 +620,22 @@ function renderRun(run) {
     addMarker(marker.point, marker.label, markerColor(marker.kind), radius);
   });
 
-  runDetailsEl.textContent = buildDetails(run);
+  const details = buildDetails(run);
+  runDetailsEl.textContent = details;
+  runInfoDetailsEl.textContent = details;
+  runInfoPanel.classList.remove("run-info-hidden");
   renderTransportOverlays();
+  window.dashboardExtensions.forEach(ext => ext.renderRun(run));
 }
 
-// Help overlay rendering explains the intended interactive map workflow.
-function renderMapHelp() {
-  mapHelpContentEl.innerHTML = "";
-
-  mapHelpSections.forEach(section => {
-    const heading = document.createElement("h3");
-    heading.textContent = section.title;
-    mapHelpContentEl.appendChild(heading);
-
-    const list = document.createElement("ul");
-    section.items.forEach(item => {
-      const entry = document.createElement("li");
-      entry.textContent = item;
-      list.appendChild(entry);
-    });
-    mapHelpContentEl.appendChild(list);
-  });
-}
-
-function setMapHelpVisible(visible) {
-  mapHelpOverlayEl.hidden = !visible;
-}
-
-// Data loading keeps the selected bundle, report payload, and URL state aligned.
-function updateBundleQuery(bundleId) {
-  const nextParams = new URLSearchParams(window.location.search);
-  if (bundleId) {
-    nextParams.set("bundle", bundleId);
-  } else {
-    nextParams.delete("bundle");
-  }
-  const query = nextParams.toString();
-  window.history.replaceState({}, "", `${window.location.pathname}${query ? `?${query}` : ""}`);
-}
-
-function renderReport(report, selectedBundleTitle) {
+function renderReport(report) {
   const runs = report.runs || [];
   reportTransportLayers = report.transportLayers || [];
   allRuns = runs;
   selectedRun = null;
   clearLayers();
   summaryEl.textContent =
-    `${selectedBundleTitle ? `${selectedBundleTitle}\n` : ""}` +
+    `${report.title ? `${report.title}\n` : ""}` +
     `${report.summary.successfulRuns}/${report.summary.totalRuns} reached, ` +
     `${report.summary.failedRuns} unreached` +
     (report.subtitle ? `\n${report.subtitle}` : "");
@@ -666,127 +652,97 @@ function renderReport(report, selectedBundleTitle) {
   renderRunList();
 }
 
-async function loadReport(url, selectedBundleTitle) {
+async function loadReport(url) {
+  currentBundleBase = url.substring(0, url.lastIndexOf("/") + 1);
+  window.currentBundleBase = currentBundleBase;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Failed to load ${url}`);
   }
   const report = await response.json();
-  renderReport(report, selectedBundleTitle);
+  renderReport(report);
 }
 
-async function loadBundle(bundle) {
-  if (bundleSelectEl) {
-    bundleSelectEl.value = bundle.id;
+async function initDashboard() {
+  const indexResp = await fetch("bundles/index.json");
+  if (!indexResp.ok) {
+    throw new Error("No bundles/index.json found. Run a dashboard task first.");
   }
-  updateBundleQuery(bundle.id);
-  await loadReport(bundle.reportPath, bundle.title);
-}
-
-async function loadBundleIndex() {
-  if (reportUrl) {
-    if (bundleSelectEl) {
-      bundleSelectEl.disabled = true;
-    }
-    await loadReport(reportUrl, null);
-    return;
+  const index = await indexResp.json();
+  if (!index.bundles || index.bundles.length === 0) {
+    throw new Error("No bundles registered in index.json.");
   }
 
-  const response = await fetch(bundleIndexUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to load ${bundleIndexUrl}`);
-  }
-  const index = await response.json();
-  const bundles = index.bundles || [];
-  availableBundles = bundles;
-  if (!bundleSelectEl) {
-    throw new Error("Bundle selector element is missing");
-  }
+  // Populate bundle selector
   bundleSelectEl.innerHTML = "";
-
-  if (bundles.length === 0) {
-    throw new Error("No report bundles found");
+  for (const bundle of index.bundles) {
+    const opt = document.createElement("option");
+    opt.value = bundle.reportPath;
+    opt.textContent = bundle.title || bundle.name;
+    bundleSelectEl.appendChild(opt);
   }
-
-  bundles.forEach(bundle => {
-    const option = document.createElement("option");
-    option.value = bundle.id;
-    option.textContent = bundle.title || bundle.id;
-    bundleSelectEl.appendChild(option);
+  if (index.bundles.length > 1) {
+    bundleSelectEl.hidden = false;
+  }
+  bundleSelectEl.addEventListener("change", () => {
+    loadReport("bundles/" + bundleSelectEl.value).catch(error => {
+      summaryEl.textContent = error.message;
+    });
   });
-  bundleSelectEl.disabled = false;
 
-  const selectedBundle = bundles.find(bundle => bundle.id === bundleIdFromQuery) || bundles[0];
-  await loadBundle(selectedBundle);
+  // Check URL for ?bundle= parameter
+  const params = new URLSearchParams(window.location.search);
+  const requested = params.get("bundle");
+  const initial = requested
+    ? index.bundles.find(b => b.name === requested)
+    : index.bundles[0];
+  if (initial) {
+    bundleSelectEl.value = initial.reportPath;
+    await loadReport("bundles/" + initial.reportPath);
+  } else {
+    bundleSelectEl.value = index.bundles[0].reportPath;
+    await loadReport("bundles/" + index.bundles[0].reportPath);
+  }
 }
 
-loadBundleIndex().catch(error => {
+initDashboard().catch(error => {
   summaryEl.textContent = error.message;
   runDetailsEl.textContent = "Unable to render dashboard.";
 });
 
-renderMapHelp();
+// ── Event listeners ───────────────────────────────────────────────────
 
-if (bundleSelectEl) {
-  bundleSelectEl.addEventListener("change", async () => {
-    try {
-      const bundle = availableBundles.find(entry => entry.id === bundleSelectEl.value);
-      if (!bundle) {
-        throw new Error(`Unknown bundle: ${bundleSelectEl.value}`);
-      }
-      await loadBundle(bundle);
-    } catch (error) {
-      summaryEl.textContent = error.message;
-    }
-  });
+// Run info panel toggle (right side of map)
+runInfoToggle.addEventListener("click", () => {
+  const collapsed = runInfoPanel.classList.toggle("collapsed");
+  runInfoToggle.innerHTML = (collapsed ? "&#9656;" : "&#9666;") + " Scenario";
+});
+
+// Sidebar toggle
+sidebarToggle.addEventListener("click", () => {
+  const collapsed = sidebarEl.classList.toggle("collapsed");
+  sidebarToggle.querySelector("span").innerHTML = collapsed ? "&#9654;" : "&#9664;";
+  setTimeout(() => map.invalidateSize(), 250);
+});
+
+function onFilterChange() {
+  const runs = filteredRuns();
+  renderRunList();
+  if (runs.length === 0) {
+    selectedRun = null;
+    runDetailsEl.textContent = "No matching scenarios.";
+    clearLayers();
+    return;
+  }
+
+  if (!selectedRun || !runs.includes(selectedRun)) {
+    renderRun(runs[0]);
+    renderRunList();
+  }
 }
 
-mapHelpButtonEl.addEventListener("click", () => {
-  setMapHelpVisible(true);
-});
-
-mapHelpCloseEl.addEventListener("click", () => {
-  setMapHelpVisible(false);
-});
-
-mapHelpOverlayEl.addEventListener("click", event => {
-  if (event.target === mapHelpOverlayEl) {
-    setMapHelpVisible(false);
-  }
-});
-
-// Event wiring below keeps filters, navigation, and map gestures in sync.
-runSearchEl.addEventListener("input", () => {
-  const runs = filteredRuns();
-  renderRunList();
-  if (runs.length === 0) {
-    selectedRun = null;
-    runDetailsEl.textContent = "No matching scenarios.";
-    clearLayers();
-    return;
-  }
-
-  if (!selectedRun || !runs.includes(selectedRun)) {
-    renderRun(runs[0]);
-    renderRunList();
-  }
-});
-
-unreachedOnlyEl.addEventListener("change", () => {
-  const runs = filteredRuns();
-  renderRunList();
-  if (runs.length === 0) {
-    selectedRun = null;
-    runDetailsEl.textContent = "No matching scenarios.";
-    clearLayers();
-    return;
-  }
-
-  if (!selectedRun || !runs.includes(selectedRun)) {
-    renderRun(runs[0]);
-    renderRunList();
-  }
-});
+runSearchEl.addEventListener("input", onFilterChange);
+unreachedOnlyEl.addEventListener("change", onFilterChange);
 
 centerTargetEl.addEventListener("click", () => {
   if (!selectedRun) {
@@ -842,11 +798,5 @@ map.on("click", async event => {
   updateMapCoordinates(point, copied);
   if (copied) {
     console.log(`Copied coordinate: ${formatCoordinateText(point)}`);
-  }
-});
-
-document.addEventListener("keydown", event => {
-  if (event.key === "Escape" && !mapHelpOverlayEl.hidden) {
-    setMapHelpVisible(false);
   }
 });

--- a/src/test/resources/reachability-dashboard/index.html
+++ b/src/test/resources/reachability-dashboard/index.html
@@ -9,48 +9,52 @@
 </head>
 <body>
   <main class="layout">
-    <section class="sidebar">
-      <h1>Pathfinder Dashboard</h1>
-      <p id="summary">Loading report...</p>
-      <label class="search">
-        <span>Report bundle</span>
-        <select id="bundle-select">
-          <option>Loading bundles...</option>
-        </select>
-      </label>
-      <label class="search">
-        <span>Search scenarios</span>
-        <input id="run-search" type="search" placeholder="e.g. conch bank grapple">
-      </label>
-      <label class="toggle">
-        <input id="unreached-only" type="checkbox">
-        <span>Show unreached only</span>
-      </label>
-      <div class="nav-buttons">
-        <button id="prev-run" type="button">Previous</button>
-        <button id="next-run" type="button">Next</button>
+    <section class="sidebar" id="sidebar">
+      <div class="sidebar-content">
+        <h1>Pathfinder Dashboard</h1>
+        <p id="summary">Loading report...</p>
+        <select id="bundle-select" class="bundle-select" hidden></select>
+        <label class="search">
+          <span>Search scenarios</span>
+          <input id="run-search" type="search" placeholder="e.g. conch bank grapple">
+        </label>
+        <label class="toggle">
+          <input id="unreached-only" type="checkbox">
+          <span>Show unreached only</span>
+        </label>
+        <div class="nav-buttons">
+          <button id="prev-run" type="button">Previous</button>
+          <button id="next-run" type="button">Next</button>
+        </div>
+        <pre id="run-details" hidden>Select a run to inspect its route.</pre>
+        <ol id="run-list"></ol>
       </div>
-      <pre id="run-details">Select a run to inspect its route.</pre>
-      <button id="center-target" type="button">Center on target</button>
-      <ol id="run-list"></ol>
+      <button class="sidebar-handle" id="sidebar-toggle" type="button"><span>&#9664;</span></button>
     </section>
     <section class="map-panel">
       <div id="map"></div>
-      <button id="map-help-button" class="map-help-button" type="button" aria-label="Open map help">?</button>
-      <div id="map-help-overlay" class="map-help-overlay" hidden>
-        <div class="map-help-dialog" role="dialog" aria-modal="true" aria-labelledby="map-help-title">
-          <div class="map-help-header">
-            <h2 id="map-help-title">Map controls</h2>
-            <button id="map-help-close" class="map-help-close" type="button" aria-label="Close map help">Close</button>
-          </div>
-          <div id="map-help-content"></div>
+      <div class="run-info-panel run-info-hidden" id="run-info-panel">
+        <button class="run-info-toggle" id="run-info-toggle" type="button">&#9666; Scenario</button>
+        <div class="run-info-body" id="run-info-body">
+          <pre id="run-info-details"></pre>
+          <button id="center-target" type="button">Center on target</button>
         </div>
       </div>
       <div id="transport-info" hidden>Select a transport point to inspect it.</div>
       <div id="map-coordinates">-, -, -</div>
     </section>
   </main>
+  <div class="profiler-drawer collapsed" id="profiler-drawer" hidden>
+    <button class="profiler-drawer-handle" id="profiler-drawer-toggle" type="button">&#9650; Profiler</button>
+    <div class="profiler-drawer-body" id="profiler-panels">
+      <div class="profiler-panel profiler-panel-merged"><div class="profiler-col"><h2>Overview</h2><pre id="run-overview"></pre></div><div class="profiler-col"><h2>Counters</h2><pre id="counters-view"></pre></div></div>
+      <div class="profiler-panel"><h2>Time Series</h2><canvas id="timeseries-chart"></canvas></div>
+      <div class="profiler-panel"><h2>Phase Breakdown</h2><div id="phase-chart" class="bar-chart-container"></div></div>
+      <div class="profiler-panel"><h2>Sub-Phase Breakdown</h2><p class="subphase-explainer">Breakdown of the "Add neighbors" phase — where time is spent expanding tile and transport neighbors each iteration.</p><div id="subphase-chart" class="bar-chart-container"></div></div>
+    </div>
+  </div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
   <script src="app.js"></script>
+  <script src="profiler.js"></script>
 </body>
 </html>

--- a/src/test/resources/reachability-dashboard/profiler.js
+++ b/src/test/resources/reachability-dashboard/profiler.js
@@ -1,0 +1,660 @@
+/* Profiler extension for the Pathfinder Dashboard.
+ * Renders phase breakdowns, time series, and counters in a collapsible
+ * bottom drawer overlaying the map.  Adds a tile-level heatmap as a
+ * single canvas image overlay on the main map.
+ * Registers itself via window.dashboardExtensions. */
+(function () {
+  "use strict";
+
+  const drawerEl = document.getElementById("profiler-drawer");
+  const toggleBtn = document.getElementById("profiler-drawer-toggle");
+  const runOverviewEl = document.getElementById("run-overview");
+  const countersEl = document.getElementById("counters-view");
+  const phaseChartEl = document.getElementById("phase-chart");
+  const subphaseChartEl = document.getElementById("subphase-chart");
+  const timeseriesCanvas = document.getElementById("timeseries-chart");
+
+  if (!drawerEl) return;
+
+  // ── Drawer toggle ───────────────────────────────────────────────────
+
+  let pendingTimeSeries = null;
+
+  toggleBtn.addEventListener("click", () => {
+    const collapsed = drawerEl.classList.toggle("collapsed");
+    toggleBtn.innerHTML = (collapsed ? "&#9650;" : "&#9660;") + " Profiler";
+    if (!collapsed && pendingTimeSeries) {
+      requestAnimationFrame(() => drawTimeSeries(timeseriesCanvas, pendingTimeSeries));
+    }
+  });
+
+  // ── Color palettes ──────────────────────────────────────────────────
+
+  const PHASE_COLORS = ["#4682b4", "#e8a838", "#6aaa64", "#c9534b", "#8b5cf6", "#f59e0b", "#999"];
+  const SUBPHASE_COLORS = ["#4682b4", "#e8a838", "#6aaa64", "#c9534b", "#8b5cf6", "#f59e0b"];
+  const TIMESERIES_COLORS = { boundary: "#4682b4", pending: "#e8a838" };
+
+  const CHUNK_SIZE = 64;
+  const HEATMAP_MAX = 55;   // count >= HEATMAP_MAX → magenta; observed max in data
+  const HEAT_LOW = 0.20;    // count=1 (t≈0.17) sits just below, count=2 jumps into warm
+  const HEAT_MID = 0.45;    // count≈5 is warm, count≈24 is hot orange
+
+  // ── Phase descriptions ──────────────────────────────────────────────
+
+  const PHASE_DESCRIPTIONS = {
+    "Add neighbors": "Expanding tile and transport neighbors into the search frontier — the core work of each iteration.",
+    "Queue selection": "Picking the next lowest-cost node from boundary or pending priority queues.",
+    "Target check": "Testing whether the current node is the destination, and updating the best-known path when unreachable.",
+    "Wilderness check": "Evaluating wilderness level constraints when the search crosses wilderness boundaries.",
+    "Cutoff check": "Checking System.currentTimeMillis() each iteration to enforce the calculation timeout.",
+    "Bookkeeping": "Peak queue size tracking, iteration counting, and periodic time-series sampling.",
+    "Loop overhead": "Residual JVM overhead: loop control, System.nanoTime() timing calls, and JIT compilation artifacts."
+  };
+
+  const SUBPHASE_DESCRIPTIONS = {
+    "Bank check": "Checking whether the current tile is a bank location to enable bank-requiring transports.",
+    "Transport lookup": "Looking up available transports at the current tile and adding unvisited destinations.",
+    "Collision check": "Reading the collision map to determine which cardinal and diagonal moves are walkable.",
+    "Walkable tile": "Iterating traversable directions and creating neighbor nodes for walkable tiles.",
+    "Blocked transport": "Fallback for blocked adjacent tiles — checking if a transport origin can bypass the obstacle.",
+    "Abstract node": "Expanding abstract (teleport) nodes that provide global connectivity at each wilderness level."
+  };
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  function msFromNanos(nanos) {
+    return (nanos / 1_000_000).toFixed(2);
+  }
+
+  function pct(nanos, total) {
+    if (total === 0) return "0.0";
+    return ((nanos / total) * 100).toFixed(1);
+  }
+
+  function formatK(n) {
+    return n >= 1000 ? (n / 1000).toFixed(1) + "K" : String(n);
+  }
+
+  // ── Shared floating tooltip ──────────────────────────────────────
+
+  const floatingTip = document.createElement("div");
+  floatingTip.className = "floating-tip";
+  document.body.appendChild(floatingTip);
+
+  function showFloatingTip(e, text) {
+    floatingTip.textContent = text;
+    floatingTip.style.display = "block";
+    const x = e.clientX + 12;
+    const y = e.clientY + 12;
+    const fw = floatingTip.offsetWidth;
+    const fh = floatingTip.offsetHeight;
+    floatingTip.style.left = (x + fw > window.innerWidth ? e.clientX - fw - 8 : x) + "px";
+    floatingTip.style.top = (y + fh > window.innerHeight ? e.clientY - fh - 8 : y) + "px";
+  }
+
+  function hideFloatingTip() {
+    floatingTip.style.display = "none";
+  }
+
+  // ── Interactive HTML bar chart renderer ─────────────────────────────
+
+  function renderBarChart(container, items, colors, descriptions) {
+    container.innerHTML = "";
+    const total = items.reduce((a, b) => a + b.value, 0);
+
+    if (total === 0) {
+      container.innerHTML = '<div class="bar-chart-empty">No data</div>';
+      return;
+    }
+
+    items.forEach((item, i) => {
+      const pctVal = pct(item.value, total);
+      const msVal = msFromNanos(item.value);
+      const widthPct = Math.max(0.5, (item.value / total) * 100);
+      const color = colors[i % colors.length];
+      const desc = descriptions[item.label] || "";
+
+      const row = document.createElement("div");
+      row.className = "bar-row";
+
+      row.innerHTML =
+        '<span class="bar-label">' + item.label + '</span>' +
+        '<div class="bar-track">' +
+          '<div class="bar-fill" style="width:' + widthPct + '%;background:' + color + '"></div>' +
+        '</div>' +
+        '<span class="bar-value">' + msVal + ' ms (' + pctVal + '%)</span>';
+
+      if (desc) {
+        row.addEventListener("mouseenter", (e) => showFloatingTip(e, desc));
+        row.addEventListener("mousemove", (e) => showFloatingTip(e, desc));
+        row.addEventListener("mouseleave", hideFloatingTip);
+      }
+
+      container.appendChild(row);
+    });
+  }
+
+  // ── Time series renderer (canvas) ───────────────────────────────────
+
+  function drawTimeSeries(canvas, samples) {
+    const ctx = canvas.getContext("2d");
+    const dpr = window.devicePixelRatio || 1;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, w, h);
+
+    if (!samples || samples.length === 0) {
+      ctx.fillStyle = "#999";
+      ctx.font = "13px sans-serif";
+      ctx.fillText("No time series data", 10, h / 2);
+      return;
+    }
+
+    const margin = { top: 20, right: 20, bottom: 40, left: 60 };
+    const chartW = w - margin.left - margin.right;
+    const chartH = h - margin.top - margin.bottom;
+
+    const maxIter = samples[samples.length - 1].iteration;
+    const maxBoundary = Math.max(1, ...samples.map(s => s.boundarySize));
+    const maxPending = Math.max(1, ...samples.map(s => s.pendingSize));
+    const maxSize = Math.max(maxBoundary, maxPending);
+
+    function xScale(iter) { return margin.left + (iter / maxIter) * chartW; }
+    function yScale(val) { return margin.top + chartH - (val / maxSize) * chartH; }
+
+    // Grid lines
+    ctx.strokeStyle = "rgba(0,0,0,0.08)";
+    ctx.lineWidth = 1;
+    for (let i = 0; i <= 4; i++) {
+      const y = margin.top + (chartH / 4) * i;
+      ctx.beginPath();
+      ctx.moveTo(margin.left, y);
+      ctx.lineTo(w - margin.right, y);
+      ctx.stroke();
+    }
+
+    function drawLine(key, color) {
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      samples.forEach((s, i) => {
+        const x = xScale(s.iteration);
+        const y = yScale(s[key]);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    }
+
+    drawLine("boundarySize", TIMESERIES_COLORS.boundary);
+    drawLine("pendingSize", TIMESERIES_COLORS.pending);
+
+    // Axis labels
+    ctx.fillStyle = "#555";
+    ctx.font = "11px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Iteration", margin.left + chartW / 2, h - 6);
+    for (let i = 0; i <= 4; i++) {
+      ctx.textAlign = "right";
+      ctx.fillText(formatK(Math.round(maxSize * (4 - i) / 4)), margin.left - 6, margin.top + (chartH / 4) * i + 4);
+    }
+
+    // Legend
+    const legendY = 12;
+    ctx.font = "11px sans-serif";
+    ctx.textAlign = "left";
+    [
+      { label: "Boundary queue", color: TIMESERIES_COLORS.boundary },
+      { label: "Pending queue", color: TIMESERIES_COLORS.pending }
+    ].forEach((item, i) => {
+      const x = margin.left + i * 140;
+      ctx.fillStyle = item.color;
+      ctx.fillRect(x, legendY - 8, 12, 12);
+      ctx.fillStyle = "#333";
+      ctx.fillText(item.label, x + 16, legendY + 2);
+    });
+
+    // ── Crosshair interaction ───────────────────────────────────────
+    let crosshairCleanup = canvas._crosshairCleanup;
+    if (crosshairCleanup) crosshairCleanup();
+
+    const overlay = document.createElement("canvas");
+    overlay.className = "crosshair-overlay";
+    overlay.width = canvas.width;
+    overlay.height = canvas.height;
+
+    const tooltip = document.createElement("div");
+    tooltip.className = "crosshair-tooltip";
+
+    canvas.parentElement.style.position = "relative";
+    canvas.parentElement.appendChild(overlay);
+    canvas.parentElement.appendChild(tooltip);
+
+    function onMouseMove(e) {
+      const rect = canvas.getBoundingClientRect();
+      const oCtx = overlay.getContext("2d");
+      oCtx.clearRect(0, 0, overlay.width, overlay.height);
+      oCtx.scale(dpr, dpr);
+
+      const cssX = e.clientX - rect.left;
+      const worldX = (cssX - margin.left) / chartW * maxIter;
+      if (worldX < 0 || worldX > maxIter) {
+        oCtx.setTransform(1, 0, 0, 1, 0, 0);
+        tooltip.style.display = "none";
+        return;
+      }
+
+      // Find nearest sample
+      let nearest = samples[0];
+      let bestDist = Infinity;
+      for (const s of samples) {
+        const d = Math.abs(s.iteration - worldX);
+        if (d < bestDist) { bestDist = d; nearest = s; }
+      }
+
+      const sx = xScale(nearest.iteration);
+      // Crosshair line
+      oCtx.strokeStyle = "rgba(0,0,0,0.3)";
+      oCtx.lineWidth = 1;
+      oCtx.setLineDash([4, 3]);
+      oCtx.beginPath();
+      oCtx.moveTo(sx, margin.top);
+      oCtx.lineTo(sx, margin.top + chartH);
+      oCtx.stroke();
+      oCtx.setLineDash([]);
+
+      // Dots
+      [
+        { val: nearest.boundarySize, color: TIMESERIES_COLORS.boundary },
+        { val: nearest.pendingSize, color: TIMESERIES_COLORS.pending }
+      ].forEach(pt => {
+        oCtx.fillStyle = pt.color;
+        oCtx.beginPath();
+        oCtx.arc(sx, yScale(pt.val), 4, 0, Math.PI * 2);
+        oCtx.fill();
+      });
+
+      oCtx.setTransform(1, 0, 0, 1, 0, 0);
+
+      // DOM tooltip
+      tooltip.innerHTML =
+        "Iter: " + formatK(nearest.iteration) + "<br>" +
+        "Boundary: " + formatK(nearest.boundarySize) + "<br>" +
+        "Pending: " + formatK(nearest.pendingSize);
+      tooltip.style.display = "block";
+      const tipRect = tooltip.getBoundingClientRect();
+      const parentRect = canvas.parentElement.getBoundingClientRect();
+      const tipX = (sx / w * rect.width) + rect.left - parentRect.left + 12;
+      const tipY = margin.top / h * rect.height + 8;
+      const flipX = tipX + tipRect.width > parentRect.width - 8;
+      tooltip.style.left = (flipX ? tipX - tipRect.width - 24 : tipX) + "px";
+      tooltip.style.top = tipY + "px";
+    }
+
+    function onMouseLeave() {
+      const oCtx = overlay.getContext("2d");
+      oCtx.clearRect(0, 0, overlay.width, overlay.height);
+      tooltip.style.display = "none";
+    }
+
+    canvas.style.pointerEvents = "auto";
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("mouseleave", onMouseLeave);
+    canvas._crosshairCleanup = () => {
+      canvas.removeEventListener("mousemove", onMouseMove);
+      canvas.removeEventListener("mouseleave", onMouseLeave);
+      if (overlay.parentElement) overlay.parentElement.removeChild(overlay);
+      if (tooltip.parentElement) tooltip.parentElement.removeChild(tooltip);
+    };
+  }
+
+  // ── Heatmap as tiled grid layer on main map ─────────────────────────
+
+  let heatmapLayer = null;
+  let heatmapEnabled = false;
+  let currentHeatmapRun = null;
+
+  function heatColor(t) {
+    let r, g, b;
+    if (t < HEAT_LOW) {
+      const s = t / HEAT_LOW;
+      r = 0;
+      g = Math.round(80 + 175 * s);
+      b = Math.round(220 - 80 * s);
+    } else if (t < HEAT_MID) {
+      const s = (t - HEAT_LOW) / (HEAT_MID - HEAT_LOW);
+      r = Math.round(255 * s);
+      g = 255;
+      b = Math.round(140 - 140 * s);
+    } else {
+      const s = (t - HEAT_MID) / (1 - HEAT_MID);
+      r = 255;
+      g = Math.round(255 - 200 * s);
+      b = 0;
+    }
+    return [r, g, b];
+  }
+
+  /** Build a spatial index: "chunkX:chunkY" -> [{x, y, count}, ...] */
+  function indexTiles(tiles) {
+    const index = new Map();
+    for (const tile of tiles) {
+      const cx = Math.floor(tile.x / CHUNK_SIZE);
+      const cy = Math.floor(tile.y / CHUNK_SIZE);
+      const key = cx + ":" + cy;
+      let list = index.get(key);
+      if (!list) { list = []; index.set(key, list); }
+      list.push(tile);
+    }
+    return index;
+  }
+
+  const HeatmapGridLayer = L.GridLayer.extend({
+    options: { tileSize: 256 },
+
+    setHeatData(tiles, maxCount) {
+      this._heatIndex = indexTiles(tiles);
+      this._maxCount = maxCount;
+      this.redraw();
+    },
+
+    createTile(coords) {
+      const size = this.options.tileSize;
+      const canvas = document.createElement("canvas");
+      canvas.width = size;
+      canvas.height = size;
+
+      const index = this._heatIndex;
+      if (!index) return canvas;
+
+      // Compute world bounds for this Leaflet tile.
+      // In CRS.Simple: pixel = latlng * 2^z, tile = floor(pixel / tileSize).
+      // Our world uses lat=y, lng=x.  CRS.Simple flips y: pixel_y = -lat * scale.
+      const scale = Math.pow(2, coords.z);
+      const worldPerTile = size / scale;
+
+      const wxMin = coords.x * worldPerTile;
+      const wyMin = -(coords.y + 1) * worldPerTile;
+      const wxMax = wxMin + worldPerTile;
+      const wyMax = wyMin + worldPerTile;
+
+      // Determine which spatial-index chunks overlap this tile
+      const cxMin = Math.floor(wxMin / CHUNK_SIZE);
+      const cxMax = Math.floor((wxMax - 1) / CHUNK_SIZE);
+      const cyMin = Math.floor(wyMin / CHUNK_SIZE);
+      const cyMax = Math.floor((wyMax - 1) / CHUNK_SIZE);
+
+      const ctx = canvas.getContext("2d");
+      const imageData = ctx.createImageData(size, size);
+      const data = imageData.data;
+      const logMax = Math.log1p(this._maxCount);
+      let hasData = false;
+
+      for (let ccx = cxMin; ccx <= cxMax; ccx++) {
+        for (let ccy = cyMin; ccy <= cyMax; ccy++) {
+          const list = index.get(ccx + ":" + ccy);
+          if (!list) continue;
+
+          for (const pt of list) {
+            if (pt.x < wxMin || pt.x >= wxMax || pt.y < wyMin || pt.y >= wyMax) continue;
+
+            let r, g, b, alpha;
+            if (pt.count >= this._maxCount) {
+              // Discontinuous error colour: magenta (count = observed max)
+              r = 200; g = 0; b = 200; alpha = 230;
+            } else {
+              const t = Math.min(1, Math.log1p(pt.count) / logMax);
+              alpha = Math.round((0.45 + 0.50 * t) * 255);
+              [r, g, b] = heatColor(t);
+            }
+
+            // Map world coords to canvas pixel rectangle
+            const pxStart = Math.floor((pt.x - wxMin) / worldPerTile * size);
+            const pyStart = Math.floor((wyMax - pt.y - 1) / worldPerTile * size);
+            const pxEnd = Math.max(pxStart + 1, Math.floor((pt.x + 1 - wxMin) / worldPerTile * size));
+            const pyEnd = Math.max(pyStart + 1, Math.floor((wyMax - pt.y) / worldPerTile * size));
+
+            for (let py = Math.max(0, pyStart); py < Math.min(size, pyEnd); py++) {
+              for (let px = Math.max(0, pxStart); px < Math.min(size, pxEnd); px++) {
+                const idx = (py * size + px) * 4;
+                data[idx] = r;
+                data[idx + 1] = g;
+                data[idx + 2] = b;
+                data[idx + 3] = alpha;
+              }
+            }
+            hasData = true;
+          }
+        }
+      }
+
+      if (hasData) ctx.putImageData(imageData, 0, 0);
+      return canvas;
+    }
+  });
+
+  // Fixed absolute scale — counts >= HEATMAP_MAX get a discontinuous error colour
+
+  function drawHeatmap(run) {
+    const map = window._dashboardMap;
+    if (!map) return;
+    clearHeatmap();
+
+    if (!run) return;
+
+    // Lazy-load externalized heatmap data (compact flat array: [x1,y1,c1, x2,y2,c2, ...])
+    if (!run.tileHeatmap && run.heatmapFile) {
+      const base = window.currentBundleBase || "";
+      const url = base + run.heatmapFile;
+      fetch(url)
+        .then(r => { if (!r.ok) throw new Error("Failed to load " + url); return r.json(); })
+        .then(flat => {
+          const tiles = [];
+          for (let i = 0; i < flat.length; i += 3) {
+            tiles.push({ x: flat[i], y: flat[i + 1], count: flat[i + 2] });
+          }
+          run.tileHeatmap = { tiles };
+          drawHeatmap(run);
+        })
+        .catch(e => console.warn("Heatmap load failed:", e));
+      return;
+    }
+
+    const heatmap = run.tileHeatmap;
+    if (!heatmap || !heatmap.tiles || heatmap.tiles.length === 0) return;
+
+    heatmapLayer = new HeatmapGridLayer({
+      tileSize: 256,
+      minZoom: -4,
+      maxZoom: 4,
+      updateWhenZooming: false,
+      className: "heatmap-canvas-overlay"
+    });
+    heatmapLayer.setHeatData(heatmap.tiles, HEATMAP_MAX);
+    heatmapLayer.addTo(map);
+    createLegend();
+  }
+
+  function clearHeatmap() {
+    if (heatmapLayer && window._dashboardMap) {
+      window._dashboardMap.removeLayer(heatmapLayer);
+      heatmapLayer = null;
+    }
+  }
+
+  // ── Heatmap legend ───────────────────────────────────────────────
+
+  let legendControl = null;
+
+  function createLegend() {
+    if (legendControl) {
+      window._dashboardMap.removeControl(legendControl);
+      legendControl = null;
+    }
+    const Legend = L.Control.extend({
+      options: { position: "topright" },
+      onAdd() {
+        const div = L.DomUtil.create("div", "heatmap-legend leaflet-control");
+        // Gradient bar 1–HEATMAP_MAX
+        const bar = document.createElement("canvas");
+        bar.width = 200;
+        bar.height = 14;
+        const ctx = bar.getContext("2d");
+        for (let i = 0; i < 200; i++) {
+          const t = i / 199;
+          const [r, g, b] = heatColor(t);
+          ctx.fillStyle = "rgb(" + r + "," + g + "," + b + ")";
+          ctx.fillRect(i, 0, 1, 14);
+        }
+        // Labels at log-mapped positions for the actual observed count clusters
+        const labels = document.createElement("div");
+        labels.style.cssText = "position:relative;height:16px;margin-top:4px;";
+        const logMax = Math.log1p(HEATMAP_MAX);
+        [1, 2, 5, 24].forEach(count => {
+          const pct = (Math.log1p(count) / logMax * 100).toFixed(1);
+          const el = document.createElement("span");
+          el.textContent = count;
+          el.style.cssText = "position:absolute;left:" + pct + "%;transform:translateX(-50%);font:11px/1 var(--font-mono);color:#666;";
+          labels.appendChild(el);
+        });
+        const title = document.createElement("div");
+        title.className = "heatmap-legend-title";
+        title.textContent = "Visit count (log scale)";
+        div.appendChild(title);
+        div.appendChild(bar);
+        div.appendChild(labels);
+        // Error swatch for >=HEATMAP_MAX
+        const errorRow = document.createElement("div");
+        errorRow.className = "heatmap-legend-error";
+        const swatch = document.createElement("span");
+        swatch.className = "heatmap-legend-error-swatch";
+        const errorLabel = document.createElement("span");
+        errorLabel.innerHTML = "≥" + HEATMAP_MAX + " <span style=\"color:#999;font-style:italic\">(empirical max)</span>";
+        errorRow.appendChild(swatch);
+        errorRow.appendChild(errorLabel);
+        div.appendChild(errorRow);
+        L.DomEvent.disableClickPropagation(div);
+        return div;
+      }
+    });
+    legendControl = new Legend();
+    legendControl.addTo(window._dashboardMap);
+  }
+
+  function removeLegend() {
+    if (legendControl && window._dashboardMap) {
+      window._dashboardMap.removeControl(legendControl);
+      legendControl = null;
+    }
+  }
+
+  function toggleHeatmap(enabled) {
+    heatmapEnabled = enabled;
+    if (enabled && currentHeatmapRun) {
+      drawHeatmap(currentHeatmapRun);
+    } else {
+      clearHeatmap();
+      removeLegend();
+    }
+  }
+
+  // Register heatmap toggle in the main map's transport layer control
+  window.addMapLayerToggle({
+    label: "Heatmap",
+    checked: false,
+    onChange: toggleHeatmap
+  });
+
+  // ── Run rendering ───────────────────────────────────────────────────
+
+  function renderRunOverview(run) {
+    const lines = [
+      "Name:         " + run.name,
+      "Category:     " + (run.category || "-"),
+      "Reached:      " + run.reached,
+      "Termination:  " + run.terminationReason,
+      "Path length:  " + (run.path || []).length,
+      "",
+      "Nodes checked:      " + formatK(run.stats.nodesChecked),
+      "Transports checked: " + formatK(run.stats.transportsChecked),
+      "Total elapsed:      " + msFromNanos(run.stats.elapsedNanos) + " ms",
+      "",
+      "Start:  (" + run.start.x + ", " + run.start.y + ", " + run.start.plane + ")",
+      "Target: (" + run.target.x + ", " + run.target.y + ", " + run.target.plane + ")"
+    ];
+    runOverviewEl.textContent = lines.join("\n");
+  }
+
+  function renderCounters(run) {
+    const c = run.counters;
+    const lines = [
+      "Tile neighbors added:       " + formatK(c.tileNeighborsAdded),
+      "Transport neighbors added:  " + formatK(c.transportNeighborsAdded),
+      "Visited-skipped:            " + formatK(c.visitedSkipped),
+      "Abstract nodes expanded:    " + c.abstractNodesExpanded,
+      "Transport evaluations:      " + formatK(c.transportEvaluations),
+      "Blocked-tile transport:     " + formatK(c.blockedTileTransportChecks),
+      "Bank transitions:           " + c.bankTransitions,
+      "Wilderness level changes:   " + c.wildernessLevelChanges,
+      "Peak boundary queue:        " + formatK(c.peakBoundarySize),
+      "Peak pending queue:         " + formatK(c.peakPendingSize)
+    ];
+    countersEl.textContent = lines.join("\n");
+  }
+
+  // ── Extension entry point ───────────────────────────────────────────
+
+  window.dashboardExtensions.push({
+    renderRun(run) {
+      const hasProfiler = run.phases && run.counters;
+      drawerEl.hidden = !hasProfiler;
+      if (!hasProfiler) return;
+
+      renderRunOverview(run);
+      renderCounters(run);
+
+      const p = run.phases;
+      renderBarChart(phaseChartEl,
+        [
+          { label: "Add neighbors", value: p.addNeighborsNanos },
+          { label: "Queue selection", value: p.queueSelectionNanos },
+          { label: "Target check", value: p.targetCheckNanos },
+          { label: "Wilderness check", value: p.wildernessCheckNanos },
+          { label: "Cutoff check", value: p.cutoffCheckNanos || 0 },
+          { label: "Bookkeeping", value: p.bookkeepingNanos || 0 },
+          { label: "Loop overhead", value: p.otherNanos }
+        ],
+        PHASE_COLORS,
+        PHASE_DESCRIPTIONS
+      );
+
+      const sp = run.subPhases;
+      renderBarChart(subphaseChartEl,
+        [
+          { label: "Bank check", value: sp.bankCheckNanos },
+          { label: "Transport lookup", value: sp.transportLookupNanos },
+          { label: "Collision check", value: sp.collisionCheckNanos },
+          { label: "Walkable tile", value: sp.walkableTileNanos },
+          { label: "Blocked transport", value: sp.blockedTileTransportNanos },
+          { label: "Abstract node", value: sp.abstractNodeNanos }
+        ],
+        SUBPHASE_COLORS,
+        SUBPHASE_DESCRIPTIONS
+      );
+
+      pendingTimeSeries = run.timeSeries;
+      if (!drawerEl.classList.contains("collapsed")) {
+        drawTimeSeries(timeseriesCanvas, run.timeSeries);
+      }
+
+      // Update heatmap on main map
+      currentHeatmapRun = run;
+      if (heatmapEnabled) {
+        drawHeatmap(run);
+      }
+    }
+  });
+})();

--- a/src/test/resources/reachability-dashboard/profiler.js
+++ b/src/test/resources/reachability-dashboard/profiler.js
@@ -599,6 +599,8 @@
       "Blocked-tile transport:     " + formatK(c.blockedTileTransportChecks),
       "Bank transitions:           " + c.bankTransitions,
       "Wilderness level changes:   " + c.wildernessLevelChanges,
+      "Delayed-visit enqueued:     " + formatK(c.delayedVisitEnqueued),
+      "Delayed-visit skipped:      " + formatK(c.delayedVisitSkipped),
       "Peak boundary queue:        " + formatK(c.peakBoundarySize),
       "Peak pending queue:         " + formatK(c.peakPendingSize)
     ];

--- a/src/test/resources/reachability-dashboard/styles.css
+++ b/src/test/resources/reachability-dashboard/styles.css
@@ -1,28 +1,163 @@
+/* ── Design tokens ──────────────────────────────────────────────────── */
+
+:root {
+  --color-text: #1d1b19;
+  --color-muted: #444;
+  --color-light: #f6f6f0;
+  --color-accent: #e8a838;
+  --color-selected-border: #7c2d12;
+  --color-selected-bg: #efe2c7;
+
+  --bg-primary: #fffdf8;
+  --bg-hover: #f3ecdf;
+  --bg-panel: rgba(255, 250, 244, 0.96);
+  --bg-panel-light: rgba(255, 250, 244, 0.92);
+  --bg-dark: rgba(31, 36, 48, 0.92);
+  --bg-code: #1f2430;
+
+  --border-color: rgba(29, 27, 25, 0.18);
+  --border-color-subtle: rgba(29, 27, 25, 0.08);
+  --border-color-light: rgba(29, 27, 25, 0.15);
+
+  --shadow-panel: 0 10px 28px rgba(43, 36, 29, 0.18);
+  --shadow-dark: 0 8px 24px rgba(31, 36, 48, 0.2);
+  --shadow-map: 0 18px 50px rgba(43, 36, 29, 0.18);
+
+  --font-mono: "SF Mono", "Cascadia Mono", "Menlo", monospace;
+
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+}
+
+/* ── Base ───────────────────────────────────────────────────────────── */
+
 html, body {
   height: 100%;
   margin: 0;
-  font-family: "IBM Plex Sans", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   background: linear-gradient(180deg, #f5f0e8 0%, #e5dccf 100%);
-  color: #1d1b19;
+  color: var(--color-text);
 }
+
+/* ── Navigation bar ────────────────────────────────────────────────── */
+
+.dashboard-nav {
+  display: flex;
+  gap: 0;
+  background: #2c2825;
+  padding: 0 16px;
+  font-size: 13px;
+}
+
+.dashboard-nav a {
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: none;
+  padding: 10px 16px;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.dashboard-nav a:hover {
+  color: #fff;
+}
+
+.dashboard-nav a.active {
+  color: #fff;
+  border-bottom-color: var(--color-accent);
+}
+
+/* ── Layout ────────────────────────────────────────────────────────── */
 
 .layout {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: auto 1fr;
   height: 100%;
 }
 
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-color-light);
+  }
+}
+
+/* ── Sidebar ───────────────────────────────────────────────────────── */
+
 .sidebar {
+  display: flex;
+  flex-direction: row;
+  border-right: 1px solid var(--border-color-light);
+  background: var(--bg-panel-light);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.sidebar-content {
+  width: 340px;
   padding: 20px;
-  overflow: auto;
-  border-right: 1px solid rgba(29, 27, 25, 0.15);
-  background: rgba(255, 250, 244, 0.92);
+  overflow-y: auto;
+  transition: width 0.2s ease, padding 0.2s ease, opacity 0.2s ease;
+}
+
+.sidebar.collapsed .sidebar-content {
+  width: 0;
+  padding: 0;
+  overflow: hidden;
+  opacity: 0;
 }
 
 .sidebar h1 {
   margin-top: 0;
-  font-size: 24px;
+  font-size: 22px;
+  white-space: nowrap;
 }
+
+.sidebar-handle {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #888;
+  font-size: 11px;
+  padding: 0;
+  user-select: none;
+  border-left: 1px solid var(--border-color-subtle);
+  transition: background 0.15s;
+}
+
+.sidebar-handle:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--color-muted);
+}
+
+/* ── Bundle selector ───────────────────────────────────────────────── */
+
+.bundle-select {
+  width: 100%;
+  padding: 6px 8px;
+  margin-bottom: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.bundle-select[hidden] {
+  display: none;
+}
+
+/* ── Search & filter controls ──────────────────────────────────────── */
 
 .search {
   display: block;
@@ -35,22 +170,13 @@ html, body {
   margin-bottom: 6px;
 }
 
-.search input {
-  width: 100%;
-  box-sizing: border-box;
-  border: 1px solid rgba(29, 27, 25, 0.18);
-  background: #fffdf8;
-  border-radius: 8px;
-  padding: 10px 12px;
-  font: inherit;
-}
-
+.search input,
 .search select {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid rgba(29, 27, 25, 0.18);
-  background: #fffdf8;
-  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  border-radius: var(--radius-md);
   padding: 10px 12px;
   font: inherit;
 }
@@ -72,10 +198,151 @@ html, body {
   flex: 1;
 }
 
+/* ── Navigation buttons ────────────────────────────────────────────── */
+
+#center-target {
+  width: 100%;
+  margin: 0 0 16px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+#center-target:hover {
+  background: var(--bg-hover);
+}
+
+.nav-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin: 0 0 16px;
+}
+
+.nav-buttons button {
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.nav-buttons button:hover {
+  background: var(--bg-hover);
+}
+
+.nav-buttons button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  background: #f5efe4;
+}
+
+/* ── Run list ──────────────────────────────────────────────────────── */
+
+#run-list {
+  padding-left: 20px;
+}
+
+#run-list li {
+  margin: 0 0 12px;
+}
+
+#run-list button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.run-status-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.run-status-dot--reached   { background: #22a35a; }
+.run-status-dot--unreached { background: #d94040; }
+
+#run-list button:hover {
+  background: var(--bg-hover);
+}
+
+#run-list button.selected {
+  border-color: var(--color-selected-border);
+  background: var(--color-selected-bg);
+}
+
+#run-details {
+  white-space: pre-wrap;
+  background: var(--bg-code);
+  color: var(--color-light);
+  padding: 12px;
+  border-radius: var(--radius-md);
+}
+
+/* ── Map panel ─────────────────────────────────────────────────────── */
+
+.map-panel {
+  padding: 12px;
+  padding-bottom: 48px;
+  position: relative;
+  overflow: hidden;
+  min-height: 0;
+}
+
+#map {
+  height: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: var(--shadow-map);
+}
+
+#map-coordinates {
+  position: absolute;
+  left: 32px;
+  bottom: 68px;
+  z-index: 500;
+  pointer-events: none;
+  background: rgba(31, 36, 48, 0.88);
+  color: var(--color-light);
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  font: 12px/1.3 var(--font-mono);
+  box-shadow: var(--shadow-dark);
+}
+
+#transport-info {
+  position: absolute;
+  right: 32px;
+  bottom: 32px;
+  z-index: 500;
+  max-width: 320px;
+  background: var(--bg-panel);
+  color: var(--color-text);
+  padding: 10px 12px;
+  border-radius: var(--radius-lg);
+  font-size: 12px;
+  line-height: 1.35;
+  box-shadow: var(--shadow-panel);
+  white-space: pre-wrap;
+}
+
+/* ── Transport layer control ───────────────────────────────────────── */
+
 .leaflet-control.transport-layer-control {
-  background: rgba(255, 250, 244, 0.96);
-  border-radius: 10px;
-  box-shadow: 0 10px 28px rgba(43, 36, 29, 0.18);
+  background: var(--bg-panel);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-panel);
   padding: 10px 12px;
 }
 
@@ -104,220 +371,355 @@ html, body {
   margin-bottom: 0;
 }
 
-#center-target {
-  width: 100%;
-  margin: 0 0 16px;
-  border: 1px solid rgba(29, 27, 25, 0.18);
-  background: #fffdf8;
-  border-radius: 8px;
-  padding: 10px 12px;
-  cursor: pointer;
-}
+/* ── Run info panel (right side of map) ────────────────────────────── */
 
-#center-target:hover {
-  background: #f3ecdf;
-}
-
-.nav-buttons {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-  margin: 0 0 16px;
-}
-
-.nav-buttons button {
-  border: 1px solid rgba(29, 27, 25, 0.18);
-  background: #fffdf8;
-  border-radius: 8px;
-  padding: 10px 12px;
-  cursor: pointer;
-  font: inherit;
-}
-
-.nav-buttons button:hover {
-  background: #f3ecdf;
-}
-
-.nav-buttons button:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
-  background: #f5efe4;
-}
-
-#run-list {
-  padding-left: 20px;
-}
-
-#run-list li {
-  margin: 0 0 12px;
-}
-
-#run-list button {
-  width: 100%;
-  text-align: left;
-  border: 1px solid rgba(29, 27, 25, 0.18);
-  background: #fffdf8;
-  border-radius: 8px;
-  padding: 10px 12px;
-  cursor: pointer;
-}
-
-#run-list button:hover {
-  background: #f3ecdf;
-}
-
-#run-list button.selected {
-  border-color: #7c2d12;
-  background: #efe2c7;
-}
-
-#run-details {
-  white-space: pre-wrap;
-  background: #1f2430;
-  color: #f6f6f0;
-  padding: 12px;
-  border-radius: 8px;
-}
-
-.map-panel {
-  padding: 20px;
-  position: relative;
-}
-
-.map-help-button,
-.map-help-close {
-  border: 1px solid rgba(29, 27, 25, 0.18);
-  background: rgba(255, 250, 244, 0.96);
-  color: #1d1b19;
-  border-radius: 10px;
-  padding: 10px 12px;
-  font: 13px/1.2 "IBM Plex Sans", sans-serif;
-  cursor: pointer;
-  box-shadow: 0 10px 28px rgba(43, 36, 29, 0.18);
-}
-
-.map-help-button:hover,
-.map-help-close:hover {
-  background: #f3ecdf;
-}
-
-#map-help-button {
+.run-info-panel {
   position: absolute;
-  bottom: 84px;
-  left: 32px;
+  bottom: 80px;
+  right: 20px;
   z-index: 500;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border-radius: 999px;
-  font: 600 16px/1 "IBM Plex Sans", sans-serif;
-  opacity: 0.78;
-}
-
-#map-help-button:hover {
-  opacity: 1;
-}
-
-#map {
-  height: 100%;
-  min-height: 480px;
-  border-radius: 16px;
-  overflow: hidden;
-  box-shadow: 0 18px 50px rgba(43, 36, 29, 0.18);
-}
-
-.map-help-overlay {
-  position: absolute;
-  inset: 20px;
-  z-index: 700;
   display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 24px;
-  background: rgba(31, 36, 48, 0.42);
-  border-radius: 16px;
+  flex-direction: row;
+  max-width: 320px;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-panel);
+  pointer-events: auto;
 }
 
-.map-help-overlay[hidden] {
+.run-info-hidden {
   display: none;
 }
 
-.map-help-dialog {
-  width: min(520px, 100%);
-  max-height: 100%;
-  overflow: auto;
-  background: rgba(255, 250, 244, 0.98);
-  color: #1d1b19;
-  border-radius: 14px;
-  padding: 18px;
-  box-shadow: 0 18px 50px rgba(43, 36, 29, 0.28);
+.run-info-toggle {
+  flex-shrink: 0;
+  writing-mode: vertical-lr;
+  text-orientation: mixed;
+  border: none;
+  background: var(--bg-dark);
+  color: var(--color-light);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 1;
+  padding: 10px 6px;
+  letter-spacing: 0.5px;
+  user-select: none;
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
 }
 
-.map-help-header {
+.run-info-toggle:hover {
+  background: rgba(31, 36, 48, 1);
+}
+
+.run-info-body {
+  background: var(--bg-dark);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 11px;
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+}
+
+.run-info-panel.collapsed .run-info-body {
+  display: none;
+}
+
+.run-info-body pre {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-light);
+}
+
+.run-info-body #center-target {
+  width: 100%;
+  flex-shrink: 0;
+  margin: 0;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-light);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+
+.run-info-body #center-target:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+/* ── Profiler drawer ───────────────────────────────────────────────── */
+
+.profiler-drawer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  background: rgba(255, 250, 244, 0.97);
+  border-radius: 12px 12px 0 0;
+  box-shadow: 0 -4px 24px rgba(43, 36, 29, 0.18);
+  display: flex;
+  flex-direction: column;
+  max-height: 50vh;
+  transition: max-height 0.3s ease;
+  overflow: hidden;
+}
+
+.profiler-drawer.collapsed {
+  max-height: 36px;
+}
+
+.profiler-drawer-handle {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--color-muted);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  user-select: none;
+}
+
+.profiler-drawer-handle:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.profiler-drawer.collapsed .profiler-drawer-handle {
+  border-bottom: none;
+}
+
+.profiler-drawer-body {
+  overflow-y: auto;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 12px;
-  margin-bottom: 12px;
 }
 
-.map-help-header h2 {
+.profiler-drawer.collapsed .profiler-drawer-body {
+  display: none;
+}
+
+/* ── Profiler panels ───────────────────────────────────────────────── */
+
+.profiler-panel {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--border-color-subtle);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+}
+
+.profiler-panel h2,
+.profiler-panel-merged h2 {
+  margin: 0 0 10px;
+  font-size: 15px;
+  color: var(--color-muted);
+}
+
+.profiler-panel pre {
   margin: 0;
-  font-size: 20px;
-}
-
-.map-help-overlay p,
-.map-help-overlay ul,
-.map-help-overlay h3 {
-  margin: 0 0 12px;
-}
-
-.map-help-overlay ul {
-  padding-left: 20px;
-}
-
-#map-coordinates {
-  position: absolute;
-  left: 32px;
-  bottom: 32px;
-  z-index: 500;
-  pointer-events: none;
-  background: rgba(31, 36, 48, 0.88);
-  color: #f6f6f0;
-  padding: 8px 10px;
-  border-radius: 8px;
-  font: 13px/1.3 "IBM Plex Mono", monospace;
-  box-shadow: 0 8px 24px rgba(31, 36, 48, 0.2);
-}
-
-#transport-info {
-  position: absolute;
-  right: 32px;
-  bottom: 32px;
-  z-index: 500;
-  max-width: 320px;
-  background: rgba(255, 250, 244, 0.96);
-  color: #1d1b19;
-  padding: 10px 12px;
-  border-radius: 10px;
-  font: 13px/1.35 "IBM Plex Sans", sans-serif;
-  box-shadow: 0 10px 28px rgba(43, 36, 29, 0.18);
+  font: 12px/1.6 var(--font-mono);
   white-space: pre-wrap;
+  word-break: break-word;
 }
 
-@media (max-width: 900px) {
-  .layout {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
-  }
+.profiler-panel canvas {
+  display: block;
+  width: 100%;
+  height: 260px;
+}
 
-  .sidebar {
-    border-right: 0;
-    border-bottom: 1px solid rgba(29, 27, 25, 0.15);
-  }
+.profiler-panel-wide canvas {
+  height: 300px;
+}
 
-  .map-help-overlay {
-    inset: 12px;
-    padding: 12px;
-  }
+.profiler-panel-merged {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  padding: 0;
+}
+
+.profiler-panel-merged .profiler-col {
+  padding: 16px;
+}
+
+.profiler-panel-merged .profiler-col:first-child {
+  border-right: 1px solid var(--border-color-subtle);
+}
+
+.subphase-explainer {
+  margin: 0 0 8px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #888;
+}
+
+/* ── Interactive bar chart ─────────────────────────────────────────── */
+
+.bar-chart-container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bar-chart-empty {
+  color: #999;
+  font-size: 13px;
+  padding: 8px 0;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 130px 1fr 140px;
+  align-items: center;
+  gap: 8px;
+  position: relative;
+  cursor: default;
+  padding: 2px 0;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.bar-row:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.bar-label {
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1;
+  color: #333;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 20px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+  min-width: 2px;
+}
+
+.bar-value {
+  font: 11px/1 var(--font-mono);
+  color: #555;
+  white-space: nowrap;
+}
+
+/* ── Floating tooltip (profiler bar chart hover) ───────────────────── */
+
+.floating-tip {
+  position: fixed;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  font: 11px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: #555;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  display: none;
+  white-space: normal;
+  z-index: 9999;
+  max-width: 320px;
+}
+
+/* ── Crosshair tooltip (time series hover) ─────────────────────────── */
+
+.crosshair-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.crosshair-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  font: 11px/1.5 var(--font-mono);
+  color: #333;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  display: none;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+/* ── Heatmap overlay & legend ──────────────────────────────────────── */
+
+.heatmap-canvas-overlay {
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+.heatmap-legend {
+  background: var(--bg-panel);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-panel);
+  padding: 10px 12px;
+}
+
+.heatmap-legend canvas {
+  display: block;
+  width: 100%;
+  height: 14px;
+  border-radius: 3px;
+}
+
+.heatmap-legend-title {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.heatmap-legend-labels {
+  display: flex;
+  justify-content: space-between;
+  font: 11px/1 var(--font-mono);
+  color: #666;
+  margin-top: 4px;
+}
+
+.heatmap-legend-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: #666;
+}
+
+.heatmap-legend-error-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: rgb(200, 0, 200);
 }

--- a/src/test/resources/reachability/clue_locations_full.csv
+++ b/src/test/resources/reachability/clue_locations_full.csv
@@ -1,885 +1,867 @@
-description,x,y,plane,source_file,source_line,snippet
-manual,3567,4381,0,from discord
-anagram,1212,3119,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,899,".location(new WorldPoint(1212, 3119, 0))"
-anagram,1503,3553,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,738,".location(new WorldPoint(1503, 3553, 0))"
-anagram,1504,3632,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,593,".location(new WorldPoint(1504, 3632, 0))"
-anagram,1512,3619,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,584,".location(new WorldPoint(1511, 3619, 0))"
-anagram,1529,3567,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,861,".location(new WorldPoint(1529, 3567, 0))"
-anagram,1551,3565,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,868,".location(new WorldPoint(1551, 3565, 0))"
-anagram,1639,3812,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,400,".location(new WorldPoint(1639, 3812, 0))"
-anagram,1649,3498,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,688,".location(new WorldPoint(1649, 3498, 0))"
-anagram,1688,3540,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,541,".location(new WorldPoint(1688, 3540, 0))"
-anagram,1719,3723,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,136,".location(new WorldPoint(1719, 3723, 0))"
-anagram,1737,3557,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,409,".location(new WorldPoint(1737, 3557, 0))"
-anagram,1742,2977,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,877,".location(new WorldPoint(1742, 2977, 0))"
-anagram,1761,3850,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,663,".location(new WorldPoint(1761, 3850, 0))"
-anagram,1805,3566,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,477,".location(new WorldPoint(1805, 3566, 0))"
-anagram,1814,3851,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,93,".location(new WorldPoint(1814, 3851, 0))"
-anagram,1822,3739,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,713,".location(new WorldPoint(1822, 3739, 0))"
-anagram,1841,3803,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,216,".location(new WorldPoint(1841, 3803, 0))"
-anagram,2150,3866,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,207,".location(new WorldPoint(2150, 3866, 0))"
-anagram,2209,3056,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,200,".location(new WorldPoint(2209, 3056, 0))"
-anagram,2326,3178,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,548,".location(new WorldPoint(2326, 3178, 0))"
-anagram,2335,3162,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,854,".location(new WorldPoint(2335, 3162, 0))"
-anagram,2351,3801,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,704,".location(new WorldPoint(2351, 3801, 0))"
-anagram,2395,3486,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,225,".location(new WorldPoint(2395, 3486, 0))"
-anagram,2402,3419,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,161,".location(new WorldPoint(2402, 3419, 0))"
-anagram,2432,3422,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,434,".location(new WorldPoint(2432, 3422, 0))"
-anagram,2447,3418,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,486,".location(new WorldPoint(2447, 3418, 1))"
-anagram,2454,2853,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,672,".location(new WorldPoint(2454, 2853, 1))"
-anagram,2461,3382,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,511,".location(new WorldPoint(2461, 3382, 0))"
-anagram,2501,3487,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,375,".location(new WorldPoint(2501, 3487, 0))"
-anagram,2512,10256,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,352,".location(new WorldPoint(2512, 10256, 0))"
-anagram,2526,3162,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,182,".location(new WorldPoint(2526, 3162, 0))"
-anagram,2541,3170,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,359,".location(new WorldPoint(2541, 3170, 0))"
-anagram,2541,3305,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,845,".location(new WorldPoint(2541, 3305, 0))"
-anagram,2553,2868,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,191,".location(new WorldPoint(2553, 2868, 0))"
-anagram,2566,3332,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,557,".location(new WorldPoint(2566, 3332, 0))"
-anagram,2592,4324,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,443,".location(new WorldPoint(2592, 4324, 0))"
-anagram,2606,3211,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,525,".location(new WorldPoint(2606, 3211, 0))"
-anagram,2609,3116,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,425,".location(new WorldPoint(2609, 3116, 0))"
-anagram,2613,3269,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,332,".location(new WorldPoint(2613, 3269, 0))"
-anagram,2630,2997,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,418,".location(new WorldPoint(2630, 2997, 0))"
-anagram,2658,3670,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,316,".location(new WorldPoint(2658, 3670, 0))"
-anagram,2660,3654,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,745,".location(new WorldPoint(2660, 3654, 0))"
-anagram,2715,3302,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,109,".location(new WorldPoint(2715, 3302, 0))"
-anagram,2726,3368,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,534,".location(new WorldPoint(2726, 3368, 0))"
-anagram,2736,5351,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,773,".location(new WorldPoint(2736, 5351, 1))"
-anagram,2744,3444,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,602,".location(new WorldPoint(2744, 3444, 0))"
-anagram,2760,3496,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,450,".location(new WorldPoint(2760, 3496, 0))"
-anagram,2783,3861,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,168,".location(new WorldPoint(2783, 3861, 0))"
-anagram,2790,3066,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,366,".location(new WorldPoint(2790, 3066, 0))"
-anagram,2802,2765,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,764,".location(new WorldPoint(2802, 2765, 0))"
-anagram,2803,2744,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,325,".location(new WorldPoint(2803, 2744, 0))"
-anagram,2807,3191,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,566,".location(new WorldPoint(2807, 3191, 0))"
-anagram,2822,3442,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,729,".location(new WorldPoint(2822, 3442, 0))"
-anagram,2858,3577,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,145,".location(new WorldPoint(2858, 3577, 0))"
-anagram,2872,3934,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,86,".location(new WorldPoint(2872, 3934, 0))"
-anagram,2897,3565,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,391,".location(new WorldPoint(2897, 3565, 0))"
-anagram,2906,3537,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,645,".location(new WorldPoint(2906, 3537, 0))"
-anagram,2913,10221,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,300,".location(new WorldPoint(2913, 10221, 0))"
-anagram,2919,3574,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,679,".location(new WorldPoint(2919, 3574, 0))"
-anagram,2938,3152,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,384,".location(new WorldPoint(2938, 3152, 0))"
-anagram,2940,3223,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,654,".location(new WorldPoint(2940, 3223, 0))"
-anagram,2944,3381,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,831,".location(new WorldPoint(2944, 3381, 0))"
-anagram,2951,3450,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,803,".location(new WorldPoint(2951, 3450, 0))"
-anagram,2957,3370,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,459,".location(new WorldPoint(2957, 3370, 0))"
-anagram,2975,3343,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,627,".location(new WorldPoint(2975, 3343, 0))"
-anagram,3013,3501,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,118,".location(new WorldPoint(3013, 3501, 0))"
-anagram,3026,3216,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,77,".location(new WorldPoint(3026, 3216, 0))"
-anagram,3026,3246,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,810,".location(new WorldPoint(3026, 3246, 0))"
-anagram,3039,4834,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,266,".location(new WorldPoint(3039, 4834, 0))"
-anagram,3047,3376,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,611,".location(new WorldPoint(3047, 3376, 0))"
-anagram,3061,3377,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,243,".location(new WorldPoint(3061, 3377, 0))"
-anagram,3079,9892,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,754,".location(new WorldPoint(3079, 9892, 0))"
-anagram,3080,3250,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,838,".location(new WorldPoint(3080, 3250, 0))"
-anagram,3088,3253,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,695,".location(new WorldPoint(3088, 3253, 0))"
-anagram,3102,9570,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,796,".location(new WorldPoint(3102, 9570, 0))"
-anagram,3110,3330,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,817,".location(new WorldPoint(3110, 3330, 0))"
-anagram,3143,2423,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,908,".location(new WorldPoint(3143, 2423, 0))"
-anagram,3151,3412,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,824,".location(new WorldPoint(3151, 3412, 0))"
-anagram,3182,3946,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,284,".location(new WorldPoint(3182, 3946, 0))"
-anagram,3182,3946,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,291,".location(new WorldPoint(3182, 3946, 0))"
-anagram,3195,3404,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,789,".location(new WorldPoint(3195, 3404, 0))"
-anagram,3207,3214,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,575,".location(new WorldPoint(3207, 3214, 0))"
-anagram,3209,3392,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,127,".location(new WorldPoint(3209, 3392, 0))"
-anagram,3217,3434,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,68,".location(new WorldPoint(3217, 3434, 0))"
-anagram,3220,3476,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,468,".location(new WorldPoint(3220, 3476, 0))"
-anagram,3230,3230,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,275,".location(new WorldPoint(3230, 3230, 0))"
-anagram,3233,3423,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,345,".location(new WorldPoint(3233, 3423, 0))"
-anagram,3238,3220,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,175,".location(new WorldPoint(3238, 3220, 0))"
-anagram,3243,3208,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,152,".location(new WorldPoint(3243, 3208, 0))"
-anagram,3273,3181,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,636,".location(new WorldPoint(3273, 3181, 0))"
-anagram,3284,3943,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,259,".location(new WorldPoint(3284, 3943, 0))"
-anagram,3300,3231,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,502,".location(new WorldPoint(3300, 3231, 0))"
-anagram,3315,3163,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,782,".location(new WorldPoint(3315, 3163, 0))"
-anagram,3359,3276,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,102,".location(new WorldPoint(3359, 3276, 0))"
-anagram,3389,2877,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,722,".location(new WorldPoint(3389, 2877, 0))"
-anagram,3462,3557,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,234,".location(new WorldPoint(3462, 3557, 0))"
-anagram,3508,3237,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,495,".location(new WorldPoint(3508, 3237, 0))"
-anagram,3564,3288,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,307,".location(new WorldPoint(3564, 3288, 0))"
-anagram,3602,3209,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,518,".location(new WorldPoint(3602, 3209, 0))"
-anagram,3661,3849,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,889,"new WorldPoint(3661, 3849, 0); // West side of Fossil Island"
-anagram,3681,2963,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,618,".location(new WorldPoint(3681, 2963, 0))"
-anagram,3719,3810,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,888,"new WorldPoint(3719, 3810, 0) : // Museum camp"
-anagram,3728,3302,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,252,".location(new WorldPoint(3728, 3302, 0))"
-beginner_map,3043,3398,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,39,"new BeginnerMapClue(InterfaceID.TRAIL_MAP06, new WorldPoint(3043, 3398, 0), MapClue.STANDING_STONES),"
-beginner_map,3093,3226,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,38,"new BeginnerMapClue(InterfaceID.TRAIL_MAP03, new WorldPoint(3093, 3226, 0), MapClue.SOUTH_OF_DRAYNOR_BANK),"
-beginner_map,3110,3152,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,40,"new BeginnerMapClue(InterfaceID.TRAIL_MAP11, new WorldPoint(3110, 3152, 0), MapClue.WIZARDS_TOWER_DIS)"
-beginner_map,3166,3361,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,36,"new BeginnerMapClue(InterfaceID.TRAIL_MAP01, new WorldPoint(3166, 3361, 0), MapClue.CHAMPIONS_GUILD),"
-beginner_map,3290,3374,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,37,"new BeginnerMapClue(InterfaceID.TRAIL_MAP02, new WorldPoint(3290, 3374, 0), MapClue.VARROCK_EAST_MINE),"
-cipher,1376,3037,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,199,".location(new WorldPoint(1376, 3037, 0))"
-cipher,1559,3045,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,192,".location(new WorldPoint(1559, 3045, 0))"
-cipher,1625,3802,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,163,".location(new WorldPoint(1625, 3802, 0))"
-cipher,1845,3754,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,95,".location(new WorldPoint(1845, 3754, 0))"
-cipher,2289,3144,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,104,".locationProvider((plugin) -> isElunedInPrifddinas(plugin) ? new WorldPoint(3229, 6062, 0) : new WorldPoint(2289, 3144, 0))"
-cipher,2329,3689,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,179,".location(new WorldPoint(2329, 3689, 0))"
-cipher,2347,4435,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,156,".location(new WorldPoint(2347, 4435, 0))"
-cipher,2446,4428,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,140,".location(new WorldPoint(2446, 4428, 0))"
-cipher,2501,3487,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,122,".location(new WorldPoint(2501, 3487, 0))"
-cipher,2541,3548,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,172,".location(new WorldPoint(2541, 3548, 0))"
-cipher,2634,4682,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,113,".location(new WorldPoint(2634, 4682, 1))"
-cipher,3077,3260,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,185,".location(new WorldPoint(3077, 3260, 0))"
-cipher,3112,3162,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,131,".location(new WorldPoint(3112, 3162, 0))"
-cipher,3224,3112,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,86,".location(new WorldPoint(3224, 3112, 0))"
-cipher,3227,3227,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,77,".location(new WorldPoint(3227, 3227, 0))"
-cipher,3229,6062,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,104,".locationProvider((plugin) -> isElunedInPrifddinas(plugin) ? new WorldPoint(3229, 6062, 0) : new WorldPoint(2289, 3144, 0))"
-cipher,3354,2974,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,59,".location(new WorldPoint(3354, 2974, 0))"
-cipher,3440,9895,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,68,".location(new WorldPoint(3440, 9895, 0))"
-cipher,3680,3537,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,149,".location(new WorldPoint(3680, 3537, 0))"
-coordinate,1193,2774,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,603,".location(new WorldPoint(1193, 2774, 0))"
-coordinate,1247,3726,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,266,".location(new WorldPoint(1247, 3726, 0))"
-coordinate,1248,3751,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,955,".location(new WorldPoint(1248, 3751, 0))"
-coordinate,1321,3323,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,851,".location(new WorldPoint(1321, 3323, 0))"
-coordinate,1409,3483,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,597,".location(new WorldPoint(1409, 3483, 0))"
-coordinate,1410,3611,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,591,".location(new WorldPoint(1410, 3611, 0))"
-coordinate,1442,3878,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,991,".location(new WorldPoint(1442, 3878, 0))"
-coordinate,1451,3509,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,827,".location(new WorldPoint(1451, 3509, 0))"
-coordinate,1451,3695,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,943,".location(new WorldPoint(1451, 3695, 0))"
-coordinate,1460,3782,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,484,".location(new WorldPoint(1460, 3782, 0))"
-coordinate,1476,3566,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,241,".location(new WorldPoint(1476, 3566, 0))"
-coordinate,1479,3699,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,454,".location(new WorldPoint(1479, 3699, 0))"
-coordinate,1557,3183,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,839,".location(new WorldPoint(1557, 3183, 0))"
-coordinate,1571,3245,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,845,".location(new WorldPoint(1571, 3245, 0))"
-coordinate,1659,3111,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,276,".location(new WorldPoint(1659, 3111, 0))"
-coordinate,1698,3792,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,961,".location(new WorldPoint(1698, 3792, 0))"
-coordinate,1761,3853,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,979,".location(new WorldPoint(1761, 3853, 0))"
-coordinate,1769,3418,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1021,".location(new WorldPoint(1769, 3418, 0))"
-coordinate,1773,3510,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,683,".location(new WorldPoint(1773, 3510, 0))"
-coordinate,2065,3923,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,755,".location(new WorldPoint(2065, 3923, 0))"
-coordinate,2081,3184,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,857,".location(new WorldPoint(2081, 3184, 0))"
-coordinate,2090,3863,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,985,".location(new WorldPoint(2090, 3863, 0))"
-coordinate,2094,2889,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,821,".location(new WorldPoint(2094, 2889, 0))"
-coordinate,2155,3100,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,870,".location(new WorldPoint(2155, 3100, 0))"
-coordinate,2178,3209,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,864,".location(new WorldPoint(2178, 3209, 0))"
-coordinate,2180,3282,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,635,".location(new WorldPoint(2180, 3282, 0))"
-coordinate,2181,3206,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,293,".location(new WorldPoint(2181, 3206, 0))"
-coordinate,2194,3807,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,731,".location(new WorldPoint(2194, 3807, 0))"
-coordinate,2202,3825,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,973,".location(new WorldPoint(2202, 3825, 0))"
-coordinate,2209,3161,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,287,".location(new WorldPoint(2209, 3161, 0))"
-coordinate,2217,3092,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,876,".location(new WorldPoint(2217, 3092, 0))"
-coordinate,2222,3331,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,803,".location(new WorldPoint(2222, 3331, 0))"
-coordinate,2303,3328,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,907,".location(new WorldPoint(2303, 3328, 0))"
-coordinate,2316,3814,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,785,".location(new WorldPoint(2316, 3814, 0))"
-coordinate,2318,2954,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,815,".location(new WorldPoint(2318, 2954, 0))"
-coordinate,2322,3061,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,126,".location(new WorldPoint(2322, 3061, 0))"
-coordinate,2339,3311,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,358,".location(new WorldPoint(2339, 3311, 0))"
-coordinate,2341,3697,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,574,".location(new WorldPoint(2341, 3697, 0))"
-coordinate,2357,3151,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,610,".location(new WorldPoint(2357, 3151, 0))"
-coordinate,2359,3799,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,725,".location(new WorldPoint(2359, 3799, 0))"
-coordinate,2363,3531,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,226,".location(new WorldPoint(2363, 3531, 0))"
-coordinate,2381,3468,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,196,".location(new WorldPoint(2381, 3468, 0))"
-coordinate,2383,3370,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,156,".location(new WorldPoint(2383, 3370, 0))"
-coordinate,2387,3435,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,186,".location(new WorldPoint(2387, 3435, 0))"
-coordinate,2416,3516,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,216,".location(new WorldPoint(2416, 3516, 0))"
-coordinate,2479,3158,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,66,".location(new WorldPoint(2479, 3158, 0))"
-coordinate,2484,4016,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,797,".location(new WorldPoint(2484, 4016, 0))"
-coordinate,2505,3899,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,538,".location(new WorldPoint(2505, 3899, 0))"
-coordinate,2511,2980,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,653,".location(new WorldPoint(2511, 2980, 0))"
-coordinate,2512,3467,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,191,".location(new WorldPoint(2512, 3467, 0))"
-coordinate,2537,3881,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,256,".location(new WorldPoint(2537, 3881, 0))"
-coordinate,2538,3739,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,949,".location(new WorldPoint(2538, 3739, 0))"
-coordinate,2542,3031,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,340,".location(new WorldPoint(2542, 3031, 0))"
-coordinate,2581,3030,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,346,".location(new WorldPoint(2581, 3030, 0))"
-coordinate,2583,2990,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,146,".location(new WorldPoint(2583, 2990, 0))"
-coordinate,2585,3505,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,206,".location(new WorldPoint(2585, 3505, 0))"
-coordinate,2594,2899,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,181,".location(new WorldPoint(2594, 2899, 0))"
-coordinate,2643,3252,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,121,".location(new WorldPoint(2643, 3252, 0))"
-coordinate,2679,3110,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,106,".location(new WorldPoint(2679, 3110, 0))"
-coordinate,2681,3653,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,251,".location(new WorldPoint(2681, 3653, 0))"
-coordinate,2697,2705,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,707,".location(new WorldPoint(2697, 2705, 0))"
-coordinate,2697,3207,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,101,".location(new WorldPoint(2697, 3207, 0))"
-coordinate,2699,3251,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,310,".location(new WorldPoint(2699, 3251, 0))"
-coordinate,2700,3808,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,737,".location(new WorldPoint(2700, 3808, 0))"
-coordinate,2712,3732,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,460,".location(new WorldPoint(2712, 3732, 0))"
-coordinate,2732,3284,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,895,".location(new WorldPoint(2732, 3284, 0))"
-coordinate,2732,3372,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,659,".location(new WorldPoint(2732, 3372, 0))"
-coordinate,2735,3638,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,246,".location(new WorldPoint(2735, 3638, 0))"
-coordinate,2743,3151,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,76,".location(new WorldPoint(2743, 3151, 0))"
-coordinate,2763,2974,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,370,".location(new WorldPoint(2763, 2974, 0))"
-coordinate,2775,2891,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,406,".location(new WorldPoint(2775, 2891, 0))"
-coordinate,2778,3678,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,713,".location(new WorldPoint(2778, 3678, 0))"
-coordinate,2820,3078,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,622,".location(new WorldPoint(2820, 3078, 0))"
-coordinate,2827,3740,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,719,".location(new WorldPoint(2827, 3740, 0))"
-coordinate,2828,3234,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,261,".location(new WorldPoint(2828, 3234, 0))"
-coordinate,2834,3271,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,889,".location(new WorldPoint(2834, 3271, 0))"
-coordinate,2838,2914,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,388,".location(new WorldPoint(2838, 2914, 0))"
-coordinate,2840,3423,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,919,".location(new WorldPoint(2840, 3423, 0))"
-coordinate,2841,3267,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,328,".location(new WorldPoint(2841, 3267, 0))"
-coordinate,2848,3296,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,141,".location(new WorldPoint(2848, 3296, 0))"
-coordinate,2849,3033,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,136,".location(new WorldPoint(2849, 3033, 0))"
-coordinate,2853,3690,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,430,".location(new WorldPoint(2853, 3690, 0))"
-coordinate,2870,2997,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,641,".location(new WorldPoint(2870, 2997, 0))"
-coordinate,2872,3937,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,791,".location(new WorldPoint(2872, 3937, 0))"
-coordinate,2875,3046,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,131,".location(new WorldPoint(2875, 3046, 0))"
-coordinate,2887,3154,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,71,".location(new WorldPoint(2887, 3154, 0))"
-coordinate,2892,3675,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,418,".location(new WorldPoint(2892, 3675, 0))"
-coordinate,2896,3119,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,96,".location(new WorldPoint(2896, 3119, 0))"
-coordinate,2919,3535,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,231,".location(new WorldPoint(2919, 3535, 0))"
-coordinate,2920,3403,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,176,".location(new WorldPoint(2920, 3403, 0))"
-coordinate,2924,2963,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,382,".location(new WorldPoint(2924, 2963, 0))"
-coordinate,2934,2727,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,937,".location(new WorldPoint(2934, 2727, 0))"
-coordinate,2936,2721,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,701,".location(new WorldPoint(2936, 2721, 0))"
-coordinate,2946,3819,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,502,".location(new WorldPoint(2946, 3819, 0))"
-coordinate,2950,2902,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,400,".location(new WorldPoint(2950, 2902, 0))"
-coordinate,2951,3820,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,967,".location(new WorldPoint(2951, 3820, 0))"
-coordinate,2961,3024,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,352,".location(new WorldPoint(2961, 3024, 0))"
-coordinate,2970,3749,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,466,".location(new WorldPoint(2970, 3749, 0))"
-coordinate,2970,3913,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,586,".location(new WorldPoint(2970, 3913, 0))"
-coordinate,2987,3963,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,562,".location(new WorldPoint(2987, 3963, 0))"
-coordinate,3005,3475,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,201,".location(new WorldPoint(3005, 3475, 0))"
-coordinate,3007,3144,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,91,".location(new WorldPoint(3007, 3144, 0))"
-coordinate,3013,3846,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,514,".location(new WorldPoint(3013, 3846, 0))"
-coordinate,3028,3928,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1015,".location(new WorldPoint(3028, 3928, 0))"
-coordinate,3039,3960,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,556,".location(new WorldPoint(3039, 3960, 0))"
-coordinate,3043,3940,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,767,".location(new WorldPoint(3043, 3940, 0))"
-coordinate,3051,3736,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,779,".location(new WorldPoint(3051, 3736, 0))"
-coordinate,3055,3696,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,442,".location(new WorldPoint(3055, 3696, 0))"
-coordinate,3058,3884,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,520,".location(new WorldPoint(3058, 3884, 0))"
-coordinate,3081,3209,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,299,".location(new WorldPoint(3081, 3209, 0))"
-coordinate,3085,3569,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,931,".location(new WorldPoint(3085, 3569, 0))"
-coordinate,3094,3764,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,472,".location(new WorldPoint(3094, 3764, 0))"
-coordinate,3113,3602,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,412,".location(new WorldPoint(3113, 3602, 0))"
-coordinate,3121,3384,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,166,".location(new WorldPoint(3121, 3384, 0))"
-coordinate,3138,2969,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,376,".location(new WorldPoint(3138, 2969, 0))"
-coordinate,3140,3804,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,496,".location(new WorldPoint(3140, 3804, 0))"
-coordinate,3143,3774,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,580,".location(new WorldPoint(3143, 3774, 0))"
-coordinate,3159,3959,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,550,".location(new WorldPoint(3159, 3959, 0))"
-coordinate,3160,3251,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,116,".location(new WorldPoint(3160, 3251, 0))"
-coordinate,3168,3041,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,334,".location(new WorldPoint(3168, 3041, 0))"
-coordinate,3168,3677,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,424,".location(new WorldPoint(3168, 3677, 0))"
-coordinate,3179,3344,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,151,".location(new WorldPoint(3179, 3344, 0))"
-coordinate,3183,2453,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,281,".location(new WorldPoint(3183, 2453, 0))"
-coordinate,3184,3150,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,81,".location(new WorldPoint(3184, 3150, 0))"
-coordinate,3188,3933,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,761,".location(new WorldPoint(3188, 3933, 0))"
-coordinate,3188,3939,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1003,".location(new WorldPoint(3188, 3939, 0))"
-coordinate,3189,3963,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,568,".location(new WorldPoint(3189, 3963, 0))"
-coordinate,3215,3835,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,743,".location(new WorldPoint(3215, 3835, 0))"
-coordinate,3217,3177,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,86,".location(new WorldPoint(3217, 3177, 0))"
-coordinate,3225,2838,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,677,".location(new WorldPoint(3225, 2838, 0))"
-coordinate,3244,3792,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,490,".location(new WorldPoint(3244, 3792, 0))"
-coordinate,3285,3942,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,544,".location(new WorldPoint(3285, 3942, 0))"
-coordinate,3290,3889,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,526,".location(new WorldPoint(3290, 3889, 0))"
-coordinate,3302,2988,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,647,".location(new WorldPoint(3302, 2988, 0))"
-coordinate,3302,3696,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,448,".location(new WorldPoint(3302, 3696, 0))"
-coordinate,3304,3941,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1009,".location(new WorldPoint(3304, 3941, 0))"
-coordinate,3305,3692,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,436,".location(new WorldPoint(3305, 3692, 0))"
-coordinate,3311,3769,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,478,".location(new WorldPoint(3311, 3769, 0))"
-coordinate,3312,3375,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,161,".location(new WorldPoint(3312, 3375, 0))"
-coordinate,3318,2706,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,833,".location(new WorldPoint(3318, 2706, 0))"
-coordinate,3369,3894,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,749,".location(new WorldPoint(3369, 3894, 0))"
-coordinate,3380,3929,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,997,".location(new WorldPoint(3380, 3929, 0))"
-coordinate,3380,3963,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,773,".location(new WorldPoint(3380, 3963, 0))"
-coordinate,3399,3246,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,305,".location(new WorldPoint(3399, 3246, 0))"
-coordinate,3429,3523,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,221,".location(new WorldPoint(3429, 3523, 0))"
-coordinate,3430,3388,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,171,".location(new WorldPoint(3430, 3388, 0))"
-coordinate,3440,3341,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,364,".location(new WorldPoint(3440, 3341, 0))"
-coordinate,3441,3419,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,394,".location(new WorldPoint(3441, 3419, 0))"
-coordinate,3443,3515,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,211,".location(new WorldPoint(3443, 3515, 0))"
-coordinate,3510,3074,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,111,".location(new WorldPoint(3510, 3074, 0))"
-coordinate,3544,3256,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,322,".location(new WorldPoint(3544, 3256, 0))"
-coordinate,3546,3251,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,316,".location(new WorldPoint(3546, 3251, 0))"
-coordinate,3548,3560,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,236,".location(new WorldPoint(3548, 3560, 0))"
-coordinate,3560,3987,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,809,".location(new WorldPoint(3560, 3987, 0))"
-coordinate,3570,3405,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,913,".location(new WorldPoint(3570, 3405, 0))"
-coordinate,3573,3425,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,665,".location(new WorldPoint(3573, 3425, 0))"
-coordinate,3587,3180,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,616,".location(new WorldPoint(3587, 3180, 0))"
-coordinate,3603,3564,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,695,".location(new WorldPoint(3603, 3564, 0))"
-coordinate,3604,3564,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,925,".location(new WorldPoint(3604, 3564, 0))"
-coordinate,3622,3320,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,901,".location(new WorldPoint(3622, 3320, 0))"
-coordinate,3764,3900,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,271,".location(new WorldPoint(3764, 3900, 0))"
-coordinate,3765,3899,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,532,".location(new WorldPoint(3765, 3899, 0))"
-coordinate,3771,3825,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,508,".location(new WorldPoint(3771, 3825, 0))"
-coordinate,3811,3060,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,628,".location(new WorldPoint(3811, 3060, 0))"
-coordinate,3822,3562,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,689,".location(new WorldPoint(3822, 3562, 0))"
-coordinate,3828,2848,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,671,".location(new WorldPoint(3828, 2848, 0))"
-coordinate,3830,3060,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,882,".location(new WorldPoint(3830, 3060, 0))"
-cryptic,1179,3626,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1761,".location(new WorldPoint(1179, 3626, 0))"
-cryptic,1310,1251,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1068,".location(new WorldPoint(1310, 1251, 0))"
-cryptic,1367,3367,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2014,".location(new WorldPoint(1367, 3367, 0))"
-cryptic,1388,3216,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2026,".location(new WorldPoint(1388, 3216, 0))"
-cryptic,1390,2926,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2007,".location(new WorldPoint(1390, 2926, 0))"
-cryptic,1418,3591,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1921,".location(new WorldPoint(1418, 3591, 0))"
-cryptic,1432,9584,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1988,".location(new WorldPoint(1432, 9584, 1))"
-cryptic,1486,3834,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1369,".location(new WorldPoint(1486, 3834, 0))"
-cryptic,1490,3257,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1995,".location(new WorldPoint(1490, 3257, 0))"
-cryptic,1506,3590,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1934,".location(new WorldPoint(1506, 3590, 2))"
-cryptic,1560,3048,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1974,".location(new WorldPoint(1560, 3048, 2))"
-cryptic,1633,3808,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1586,".location(new WorldPoint(1633, 3808, 0))"
-cryptic,1633,3825,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1712,".location(new WorldPoint(1633, 3825, 2))"
-cryptic,1639,3673,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1693,".location(new WorldPoint(1639, 3673, 0))"
-cryptic,1646,3631,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1255,".location(new WorldPoint(1646, 3631, 0))"
-cryptic,1683,3616,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1732,".location(new WorldPoint(1683, 3616, 0))"
-cryptic,1703,3524,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1593,".location(new WorldPoint(1703, 3524, 0))"
-cryptic,1718,3626,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1942,".location(new WorldPoint(1718, 3626, 0))"
-cryptic,1720,3652,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1619,".location(new WorldPoint(1720, 3652, 1))"
-cryptic,1734,3576,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,274,".location(new WorldPoint(1734, 3576, 0))"
-cryptic,1746,3490,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1472,".location(new WorldPoint(1746, 3490, 0))"
-cryptic,1756,4940,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1145,".location(new WorldPoint(1756, 4940, 0))"
-cryptic,1799,3613,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1927,".location(new WorldPoint(1799, 3613, 0))"
-cryptic,1802,9504,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1981,".location(new WorldPoint(1802, 9504, 0))"
-cryptic,1820,9935,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1949,".location(new WorldPoint(1820, 9935, 0))"
-cryptic,1821,3690,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1824,".location(new WorldPoint(1821, 3690, 0))"
-cryptic,1836,3786,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1522,".location(new WorldPoint(1836, 3786, 0))"
-cryptic,1863,4639,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1307,".location(new WorldPoint(1863, 4639, 0))"
-cryptic,1910,4367,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1249,".location(new WorldPoint(1910, 4367, 0))"
-cryptic,1934,4427,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,789,".location(new WorldPoint(1934, 4427, 0))"
-cryptic,2186,3148,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1901,".location(new WorldPoint(2186, 3148, 0))"
-cryptic,2204,3050,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,445,".location(new WorldPoint(2204, 3050, 0))"
-cryptic,2221,3091,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1895,".location(new WorldPoint(2221, 3091, 0))"
-cryptic,2288,4702,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1241,".location(new WorldPoint(2288, 4702, 0))"
-cryptic,2324,2772,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2040,".location(new WorldPoint(2324, 2772, 0))"
-cryptic,2333,3165,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1908,".location(new WorldPoint(2333, 3165, 0))"
-cryptic,2336,3799,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,932,".location(new WorldPoint(2336, 3799, 0))"
-cryptic,2342,3677,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1706,".location(new WorldPoint(2342, 3677, 0))"
-cryptic,2386,3487,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1170,".location(new WorldPoint(2386, 3487, 0))"
-cryptic,2410,4714,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1294,".location(new WorldPoint(2410, 4714, 0))"
-cryptic,2444,3049,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1752,".location(new WorldPoint(2444, 3049, 0))"
-cryptic,2458,3504,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1119,".location(new WorldPoint(2458, 3504, 0))"
-cryptic,2476,3428,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,649,".location(new WorldPoint(2476, 3428, 0))"
-cryptic,2488,3409,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1021,".location(new WorldPoint(2488, 3409, 1))"
-cryptic,2490,3488,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,149,".location(new WorldPoint(2490, 3488, 0))"
-cryptic,2512,3641,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1110,".location(new WorldPoint(2512, 3641, 1))"
-cryptic,2523,3493,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,693,".location(new WorldPoint(2523, 3493, 1))"
-cryptic,2523,3739,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1321,".location(new WorldPoint(2523, 3739, 0))"
-cryptic,2527,3891,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,140,".location(new WorldPoint(2527, 3891, 0))"
-cryptic,2529,2838,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1739,".location(new WorldPoint(2529, 2838, 0))"
-cryptic,2544,3170,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,479,".location(new WorldPoint(2544, 3170, 0))"
-cryptic,2561,3323,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1961,".location(new WorldPoint(2561, 3323, 0))"
-cryptic,2570,3085,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1327,".location(new WorldPoint(2570, 3085, 0))"
-cryptic,2570,3250,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,684,".location(new WorldPoint(2570, 3250, 0))"
-cryptic,2574,3326,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,604,".location(new WorldPoint(2574, 3326, 1))"
-cryptic,2574,3326,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1396,".location(new WorldPoint(2574, 3326, 1))"
-cryptic,2576,3464,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,748,".location(new WorldPoint(2576, 3464, 0))"
-cryptic,2576,9583,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,904,".location(new WorldPoint(2576, 9583, 0))"
-cryptic,2591,3879,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,557,".location(new WorldPoint(2591, 3879, 0))"
-cryptic,2593,3108,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,495,".location(new WorldPoint(2593, 3108, 1))"
-cryptic,2598,3105,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,714,".location(new WorldPoint(2598, 3105, 0))"
-cryptic,2598,3267,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,232,".location(new WorldPoint(2598, 3267, 0))"
-cryptic,2608,3116,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,959,".location(new WorldPoint(2608, 3116, 0))"
-cryptic,2611,3324,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,213,".location(new WorldPoint(2611, 3324, 1))"
-cryptic,2612,3304,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,419,".location(new WorldPoint(2612, 3304, 1))"
-cryptic,2614,3204,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,199,".location(new WorldPoint(2614, 3204, 0))"
-cryptic,2615,3291,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1537,".location(new WorldPoint(2615, 3291, 0))"
-cryptic,2617,3347,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,267,".location(new WorldPoint(2617, 3347, 0))"
-cryptic,2635,3310,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,987,".location(new WorldPoint(2635, 3310, 0))"
-cryptic,2636,3453,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,98,".location(new WorldPoint(2636, 3453, 0))"
-cryptic,2638,2656,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1314,".location(new WorldPoint(2638, 2656, 0))"
-cryptic,2645,3338,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1349,".location(new WorldPoint(2645, 3338, 0))"
-cryptic,2653,3320,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1089,".location(new WorldPoint(2653, 3320, 0))"
-cryptic,2654,3299,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1458,".location(new WorldPoint(2654, 3299, 0))"
-cryptic,2660,3149,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,245,".location(new WorldPoint(2660, 3149, 0))"
-cryptic,2671,3437,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1179,".location(new WorldPoint(2671, 3437, 0))"
-cryptic,2671,10396,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1551,".location(new WorldPoint(2671, 10396, 0))"
-cryptic,2672,3416,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,635,".location(new WorldPoint(2672, 3416, 0))"
-cryptic,2682,3325,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1674,".location(new WorldPoint(2682, 3325, 0))"
-cryptic,2689,3550,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,126,".location(new WorldPoint(2689, 3550, 0))"
-cryptic,2699,3470,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,171,".location(new WorldPoint(2699, 3470, 0))"
-cryptic,2703,3409,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,762,".location(new WorldPoint(2703, 3409, 1))"
-cryptic,2707,3488,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,514,".location(new WorldPoint(2707, 3488, 2))"
-cryptic,2709,3478,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1529,".location(new WorldPoint(2709, 3478, 0))"
-cryptic,2716,3471,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,925,".location(new WorldPoint(2716, 3471, 1))"
-cryptic,2723,9891,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1681,".location(new WorldPoint(2723, 9891, 0))"
-cryptic,2733,3415,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,69,".location(new WorldPoint(2733, 3415, 0))"
-cryptic,2736,3578,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,721,".location(new WorldPoint(2736, 3578, 0))"
-cryptic,2737,3580,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,563,".location(new WorldPoint(2737, 3580, 0))"
-cryptic,2744,5116,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1403,".location(new WorldPoint(2744, 5116, 0))"
-cryptic,2745,3151,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,192,".location(new WorldPoint(2745, 3151, 0))"
-cryptic,2748,3495,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1493,".location(new WorldPoint(2748, 3495, 2))"
-cryptic,2759,2775,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1193,".location(new WorldPoint(2759, 2775, 0))"
-cryptic,2759,3497,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,185,".location(new WorldPoint(2759, 3497, 0))"
-cryptic,2764,3273,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,966,".location(new WorldPoint(2764, 3273, 0))"
-cryptic,2779,3211,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,741,".location(new WorldPoint(2779, 3211, 0))"
-cryptic,2780,3783,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,671,".location(new WorldPoint(2780, 3783, 0))"
-cryptic,2791,3183,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,734,".location(new WorldPoint(2791, 3183, 0))"
-cryptic,2799,3438,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,156,".location(new WorldPoint(2799, 3438, 0))"
-cryptic,2800,3074,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,584,".location(new WorldPoint(2800, 3074, 0))"
-cryptic,2803,3430,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,939,".location(new WorldPoint(2803, 3430, 0))"
-cryptic,2809,3165,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1429,".location(new WorldPoint(2809, 3165, 1))"
-cryptic,2809,3451,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1613,".location(new WorldPoint(2809, 3451, 1))"
-cryptic,2818,3351,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,707,".location(new WorldPoint(2818, 3351, 0))"
-cryptic,2825,3442,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1479,".location(new WorldPoint(2825, 3442, 0))"
-cryptic,2832,9586,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,544,".location(new WorldPoint(2832, 9586, 0))"
-cryptic,2833,2992,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,980,".location(new WorldPoint(2833, 2992, 0))"
-cryptic,2840,3538,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,488,".location(new WorldPoint(2840, 3538, 0))"
-cryptic,2847,3499,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,260,".location(new WorldPoint(2847, 3499, 0))"
-cryptic,2857,2966,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1508,".location(new WorldPoint(2857, 2966, 0))"
-cryptic,2860,3431,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,452,".location(new WorldPoint(2860, 3431, 0))"
-cryptic,2867,3546,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,809,".location(new WorldPoint(2867, 3546, 0))"
-cryptic,2874,3757,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1376,".location(new WorldPoint(2874, 3757, 0))"
-cryptic,2878,3546,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1579,".location(new WorldPoint(2878, 3546, 0))"
-cryptic,2884,3450,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,836,".location(new WorldPoint(2884, 3450, 0))"
-cryptic,2885,3540,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1300,".location(new WorldPoint(2885, 3540, 0))"
-cryptic,2886,3449,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1416,".location(new WorldPoint(2886, 3449, 0))"
-cryptic,2894,3418,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1221,".location(new WorldPoint(2894, 3418, 0))"
-cryptic,2898,3428,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,829,".location(new WorldPoint(2898, 3428, 0))"
-cryptic,2913,3536,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,281,".location(new WorldPoint(2913, 3536, 0))"
-cryptic,2914,3433,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1014,".location(new WorldPoint(2914, 3433, 0))"
-cryptic,2914,5300,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1423,".location(new WorldPoint(2914, 5300, 1))"
-cryptic,2915,3452,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1875,".location(new WorldPoint(2915, 3452, 0))"
-cryptic,2921,3577,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1356,".location(new WorldPoint(2921, 3577, 0))"
-cryptic,2922,3484,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,350,".location(new WorldPoint(2922, 3484, 0))"
-cryptic,2924,3405,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,776,".location(new WorldPoint(2924, 3405, 0))"
-cryptic,2927,3761,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1644,".location(new WorldPoint(2927, 3761, 0))"
-cryptic,2929,3570,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1334,".location(new WorldPoint(2929, 3570, 0))"
-cryptic,2930,3536,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1882,".location(new WorldPoint(2930, 3536, 0))"
-cryptic,2932,3212,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1719,".location(new WorldPoint(2932, 3212, 0))"
-cryptic,2945,3335,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1465,".location(new WorldPoint(2945, 3335, 0))"
-cryptic,2945,3379,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,857,".location(new WorldPoint(2945, 3379, 0))"
-cryptic,2946,3207,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1832,".location(new WorldPoint(2946, 3207, 0))"
-cryptic,2951,3451,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,946,".location(new WorldPoint(2951, 3451, 0))"
-cryptic,2955,3390,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,577,".location(new WorldPoint(2955, 3390, 0))"
-cryptic,2955,3390,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1861,".location(new WorldPoint(2955, 3390, 0))"
-cryptic,2957,3511,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,871,".location(new WorldPoint(2957, 3511, 0))"
-cryptic,2969,3311,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,850,".location(new WorldPoint(2969, 3311, 0))"
-cryptic,2970,3214,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,621,".location(new WorldPoint(2970, 3214, 1))"
-cryptic,2971,3386,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1103,".location(new WorldPoint(2971, 3386, 1))"
-cryptic,2972,3312,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1868,".location(new WorldPoint(2972, 3312, 0))"
-cryptic,2975,3383,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1281,".location(new WorldPoint(2975, 3383, 0))"
-cryptic,2977,3343,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1514,".location(new WorldPoint(2977, 3343, 0))"
-cryptic,2978,3239,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1557,".location(new WorldPoint(2978, 3239, 0))"
-cryptic,2979,3340,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,537,".location(new WorldPoint(2979, 3340, 0))"
-cryptic,2979,3435,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,465,".location(new WorldPoint(2979, 3435, 0))"
-cryptic,2982,3336,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1699,".location(new WorldPoint(2982, 3336, 2))"
-cryptic,2983,3338,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,815,".location(new WorldPoint(2983, 3338, 0))"
-cryptic,3000,9798,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1662,".location(new WorldPoint(3000, 9798, 0))"
-cryptic,3012,3222,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,769,".location(new WorldPoint(3012, 3222, 0))"
-cryptic,3013,3179,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,112,".location(new WorldPoint(3013, 3179, 0))"
-cryptic,3014,3222,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,843,".location(new WorldPoint(3014, 3222, 0))"
-cryptic,3016,3205,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,288,".location(new WorldPoint(3016, 3205, 1))"
-cryptic,3019,3232,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1486,".location(new WorldPoint(3019, 3232, 0))"
-cryptic,3024,3259,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1186,".location(new WorldPoint(3024, 3259, 0))"
-cryptic,3026,3216,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,371,".location(new WorldPoint(3026, 3216, 0))"
-cryptic,3026,3378,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,521,".location(new WorldPoint(3026, 3378, 0))"
-cryptic,3029,3355,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,322,".location(new WorldPoint(3029, 3355, 0))"
-cryptic,3035,9849,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,412,".location(new WorldPoint(3035, 9849, 0))"
-cryptic,3038,3292,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,163,".location(new WorldPoint(3038, 3292, 0))"
-cryptic,3039,3342,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1389,".location(new WorldPoint(3039, 3342, 0))"
-cryptic,3040,3399,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,459,".location(new WorldPoint(3040, 3399, 0))"
-cryptic,3041,3364,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1033,".location(new WorldPoint(3041, 3364, 1))"
-cryptic,3041,9820,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,892,".location(new WorldPoint(3041, 9820, 0))"
-cryptic,3042,3236,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1500,".location(new WorldPoint(3042, 3236, 0))"
-cryptic,3043,4974,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1062,".location(new WorldPoint(3043, 4974, 1))"
-cryptic,3045,3256,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,76,".location(new WorldPoint(3045, 3256, 0))"
-cryptic,3045,10265,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1151,".location(new WorldPoint(3045, 10265, 0))"
-cryptic,3046,3382,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,677,".location(new WorldPoint(3046, 3382, 0))"
-cryptic,3049,4839,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,796,".location(new WorldPoint(3049, 4839, 0))"
-cryptic,3054,3484,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,911,".location(new WorldPoint(3054, 3484, 0))"
-cryptic,3055,10338,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1288,".location(new WorldPoint(3055, 10338, 0))"
-cryptic,3058,3487,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1096,".location(new WorldPoint(3058, 3487, 0))"
-cryptic,3058,3487,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1228,".location(new WorldPoint(3058, 3487, 0))"
-cryptic,3068,3516,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,84,".location(new WorldPoint(3068, 3516, 0))"
-cryptic,3069,3935,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1607,".location(new WorldPoint(3069, 3935, 0))"
-cryptic,3073,3430,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,570,".location(new WorldPoint(3073, 3430, 0))"
-cryptic,3079,3493,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,384,".location(new WorldPoint(3079, 3493, 0))"
-cryptic,3081,3421,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,378,".location(new WorldPoint(3081, 3421, 0))"
-cryptic,3085,3255,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1001,".location(new WorldPoint(3085, 3255, 0))"
-cryptic,3085,3429,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1007,".location(new WorldPoint(3085, 3429, 0))"
-cryptic,3087,3261,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,472,".location(new WorldPoint(3087, 3261, 0))"
-cryptic,3088,3357,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1564,".location(new WorldPoint(3088, 3357, 0))"
-cryptic,3089,3468,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,316,".location(new WorldPoint(3089, 3468, 0))"
-cryptic,3091,3477,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,700,".location(new WorldPoint(3091, 3477, 0))"
-cryptic,3096,9572,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,628,".location(new WorldPoint(3096, 9572, 0))"
-cryptic,3097,3277,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1409,".location(new WorldPoint(3097, 3277, 0))"
-cryptic,3097,3432,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1782,".location(new WorldPoint(3097, 3432, 2))"
-cryptic,3098,3258,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,391,".location(new WorldPoint(3098, 3258, 0))"
-cryptic,3098,3268,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1817,".location(new WorldPoint(3098, 3268, 0))"
-cryptic,3103,3163,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,994,".location(new WorldPoint(3103, 3163, 2))"
-cryptic,3106,3369,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,336,".location(new WorldPoint(3106, 3369, 2))"
-cryptic,3113,3159,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,133,".location(new WorldPoint(3113, 3159, 0))"
-cryptic,3116,9562,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,504,".location(new WorldPoint(3116, 9562, 0))"
-cryptic,3121,9995,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2047,"private static final WorldPoint VIGGORA_EDGEVILLE_DUNGEON = new WorldPoint(3121, 9995, 0);"
-cryptic,3139,4554,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1275,".location(new WorldPoint(3139, 4554, 0))"
-cryptic,3143,3445,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,438,".location(new WorldPoint(3143, 3445, 0))"
-cryptic,3146,3177,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1050,".location(new WorldPoint(3146, 3177, 0))"
-cryptic,3146,9913,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,329,".location(new WorldPoint(3146, 9913, 0))"
-cryptic,3146,9913,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,755,".location(new WorldPoint(3146, 9913, 0))"
-cryptic,3149,3177,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1810,".location(new WorldPoint(3149, 3177, 0))"
-cryptic,3156,3406,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1138,".location(new WorldPoint(3156, 3406, 0))"
-cryptic,3161,9904,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1157,".location(new WorldPoint(3161, 9904, 0))"
-cryptic,3166,3309,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,614,".location(new WorldPoint(3166, 3309, 2))"
-cryptic,3170,3885,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,665,".location(new WorldPoint(3170, 3885, 0))"
-cryptic,3174,3663,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,432,".location(new WorldPoint(3174, 3663, 0))"
-cryptic,3176,2478,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2033,".location(new WorldPoint(3176, 2478, 0))"
-cryptic,3178,2987,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,973,".location(new WorldPoint(3178, 2987, 0))"
-cryptic,3183,3941,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1889,".location(new WorldPoint(3183, 3941, 0))"
-cryptic,3185,3274,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1803,".location(new WorldPoint(3185, 3274, 0))"
-cryptic,3186,3936,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1082,".location(new WorldPoint(3186, 3936, 0))"
-cryptic,3187,9825,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,119,".location(new WorldPoint(3187, 9825, 0))"
-cryptic,3191,9825,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,728,".location(new WorldPoint(3191, 9825, 0))"
-cryptic,3194,3403,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1200,".location(new WorldPoint(3194, 3403, 0))"
-cryptic,3195,3357,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,598,".location(new WorldPoint(3195, 3357, 0))"
-cryptic,3203,3384,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,357,".location(new WorldPoint(3203, 3384, 0))"
-cryptic,3203,3424,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1163,".location(new WorldPoint(3203, 3424, 0))"
-cryptic,3205,3474,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,918,".location(new WorldPoint(3205, 3474, 0))"
-cryptic,3206,3419,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1131,".location(new WorldPoint(3206, 3419, 1))"
-cryptic,3208,3213,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1774,".location(new WorldPoint(3208, 3213, 0))"
-cryptic,3209,3218,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1437,".location(new WorldPoint(3209, 3218, 1))"
-cryptic,3209,3390,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1789,".location(new WorldPoint(3209, 3390, 0))"
-cryptic,3211,3219,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,178,".location(new WorldPoint(3211, 3219, 0))"
-cryptic,3211,3219,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,398,".location(new WorldPoint(3211, 3219, 0))"
-cryptic,3213,3216,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,309,".location(new WorldPoint(3213, 3216, 1))"
-cryptic,3219,9617,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1214,".location(new WorldPoint(3219, 9617, 0))"
-cryptic,3221,3218,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1767,".location(new WorldPoint(3221, 3218, 0))"
-cryptic,3221,3219,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1235,".location(new WorldPoint(3221, 3219, 0))"
-cryptic,3221,3435,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,822,".location(new WorldPoint(3221, 3435, 0))"
-cryptic,3224,3492,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,550,".location(new WorldPoint(3224, 3492, 0))"
-cryptic,3226,3399,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,252,".location(new WorldPoint(3226, 3399, 0))"
-cryptic,3226,3452,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,343,".location(new WorldPoint(3226, 3452, 0))"
-cryptic,3228,3212,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,642,".location(new WorldPoint(3228, 3212, 1))"
-cryptic,3228,3433,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1572,".location(new WorldPoint(3228, 3433, 0))"
-cryptic,3228,3433,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1854,".location(new WorldPoint(3228, 3433, 0))"
-cryptic,3230,3209,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1955,".location(new WorldPoint(3230, 3209, 0))"
-cryptic,3230,3401,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1846,".location(new WorldPoint(3230, 3401, 0))"
-cryptic,3232,3228,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1444,".location(new WorldPoint(3232, 3228, 0))"
-cryptic,3242,3207,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,105,".location(new WorldPoint(3242, 3207, 0))"
-cryptic,3245,3245,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,802,".location(new WorldPoint(3245, 3245, 0))"
-cryptic,3250,3420,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1745,".location(new WorldPoint(3250, 3420, 1))"
-cryptic,3252,9517,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1262,".location(new WorldPoint(3252, 9517, 2))"
-cryptic,3256,3487,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,528,".location(new WorldPoint(3256, 3487, 0))"
-cryptic,3260,3385,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1341,".location(new WorldPoint(3260, 3385, 0))"
-cryptic,3276,3191,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1655,".location(new WorldPoint(3276, 3191, 0))"
-cryptic,3283,3329,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1839,".location(new WorldPoint(3283, 3329, 0))"
-cryptic,3287,3190,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1600,".location(new WorldPoint(3287, 3190, 0))"
-cryptic,3289,3022,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,591,".location(new WorldPoint(3289, 3022, 0))"
-cryptic,3289,3202,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1632,".location(new WorldPoint(3289, 3202, 0))"
-cryptic,3295,3934,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2045,"private static final WorldPoint VIGGORA_ROGUES_CASTLE = new WorldPoint(3295, 3934, 1);"
-cryptic,3297,3890,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1125,".location(new WorldPoint(3297, 3890, 0))"
-cryptic,3301,3169,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1451,".location(new WorldPoint(3301, 3169, 1))"
-cryptic,3303,3123,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1796,".location(new WorldPoint(3303, 3123, 0))"
-cryptic,3303,6092,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1915,".location(new WorldPoint(3303, 6092, 0))"
-cryptic,3307,9505,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1626,".location(new WorldPoint(3307, 9505, 0))"
-cryptic,3308,3206,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1075,".location(new WorldPoint(3308, 3206, 0))"
-cryptic,3345,3378,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,878,".location(new WorldPoint(3345, 3378, 0))"
-cryptic,3353,3332,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,301,".location(new WorldPoint(3353, 3332, 0))"
-cryptic,3362,3341,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,864,".location(new WorldPoint(3362, 3341, 0))"
-cryptic,3367,3221,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,885,".location(new WorldPoint(3367, 3221, 0))"
-cryptic,3371,9320,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,656,".location(new WorldPoint(3371, 9320, 0))"
-cryptic,3376,3284,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,206,".location(new WorldPoint(3376, 3284, 0))"
-cryptic,3388,3152,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,953,".location(new WorldPoint(3388, 3152, 0))"
-cryptic,3410,3324,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,295,".location(new WorldPoint(3410, 3324, 0))"
-cryptic,3444,3461,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,91,".location(new WorldPoint(3444, 3461, 0))"
-cryptic,3447,3547,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2046,"private static final WorldPoint VIGGORA_SLAYER_TOWER = new WorldPoint(3447, 3547, 1);"
-cryptic,3478,3091,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,364,".location(new WorldPoint(3478, 3091, 0))"
-cryptic,3488,3289,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,426,".location(new WorldPoint(3488, 3289, 0))"
-cryptic,3494,3474,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1382,".location(new WorldPoint(3494, 3474, 0))"
-cryptic,3498,3507,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,238,".location(new WorldPoint(3498, 3507, 0))"
-cryptic,3499,3503,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,225,".location(new WorldPoint(3499, 3503, 0))"
-cryptic,3509,3497,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,405,".location(new WorldPoint(3509, 3497, 0))"
-cryptic,3547,3183,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,783,".location(new WorldPoint(3547, 3183, 0))"
-cryptic,3572,4372,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1968,".location(new WorldPoint(3572, 4372, 0))"
-cryptic,3673,3492,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1207,".location(new WorldPoint(3673, 3492, 0))"
-cryptic,3816,3810,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1726,".location(new WorldPoint(3816, 3810, 0))"
-emote,1306,3839,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,164,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP10, ""Clap your hands north of Mount Karuulm Spin before you talk to me. Equip an adamant warhammer, a ring of life and a pair of mithril boots."", ""Mount Karuulm"", NORTH_OF_MOUNT_KARUULM, new WorldPoint(1306, 3839, 0), CLAP, SPIN, item(ItemID.ADAMNT_WARHAMMER), item(ItemID.RING_OF_LIFE), item(ItemID.MITHRIL_ARMOURED_BOOTS)),"
-emote,1436,3115,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,211,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Salute outside the gates of Cam Torum. Beware of double agents! Equip a full set of blue moon equipment."", ""Cam Torum"", CAM_TORUM_ENTRANCE, new WorldPoint(1436, 3115, 0), DOUBLE_AGENT_141, SALUTE, any(""Blue moon helm"", item(ItemID.FROST_MOON_HELM), item(ItemID.FROST_MOON_HELM_DEGRADED)), any(""Blue moon chestplate"", item(ItemID.FROST_MOON_CHESTPLATE), item(ItemID.FROST_MOON_CHESTPLATE_DEGRADED)), any(""Blue moon tassets"", item(ItemID.FROST_MOON_TASSETS), item(ItemID.FROST_MOON_TASSETS_DEGRADED)), item(ItemID.FROSTMOON_SPEAR)),"
-emote,1487,3635,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,215,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP13, ""Shrug in the Shayzien war tent. Equip a blue mystic robe bottom, a rune kiteshield and any bob shirt."", ""Shayzien war tent"", SHAYZIEN_WAR_TENT, new WorldPoint(1487, 3635, 0), SHRUG, item(ItemID.MYSTIC_ROBE_BOTTOM), item(ItemID.RUNE_KITESHIELD), range(""Any bob shirt"", ItemID.TRAIL_BOB_SHIRT_RED, ItemID.TRAIL_BOB_SHIRT_PURPLE)),"
-emote,1543,3623,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,143,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP7, ""Beckon in the Shayzien Combat Ring. Show your anger before you talk to me. Equip an adamant platebody, adamant full helm and adamant platelegs."", ""Shayzien Combat Ring"", WEST_OF_THE_SHAYZIEN_COMBAT_RING, new WorldPoint(1543, 3623, 0), BECKON, ANGRY, item(ItemID.ADAMANT_PLATELEGS), item(ItemID.ADAMANT_PLATEBODY), item(ItemID.ADAMANT_FULL_HELM)),"
-emote,1610,3302,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,226,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Think on the western coast of Salvager Overlook. Beware of double agents! Equip a Hueycoatl hide coif and some Hueycoatl hide vambraces."", ""Salvager Overlook"", WESTERN_SALVAGER_OVERLOOK, new WorldPoint(1610, 3302, 0), DOUBLE_AGENT_141, THINK, item(ItemID.HUEY_COIF), item(ItemID.HUEY_VAMBRACES)),"
-emote,1626,3241,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,196,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_24, ""Nod your head where the River Ortus meets the Proudspire. Indicate 'no' before you talk to me. Equip a blue wizard hat, a blue wizard robe and wear nothing on your legs."", ""East of The Proudspire"", ORTUS_MEETS_PROUDSPIRE, new WorldPoint(1626, 3241, 0), YES, NO, item(ItemID.BLUEWIZHAT), item(ItemID.WIZARDS_ROBE), emptySlot(""Nothing on legs"", LEGS)),"
-emote,1632,3807,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,237,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP8, ""Yawn in the centre of the Arceuus Library. Nod your head before you talk to me. Equip blue dragonhide vambraces, adamant boots and an adamant dagger."", ""Arceuus library"", ENTRANCE_OF_THE_ARCEUUS_LIBRARY, new WorldPoint(1632, 3807, 0), YAWN, YES, item(ItemID.BLUE_DRAGON_VAMBRACES), item(ItemID.ADAMANT_ARMOURED_BOOTS), item(ItemID.ADAMANT_DAGGER)),"
-emote,1646,3631,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,210,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_EXP6, ""Salute in the centre of the mess hall. Beware of double agents! Equip a rune halberd rune platebody and an amulet of strength."", ""Hosidius mess hall"", HOSIDIUS_MESS, new WorldPoint(1646, 3631, 0), DOUBLE_AGENT_108, SALUTE, item(ItemID.RUNE_HALBERD), item(ItemID.RUNE_PLATEBODY), item(ItemID.AMULET_OF_STRENGTH)),"
-emote,1663,10045,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,216,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Slap your head in the centre of the Kourend catacombs. Beware of double agents! Equip arclight or emberlight along with the amulet of the damned."", ""Kourend catacombs"", CENTRE_OF_THE_CATACOMBS_OF_KOUREND, new WorldPoint(1663, 10045, 0), DOUBLE_AGENT_141, SLAP_HEAD, any(""Arclight or Emberlight"", item(ItemID.ARCLIGHT), item(ItemID.ARCLIGHT_INACTIVE), item(ItemID.EMBERLIGHT)), any(""Amulet of the damned"", item(ItemID.DAMNED_AMULET_DEGRADED), item(ItemID.DAMNED_AMULET))),"
-emote,1694,3247,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,203,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_VM2, ""Panic outside the Twilight Temple. Beware of double agents! Equip a rune longsword, rune platebody and a rune plateskirt."", ""Twilight Temple"", OUTSIDE_TWILIGHT_TEMPLE, new WorldPoint(1694, 3247, 0), DOUBLE_AGENT_108, PANIC, item(ItemID.RUNE_LONGSWORD), item(ItemID.RUNE_PLATEBODY), item(ItemID.RUNE_PLATESKIRT)),"
-emote,1699,3087,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,150,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_VM01, ""Bow within the temple in Civitas illa Fortis. Equip any piece of sunfire fanatic armour."", ""Civitas illa Fortis"", TEMPLE_SOUTHEAST_OF_THE_BAZAAR, new WorldPoint(1699, 3087, 0), BOW, any(""Any piece of Sunfire Fanatic armour"", item(ItemID.SUNFIRE_HELM), item(ItemID.SUNFIRE_BODY), item(ItemID.SUNFIRE_LEGS))),"
-emote,1712,3163,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,238,"new EmoteClue(ItemID.TRAIL_EASY_EMOTE_VM01, ""Yawn in the Fortis Grand Museum. Equip an emerald necklace, blue skirt, and turqoise gnome robe top."", ""Fortis Grand Museum"", FORTIS_GRAND_MUSEUM, new WorldPoint(1712, 3163, 0), YAWN, item(ItemID.EMERALD_NECKLACE), item(ItemID.BLUE_SKIRT), item(ItemID.GNOME_ROBETOP_TURQUOISE)),"
-emote,1714,3467,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,246,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP17, ""Salute by the Charcoal Burners. Equip a Farmer's strawhat, Shayzien platebody (5) and Pyromancer robes."", ""Charcoal Burners"", CHARCOAL_BURNERS, new WorldPoint(1714, 3467, 0), SALUTE, any(""Farmer's strawhat"", item(ItemID.TITHE_REWARD_HAT_MALE), item(ItemID.TITHE_REWARD_HAT_FEMALE)), item(ItemID.SHAYZIEN_BODY_5), item(ItemID.PYROMANCER_BOTTOM)),"
-emote,1768,5366,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,188,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP11, ""Jump for joy in the Ancient Cavern. Equip a granite shield, splitbark body and any rune heraldic helm."", ""Ancient cavern"", ENTRANCE_OF_THE_CAVERN_UNDER_THE_WHIRLPOOL, new WorldPoint(1768, 5366, 1), JUMP_FOR_JOY, item(ItemID.GRANITE_SHIELD), item(ItemID.SPLITBARK_BODY), range(""Any rune heraldic helm"", ItemID.TRAIL_HERALDIC_HELM_1_RUNE, ItemID.TRAIL_HERALDIC_HELM_5_RUNE)),"
-emote,1815,3856,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,219,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Spin in front of the Soul altar. Beware of double agents! Equip a dragon pickaxe, helm of neitiznot and a pair of rune boots."", ""Soul altar"", SOUL_ALTAR, new WorldPoint(1815, 3856, 0), DOUBLE_AGENT_141, SPIN, any(""Dragon or Crystal pickaxe"", item(ItemID.DRAGON_PICKAXE), item(ItemID.DRAGON_PICKAXE_PRETTY), item(ItemID.INFERNAL_PICKAXE), item(ItemID.INFERNAL_PICKAXE_EMPTY), item(ItemID.ZALCANO_PICKAXE), item(ItemID.TRAILBLAZER_PICKAXE_NO_INFERNAL), item(ItemID.TRAILBLAZER_RELOADED_PICKAXE_NO_INFERNAL), item(ItemID.CRYSTAL_PICKAXE), item(ItemID.CRYSTAL_PICKAXE_INACTIVE), item(ItemID.TRAILBLAZER_PICKAXE), item(ItemID.TRAILBLAZER_RELOADED_PICKAXE), item(ItemID.TRAILBLAZER_PICKAXE_EMPTY), item(ItemID.TRAILBLAZER_RELOADED_PICKAXE_EMPTY)), item(ItemID.FRIS_KINGLY_HELM), item(ItemID.RUNE_ARMOURED_BOOTS)),"
-emote,1944,4427,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,231,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Yawn in the 7th room of Pyramid Plunder. Beware of double agents! Equip a pharaoh sceptre and a full set of menaphite robes."", ""Pyramid Plunder"", _7TH_CHAMBER_OF_JALSAVRAH, new WorldPoint(1944, 4427, 0), DOUBLE_AGENT_141, YAWN, ANY_PHARAOHS_SCEPTRE, any(""Full set of menaphite robes"", all(item(ItemID.ROGUETRADER_MENAPHITE_HAT), item(ItemID.ROGUETRADER_MENAPHITE_TOP), range(ItemID.ROGUETRADER_MENAPHITE_LEGS, ItemID.ROGUETRADER_MENAPHITE_LEGS2)), all(item(ItemID.ROGUETRADER_MENAPHITE_HAT_RED), item(ItemID.ROGUETRADER_MENAPHITE_TOP_RED), range(ItemID.ROGUETRADER_MENAPHITE_LEGS_RED, ItemID.ROGUETRADER_MENAPHITE_LEGS_RED2)))),"
-emote,1946,4074,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,249,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Bow in front of the cave on Brittle Isle. Beware of double agents! Equip a Medallion of the Deep and a rosewood blowpipe."", ""Brittle Isle"", BRITTLE_ISLE, new WorldPoint(1946, 4074, 0), DOUBLE_AGENT_141, BOW, item(ItemID.MEDALLION_OF_THE_DEEP), item(ItemID.ROSEWOOD_BLOWPIPE)));"
-emote,2011,4712,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,123,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Dance in Iban's temple. Beware of double agents! Equip Iban's staff, a black mystic top and a black mystic bottom."", ""Iban's temple"", WELL_OF_VOYAGE, new WorldPoint(2011, 4712, 0), DOUBLE_AGENT_141, DANCE, any(""Any iban's staff"", item(ItemID.IBANSTAFF), item(ItemID.IBANSTAFF_UPGRADED)), item(ItemID.MYSTIC_ROBE_TOP_DARK), item(ItemID.MYSTIC_ROBE_BOTTOM_DARK)),"
-emote,2069,2608,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,248,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_SAIL, ""Do the crab dance by the monument on Wintumber Island. Equip a crab helmet and a crab claw."", ""Wintumber Island"", WINTUMBER_ISLAND, new WorldPoint(2069, 2608, 0), CRAB_DANCE, item(ItemID.HUNDRED_PIRATE_CRAB_SHELL_HELM), item(ItemID.HUNDRED_PIRATE_CRAB_SHELL_GAUNTLET)),"
-emote,2199,3056,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,190,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Jump for joy in the centre of Zul-Andra. Beware of double agents! Equip a dragon 2h sword, bandos boots and an obsidian cape."", ""Zul-Andra"", NEAR_THE_PIER_IN_ZULANDRA, new WorldPoint(2199, 3056, 0), DOUBLE_AGENT_141, JUMP_FOR_JOY, item(ItemID.DRAGON_2H_SWORD), any(""Bandos boots"", item(ItemID.BANDOS_BOOTS), item(ItemID.GUARDIAN_BOOTS), item(ItemID.ECHO_BOOTS)), item(ItemID.TZHAAR_CAPE_OBSIDIAN)),"
-emote,2205,3252,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,144,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Bow near Lord Iorwerth. Beware of double agents! Equip a charged crystal bow."", ""Lord Iorwerth's camp"", TENT_IN_LORD_IORWERTHS_ENCAMPMENT, new WorldPoint(2205, 3252, 0), DOUBLE_AGENT_141, BOW, ACTIVE_CRYSTAL_BOW_OR_BOW_OF_FAERDHINEN),"
-emote,2205,3252,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,145,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Bow in the Iorwerth Camp. Beware of double agents! Equip a charged crystal bow."", ""Lord Iorwerth's camp"", TENT_IN_LORD_IORWERTHS_ENCAMPMENT, new WorldPoint(2205, 3252, 0), DOUBLE_AGENT_141, BOW, ACTIVE_CRYSTAL_BOW_OR_BOW_OF_FAERDHINEN),"
-emote,2205,4838,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,125,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Flap at the death altar. Beware of double agents! Equip a death tiara, a legend's cape and any ring of wealth."", ""Death altar"", DEATH_ALTAR, new WorldPoint(2205, 4838, 0), DOUBLE_AGENT_141, FLAP, ANY_RING_OF_WEALTH, item(ItemID.TIARA_DEATH), item(ItemID.CAPE_OF_LEGENDS)),"
-emote,2207,4952,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,135,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE017, ""Cheer at the games room. Have nothing equipped at all when you do."", ""Burthorpe Games Room"", null, new WorldPoint(2207, 4952, 0), CHEER, emptySlot(""Nothing at all"", EquipmentInventorySlot.values())),"
-emote,2211,3427,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,140,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Beckon by a collection of crystalline maple trees. Beware of double agents! Equip Bryophyta's staff and a nature tiara."", ""North of Prifddinas"", CRYSTALLINE_MAPLE_TREES, new WorldPoint(2211, 3427, 0), DOUBLE_AGENT_141, BECKON, range(""Bryophyta's staff"", ItemID.NATURE_STAFF_UNCHARGED, ItemID.NATURE_STAFF_CHARGED), item(ItemID.TIARA_NATURE)),"
-emote,2271,4680,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,176,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Dance in the King Black Dragon's lair. Beware of double agents! Equip a black dragonhide body, black dragonhide vambraces and a black dragon mask."", ""King black dragon's lair"", KING_BLACK_DRAGONS_LAIR, new WorldPoint(2271, 4680, 0), DOUBLE_AGENT_141, DANCE, item(ItemID.BLACK_DRAGONHIDE_BODY), item(ItemID.BLACK_DRAGON_VAMBRACES), item(ItemID.DRAGONMASK_BLACK)),"
-emote,2375,3850,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,189,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP2, ""Jump for joy at the Neitiznot rune rock. Equip Rune boots, a proselyte hauberk and a dragonstone ring."", ""Fremennik Isles"", NEAR_A_RUNITE_ROCK_IN_THE_FREMENNIK_ISLES, new WorldPoint(2375, 3850, 0), JUMP_FOR_JOY, item(ItemID.RUNE_ARMOURED_BOOTS), item(ItemID.BASIC_TK_RANK2_BODY), item(ItemID.DRAGONSTONE_RING)),"
-emote,2439,3161,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,225,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE009, ""Think in the centre of the Observatory. Spin before you talk to me. Equip a mithril chain body, green dragonhide chaps and a ruby amulet."", ""Observatory"", OBSERVATORY, new WorldPoint(2439, 3161, 0), THINK, SPIN, item(ItemID.MITHRIL_CHAINBODY), item(ItemID.DRAGONHIDE_CHAPS), item(ItemID.STRUNG_RUBY_AMULET)),"
-emote,2440,3092,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,234,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE005, ""Yawn in the Castle Wars lobby. Shrug before you talk to me. Equip a ruby amulet, a mithril scimitar and a Wilderness cape."", ""Castle Wars"", CASTLE_WARS_BANK, new WorldPoint(2440, 3092, 0), YAWN, SHRUG, item(ItemID.STRUNG_RUBY_AMULET), item(ItemID.MITHRIL_SCIMITAR), ANY_TEAM_CAPE),"
-emote,2463,5149,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,168,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Cry in the TzHaar gem store. Beware of double agents! Equip a fire cape and TokTz-Xil-Ul."", ""Tzhaar gem store"", TZHAAR_GEM_STORE, new WorldPoint(2463, 5149, 0), DOUBLE_AGENT_141, CRY, any(""Fire cape"", item(ItemID.TZHAAR_CAPE_FIRE), item(ItemID.TZHAAR_CAPE_FIRE_TROUVER), item(ItemID.SKILLCAPE_MAX_FIRECAPE), item(ItemID.SKILLCAPE_MAX_FIRECAPE_TROUVER), item(ItemID.INFERNAL_CAPE), item(ItemID.INFERNAL_CAPE_TROUVER), item(ItemID.SKILLCAPE_MAX_INFERNALCAPE), item(ItemID.SKILLCAPE_MAX_INFERNALCAPE_TROUVER)), item(ItemID.TZHAAR_THROWINGRING)),"
-emote,2473,3420,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,167,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE007, ""Cry on top of the western tree in the Gnome Agility Arena. Indicate 'no' before you talk to me. Equip a steel kiteshield, ring of forging and green dragonhide chaps."", ""Gnome Stronghold"", GNOME_STRONGHOLD_BALANCING_ROPE, new WorldPoint(2473, 3420, 2), CRY, NO, item(ItemID.STEEL_KITESHIELD), item(ItemID.RING_OF_FORGING), item(ItemID.DRAGONHIDE_CHAPS)),"
-emote,2477,3047,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,134,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_EXP4, ""Jig at Jiggig. Beware of double agents! Equip a Rune spear, rune platelegs and any rune heraldic helm."", ""Jiggig"", IN_THE_MIDDLE_OF_JIGGIG, new WorldPoint(2477, 3047, 0), DOUBLE_AGENT_108, JIG, range(""Any rune heraldic helm"", ItemID.TRAIL_HERALDIC_HELM_1_RUNE, ItemID.TRAIL_HERALDIC_HELM_5_RUNE), item(ItemID.RUNE_SPEAR), item(ItemID.RUNE_PLATELEGS)),"
-emote,2477,5146,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,187,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP5, ""Jump for joy in the TzHaar sword shop. Shrug before you talk to me. Equip a Steel longsword, Blue D'hide body and blue mystic gloves."", ""Tzhaar weapon store"", TZHAAR_WEAPONS_STORE, new WorldPoint(2477, 5146, 0), JUMP_FOR_JOY, SHRUG, item(ItemID.STEEL_LONGSWORD), item(ItemID.BLUE_DRAGONHIDE_BODY), item(ItemID.MYSTIC_GLOVES)),"
-emote,2511,3641,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,149,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE003, ""Bow at the top of the lighthouse. Beware of double agents! Equip a blue dragonhide body, blue dragonhide vambraces and no jewelry."", ""Lighthouse"", TOP_FLOOR_OF_THE_LIGHTHOUSE, new WorldPoint(2511, 3641, 2), DOUBLE_AGENT_108, BOW, item(ItemID.BLUE_DRAGONHIDE_BODY), item(ItemID.BLUE_DRAGON_VAMBRACES), emptySlot(""No jewellery"", AMULET, RING)),"
-emote,2527,3375,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,156,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE010, ""Cheer in the Ogre Pen in the Training Camp. Show you are angry before you talk to me. Equip a green dragonhide body and chaps and a steel square shield."", ""King Lathas' camp"", OGRE_CAGE_IN_KING_LATHAS_TRAINING_CAMP, new WorldPoint(2527, 3375, 0), CHEER, ANGRY, item(ItemID.DRAGONHIDE_BODY), item(ItemID.DRAGONHIDE_CHAPS), item(ItemID.STEEL_SQ_SHIELD)),"
-emote,2530,3290,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,221,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP1, ""Spin in West Ardougne Church. Equip a dragon spear and red dragonhide chaps."", ""West Ardougne Church"", CHAPEL_IN_WEST_ARDOUGNE, new WorldPoint(2530, 3290, 0), SPIN, item(ItemID.DRAGON_SPEAR), item(ItemID.RED_DRAGONHIDE_CHAPS)),"
-emote,2552,3556,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,119,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE006, ""Cheer in the Barbarian Agility Arena. Headbang before you talk to me. Equip a steel platebody, maple shortbow and a Wilderness cape."", ""Barbarian Outpost"", BARBARIAN_OUTPOST_OBSTACLE_COURSE, new WorldPoint(2552, 3556, 0), CHEER, HEADBANG, item(ItemID.STEEL_PLATEBODY), item(ItemID.MAPLE_SHORTBOW), ANY_TEAM_CAPE),"
-emote,2568,3149,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,126,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP16, ""Headbang in the Fight Arena pub. Equip a pirate bandana, a dragonstone necklace and and a magic longbow."", ""Fight Arena pub"", OUTSIDE_THE_BAR_BY_THE_FIGHT_ARENA, new WorldPoint(2568, 3149, 0), HEADBANG, any(""Any pirate bandana"", item(ItemID.PIRATE_BANDANNA), item(ItemID.PIRATE_BANDANA_RED), item(ItemID.PIRATE_BANDANA_BLUE), item(ItemID.PIRATE_BANDANA_BROWN)), item(ItemID.DRAGONSTONE_NECKLACE), item(ItemID.MAGIC_LONGBOW)),"
-emote,2588,3419,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,207,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE002, ""Blow a raspberry in the Fishing Guild bank. Beware of double agents! Equip an elemental shield, blue dragonhide chaps and a rune warhammer."", ""Fishing Guild"", FISHING_GUILD_BANK, new WorldPoint(2588, 3419, 0), DOUBLE_AGENT_108, RASPBERRY, item(ItemID.ELEMENTAL_SHIELD), item(ItemID.BLUE_DRAGONHIDE_CHAPS), item(ItemID.RUNE_WARHAMMER)),"
-emote,2607,3282,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,205,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE019, ""Blow a raspberry at the monkey cage in Ardougne Zoo. Equip a studded leather body, bronze platelegs and a normal staff with no orb."", ""Ardougne Zoo"", NEAR_THE_PARROTS_IN_ARDOUGNE_ZOO, new WorldPoint(2607, 3282, 0), RASPBERRY, item(ItemID.STUDDED_BODY), item(ItemID.BRONZE_PLATELEGS), item(ItemID.PLAINSTAFF)),"
-emote,2610,3092,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,186,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE008, ""Jump for joy in Yanille bank. Dance a jig before you talk to me. Equip a brown apron, adamantite medium helmet and snakeskin chaps."", ""Yanille"", OUTSIDE_YANILLE_BANK, new WorldPoint(2610, 3092, 0), JUMP_FOR_JOY, JIG, item(ItemID.BROWN_APRON), item(ItemID.ADAMANT_MED_HELM), item(ItemID.SNAKESKIN_CHAPS)),"
-emote,2610,3391,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,182,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE021, ""Dance a jig by the entrance to the Fishing Guild. Equip an emerald ring, a sapphire amulet, and a bronze chain body."", ""Fishing Guild"", OUTSIDE_THE_FISHING_GUILD, new WorldPoint(2610, 3391, 0), JIG, item(ItemID.EMERALD_RING), item(ItemID.STRUNG_SAPPHIRE_AMULET), item(ItemID.BRONZE_CHAINBODY)),"
-emote,2629,5071,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,121,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP4, ""Cheer in the Shadow dungeon. Equip a rune crossbow, climbing boots and any mitre."", ""Shadow dungeon"", ENTRANCE_OF_THE_CAVE_OF_DAMIS, new WorldPoint(2629, 5071, 0), CHEER, any(""Any mitre"", item(ItemID.TRAIL_GUTHIX_MITRE), item(ItemID.TRAIL_SARADOMIN_MITRE), item(ItemID.TRAIL_ZAMORAK_MITRE), item(ItemID.TRAIL_ANCIENT_MITRE), item(ItemID.TRAIL_BANDOS_MITRE), item(ItemID.TRAIL_ARMADYL_MITRE)), any(""Rune crossbow"", item(ItemID.XBOWS_CROSSBOW_RUNITE), item(ItemID.LEAGUE_3_RUNE_XBOW)), any(""Climbing boots"", item(ItemID.DEATH_CLIMBINGBOOTS), item(ItemID.CLIMBING_BOOTS_G)), any(""Ring of visibility or ring of shadows"", item(ItemID.FD_RING_VISIBILITY), item(ItemID.RING_OF_SHADOWS), item(ItemID.RING_OF_SHADOWS_UNCHARGED))),"
-emote,2635,3385,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,161,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE014, ""Clap on the top level of the mill, north of East Ardougne. Equip a blue gnome robe top, HAM robe bottom and an unenchanted tiara."", ""East Ardougne"", UPSTAIRS_IN_THE_ARDOUGNE_WINDMILL, new WorldPoint(2635, 3385, 2), CLAP, item(ItemID.GNOME_ROBETOP_BLUE), item(ItemID.HAM_ROBE), item(ItemID.TIARA)),"
-emote,2666,3304,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,195,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP15, ""Laugh in front of the gem store in Ardougne market. Equip a Castlewars bracelet, a dragonstone amulet and a ring of forging."", ""Ardougne"", NEAR_THE_GEM_STALL_IN_ARDOUGNE_MARKET, new WorldPoint(2666, 3304, 0), LAUGH, any(""Castle wars bracelet"", range(ItemID.JEWL_CASTLEWARS_BRACELET3, ItemID.JEWL_CASTLEWARS_BRACELET)), item(ItemID.STRUNG_DRAGONSTONE_AMULET), item(ItemID.RING_OF_FORGING)),"
-emote,2676,3169,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,136,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE023, ""Panic on the pier where you catch the Fishing trawler. Have nothing equipped at all when you do."", ""Fishing trawler"", null, new WorldPoint(2676, 3169, 0), PANIC, emptySlot(""Nothing at all"", EquipmentInventorySlot.values())),"
-emote,2728,3377,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,147,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP14, ""Bow on the ground floor of the Legends' Guild. Equip a Cape of Legends, a dragon battleaxe and an amulet of glory."", ""Legend's Guild"", OUTSIDE_THE_LEGENDS_GUILD_DOOR, new WorldPoint(2728, 3377, 0), BOW, item(ItemID.CAPE_OF_LEGENDS), any(""Dragon battleaxe"", item(ItemID.DRAGON_BATTLEAXE), item(ItemID.BH_DRAGON_BATTLEAXE_CORRUPTED)), any(""Any amulet of glory"", item(ItemID.AMULET_OF_GLORY), item(ItemID.AMULET_OF_GLORY_1), item(ItemID.AMULET_OF_GLORY_2), item(ItemID.AMULET_OF_GLORY_3), item(ItemID.AMULET_OF_GLORY_4), item(ItemID.AMULET_OF_GLORY_5), item(ItemID.AMULET_OF_GLORY_6))),"
-emote,2729,3349,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,146,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE005, ""Bow outside the entrance to the Legends' Guild. Equip iron platelegs, an emerald amulet and an oak longbow."", ""Legend's Guild"", OUTSIDE_THE_LEGENDS_GUILD_GATES, new WorldPoint(2729, 3349, 0), BOW, item(ItemID.IRON_PLATELEGS), item(ItemID.OAK_LONGBOW), item(ItemID.STRUNG_EMERALD_AMULET)),"
-emote,2735,3469,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,162,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP3, ""Clap in Seers court house. Spin before you talk to me. Equip an adamant halberd, blue mystic robe bottom and a diamond ring."", ""Seers Village"", OUTSIDE_THE_SEERS_VILLAGE_COURTHOUSE, new WorldPoint(2735, 3469, 0), CLAP, SPIN, item(ItemID.ADAMANT_HALBERD), item(ItemID.MYSTIC_ROBE_BOTTOM), item(ItemID.DIAMOND_RING)),"
-emote,2741,3536,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,194,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE024, ""Laugh at the crossroads south of the Sinclair Mansion. Equip a cowl, a blue wizard robe top and an iron scimitar."", ""Sinclair Mansion"", ROAD_JUNCTION_SOUTH_OF_SINCLAIR_MANSION, new WorldPoint(2741, 3536, 0), LAUGH, item(ItemID.LEATHER_COWL), item(ItemID.WIZARDS_ROBE), item(ItemID.IRON_SCIMITAR)),"
-emote,2757,3401,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,206,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE022, ""Blow raspberries outside the entrance to Keep Le Faye. Equip a coif, an iron platebody and leather gloves."", ""Keep Le Faye"", OUTSIDE_KEEP_LE_FAYE, new WorldPoint(2757, 3401, 0), RASPBERRY, item(ItemID.COIF), item(ItemID.IRON_PLATEBODY), item(ItemID.LEATHER_GLOVES)),"
-emote,2759,3445,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,185,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE018, ""Jump for joy at the beehives. Equip a desert shirt, green gnome robe bottoms and a steel axe."", ""Catherby"", CATHERBY_BEEHIVE_FIELD, new WorldPoint(2759, 3445, 0), JUMP_FOR_JOY, item(ItemID.DESERT_SHIRT), item(ItemID.GNOME_ROBEBOTTOMS_GREEN), item(ItemID.STEEL_AXE)),"
-emote,2776,3781,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,202,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP12, ""Panic at the area flowers meet snow. Equip Blue D'hide vambraces, a dragon spear and a rune plateskirt."", ""Trollweiss mountain"", HALFWAY_DOWN_TROLLWEISS_MOUNTAIN, new WorldPoint(2776, 3781, 0), PANIC, item(ItemID.BLUE_DRAGON_VAMBRACES), item(ItemID.DRAGON_SPEAR), item(ItemID.RUNE_PLATESKIRT), item(ItemID.TROLLROMANCE_TOBOGGON_WAXED)),"
-emote,2782,3273,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,124,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP7, ""Dance on the Fishing Platform. Equip barrows gloves, an amulet of glory and a dragon med helm."", ""Fishing Platform"", SOUTHEAST_CORNER_OF_THE_FISHING_PLATFORM, new WorldPoint(2782, 3273, 0), DANCE, any(""Any amulet of glory"", item(ItemID.AMULET_OF_GLORY), item(ItemID.AMULET_OF_GLORY_1), item(ItemID.AMULET_OF_GLORY_2), item(ItemID.AMULET_OF_GLORY_3), item(ItemID.AMULET_OF_GLORY_4), item(ItemID.AMULET_OF_GLORY_5), item(ItemID.AMULET_OF_GLORY_6)), item(ItemID.HUNDRED_GAUNTLETS_LEVEL_10), item(ItemID.DRAGON_MED_HELM)),"
-emote,2803,3073,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,142,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE004, ""Beckon in Tai Bwo Wannai. Clap before you talk to me. Equip green dragonhide chaps, a ring of dueling and a mithril medium helmet."", ""Tai Bwo Wannai"", SOUTH_OF_THE_SHRINE_IN_TAI_BWO_WANNAI_VILLAGE, new WorldPoint(2803, 3073, 0), BECKON, CLAP, item(ItemID.DRAGONHIDE_CHAPS), any(""Ring of dueling"", item(ItemID.RING_OF_DUELING_1), item(ItemID.RING_OF_DUELING_2), item(ItemID.RING_OF_DUELING_3), item(ItemID.RING_OF_DUELING_4), item(ItemID.RING_OF_DUELING_5), item(ItemID.RING_OF_DUELING_6), item(ItemID.RING_OF_DUELING_7), item(ItemID.RING_OF_DUELING_8)), item(ItemID.MITHRIL_MED_HELM)),"
-emote,2808,3440,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,213,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP2, ""Shrug in Catherby bank. Yawn before you talk to me. Equip a maple longbow, green d'hide chaps and an iron med helm."", ""Catherby"", OUTSIDE_CATHERBY_BANK, new WorldPoint(2808, 3440, 0), SHRUG, YAWN, item(ItemID.MAPLE_LONGBOW), item(ItemID.DRAGONHIDE_CHAPS), item(ItemID.IRON_MED_HELM)),"
-emote,2812,3681,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,193,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE008, ""Laugh in Jokul's tent in the Mountain Camp. Beware of double agents! Equip a rune full helmet, blue dragonhide chaps and a fire battlestaff."", ""Mountain Camp"", MOUNTAIN_CAMP_GOAT_ENCLOSURE, new WorldPoint(2812, 3681, 0), DOUBLE_AGENT_108, LAUGH, item(ItemID.RUNE_FULL_HELM), item(ItemID.BLUE_DRAGONHIDE_CHAPS), item(ItemID.FIRE_BATTLESTAFF)),"
-emote,2823,3443,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,165,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE012, ""Cry in the Catherby Ranging shop. Bow before you talk to me. Equip blue gnome boots, a hard leather body and an unblessed silver sickle."", ""Catherby"", HICKTONS_ARCHERY_EMPORIUM, new WorldPoint(2823, 3443, 0), CRY, BOW, item(ItemID.GNOME_BOOTS_BLUE), item(ItemID.HARDLEATHER_BODY), item(ItemID.SILVER_SICKLE)),"
-emote,2843,3543,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,204,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Blow a raspberry in the bank of the Warriors' Guild. Beware of double agents! Equip a dragon battleaxe, a slayer helm of any kind and a dragon defender or avernic defender."", ""Warriors' guild"", WARRIORS_GUILD_BANK_29047, new WorldPoint(2843, 3543, 0), DOUBLE_AGENT_141, RASPBERRY, any(""Dragon battleaxe"", item(ItemID.DRAGON_BATTLEAXE), item(ItemID.BH_DRAGON_BATTLEAXE_CORRUPTED)), any(""Dragon defender or Avernic defender"", item(ItemID.DRAGON_PARRYINGDAGGER), item(ItemID.DRAGON_PARRYINGDAGGER_T), item(ItemID.DRAGON_PARRYINGDAGGER_TROUVER), item(ItemID.INFERNAL_DEFENDER), item(ItemID.INFERNAL_DEFENDER_TROUVER), item(ItemID.INFERNAL_DEFENDER_GHOMMAL_5), item(ItemID.INFERNAL_DEFENDER_GHOMMAL_5_TROUVER), item(ItemID.INFERNAL_DEFENDER_GHOMMAL_6), item(ItemID.INFERNAL_DEFENDER_GHOMMAL_6_TROUVER)), ANY_SLAYER_HELMET),"
-emote,2844,3542,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,209,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP5, ""Salute in the Warriors' Guild bank. Equip only a black salamander."", ""Warriors' guild"", WARRIORS_GUILD_BANK, new WorldPoint(2844, 3542, 0), SALUTE, item(ItemID.BLACK_SALAMANDER), emptySlot(""Nothing else"", HEAD, CAPE, AMULET, BODY, SHIELD, LEGS, GLOVES, BOOTS, RING, AMMO)),"
-emote,2847,3499,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,200,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE009, ""Panic by the pilot on White Wolf Mountain. Beware of double agents! Equip mithril platelegs, a ring of life and a rune axe."", ""White Wolf Mountain"", GNOME_GLIDER_ON_WHITE_WOLF_MOUNTAIN, new WorldPoint(2847, 3499, 0), DOUBLE_AGENT_108, PANIC, item(ItemID.MITHRIL_PLATELEGS), item(ItemID.RING_OF_LIFE), item(ItemID.RUNE_AXE)),"
-emote,2851,2954,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,151,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE010, ""Blow a kiss between the tables in Shilo Village bank. Beware of double agents! Equip a blue mystic hat, bone spear and rune platebody."", ""Shilo Village"", SHILO_VILLAGE_BANK, new WorldPoint(2851, 2954, 0), DOUBLE_AGENT_108, BLOW_KISS, item(ItemID.MYSTIC_HAT), item(ItemID.CAVE_GOBLIN_BONE_SPEAR), item(ItemID.RUNE_PLATEBODY)),"
-emote,2852,3349,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,157,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Cheer in the Entrana church. Beware of double agents! Equip a full set of black dragonhide armour."", ""Entrana church"", ENTRANA_CHAPEL, new WorldPoint(2852, 3349, 0), DOUBLE_AGENT_141, CHEER, item(ItemID.BLACK_DRAGON_VAMBRACES), item(ItemID.BLACK_DRAGONHIDE_CHAPS), item(ItemID.BLACK_DRAGONHIDE_BODY)),"
-emote,2852,3429,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,166,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP4, ""Cry on the shore of Catherby beach. Laugh before you talk to me, equip an adamant sq shield, a bone dagger and mithril platebody."", ""Catherby"", OUTSIDE_HARRYS_FISHING_SHOP_IN_CATHERBY, new WorldPoint(2852, 3429, 0), CRY, LAUGH, item(ItemID.ADAMANT_SQ_SHIELD), item(ItemID.DTTD_BONE_DAGGER), item(ItemID.MITHRIL_PLATEBODY)),"
-emote,2887,3676,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,236,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP9, ""Yawn at the top of Trollheim. Equip a lava battlestaff, black dragonhide vambraces and a mind shield."", ""Trollheim Mountain"", ON_TOP_OF_TROLLHEIM_MOUNTAIN, new WorldPoint(2887, 3676, 0), YAWN, any(""Lava battlestaff"", item(ItemID.LAVA_BATTLESTAFF), item(ItemID.LAVA_BATTLESTAFF_PRETTY)), item(ItemID.BLACK_DRAGON_VAMBRACES), item(ItemID.ELEMENTAL_MIND_SHIELD)),"
-emote,2914,3168,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,208,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE007, ""Salute in the banana plantation. Beware of double agents! Equip a diamond ring, amulet of power, and nothing on your chest and legs."", ""Karamja"", WEST_SIDE_OF_THE_KARAMJA_BANANA_PLANTATION, new WorldPoint(2914, 3168, 0), DOUBLE_AGENT_108, SALUTE, item(ItemID.DIAMOND_RING), item(ItemID.AMULET_OF_POWER), emptySlot(""Nothing on chest & legs"", BODY, LEGS)),"
-emote,2920,9893,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,192,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP10, ""Laugh by the fountain of heroes. Equip splitbark legs, dragon boots and a Rune longsword."", ""Fountain of heroes"", FOUNTAIN_OF_HEROES, new WorldPoint(2920, 9893, 0), LAUGH, item(ItemID.SPLITBARK_LEGS), any(""Dragon boots"", item(ItemID.DRAGON_BOOTS), item(ItemID.DRAGON_BOOTS_GOLD), item(ItemID.PRIMORDIAL_BOOTS)), item(ItemID.RUNE_LONGSWORD)),"
-emote,2924,3478,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,154,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE016, ""Cheer at the Druids' Circle. Equip a blue wizard hat, a bronze two-handed sword and HAM boots."", ""Taverley stone circle"", TAVERLEY_STONE_CIRCLE, new WorldPoint(2924, 3478, 0), CHEER, item(ItemID.BLUEWIZHAT), item(ItemID.BRONZE_2H_SWORD), item(ItemID.HAM_BOOTS)),"
-emote,2925,5333,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,153,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Blow a kiss outside K'ril Tsutsaroth's chamber. Beware of double agents! Equip a zamorak full helm and the shadow sword."", ""K'ril's chamber"", OUTSIDE_KRIL_TSUTSAROTHS_ROOM, new WorldPoint(2925, 5333, 2), DOUBLE_AGENT_141, BLOW_KISS, item(ItemID.RUNE_FULL_HELM_ZAMORAK), item(ItemID.SHADOW_MAJ_SHADOW_SWORD)),"
-emote,2930,4717,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,239,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Swing a bullroarer at the top of the Watchtower. Beware of double agents! Equip a dragon plateskirt, climbing boots and a dragon chainbody."", ""Yanille Watchtower"", TOP_FLOOR_OF_THE_YANILLE_WATCHTOWER, new WorldPoint(2930, 4717, 2), DOUBLE_AGENT_141, BULL_ROARER, any(""Dragon plateskirt"", item(ItemID.DRAGON_PLATESKIRT), item(ItemID.DRAGON_PLATESKIRT_GOLD)), any(""Climbing boots"", item(ItemID.DEATH_CLIMBINGBOOTS), item(ItemID.CLIMBING_BOOTS_G)), any(""Dragon chainbody"", item(ItemID.DRAGON_CHAINBODY), item(ItemID.DRAGON_CHAINBODY_GOLD)), item(ItemID.BULLROARER)),"
-emote,2945,3335,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,228,"new EmoteClue(ItemID.TRAIL_EASY_EMOTE_EXP2, ""Wave in the Falador gem store. Equip a Mithril pickaxe, Black platebody and an Iron Kiteshield."", ""Falador"", NEAR_HERQUINS_SHOP_IN_FALADOR, new WorldPoint(2945, 3335, 0), WAVE, item(ItemID.MITHRIL_PICKAXE), item(ItemID.BLACK_PLATEBODY), item(ItemID.IRON_KITESHIELD)),"
-emote,2950,3387,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,245,"new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, ""Spin at Flynn's Mace Shop."", ""Falador"", null, new WorldPoint(2950, 3387, 0), SPIN),"
-emote,2954,2933,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,118,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_EXP2, ""Beckon on the east coast of the Kharazi Jungle. Beware of double agents! Equip any vestment stole and a heraldic rune shield."", ""Kharazi Jungle"", NORTHEAST_CORNER_OF_THE_KHARAZI_JUNGLE, new WorldPoint(2954, 2933, 0), DOUBLE_AGENT_108, BECKON, any(""Any stole"", item(ItemID.TRAIL_GUTHIX_SCARF), item(ItemID.TRAIL_SARADOMIN_SCARF), item(ItemID.TRAIL_ZAMORAK_SCARF), item(ItemID.TRAIL_ARMADYL_SCARF), item(ItemID.TRAIL_BANDOS_SCARF), item(ItemID.TRAIL_ANCIENT_SCARF)), any(""Any heraldic rune shield"", item(ItemID.RUNE_HERALDIC_KITESHIELD1), item(ItemID.RUNE_HERALDIC_KITESHIELD2), item(ItemID.RUNE_HERALDIC_KITESHIELD3), item(ItemID.RUNE_HERALDIC_KITESHIELD4), item(ItemID.RUNE_HERALDIC_KITESHIELD5))),"
-emote,2956,3505,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,178,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Goblin Salute in the Goblin Village. Beware of double agents! Equip a bandos godsword, a bandos cloak and a bandos platebody."", ""Goblin Village"", OUTSIDE_MUDKNUCKLES_HUT, new WorldPoint(2956, 3505, 0), DOUBLE_AGENT_141, GOBLIN_SALUTE, item(ItemID.RUNE_PLATEBODY_BANDOS), item(ItemID.TRAIL_BANDOS_CLOAK), any(""Bandos godsword"", item(ItemID.BGS), item(ItemID.BGSG))),"
-emote,2976,3238,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,212,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE012, ""Shrug in the mine near Rimmington. Equip a gold necklace, a gold ring and a bronze spear."", ""Rimmington mine"", RIMMINGTON_MINE, new WorldPoint(2976, 3238, 0), SHRUG, item(ItemID.GOLD_NECKLACE), item(ItemID.GOLD_RING), item(ItemID.BRONZE_SPEAR)),"
-emote,2981,3276,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,217,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE020, ""Spin at the crossroads north of Rimmington. Equip a green gnome hat, cream gnome top and leather chaps."", ""Rimmington"", ROAD_JUNCTION_NORTH_OF_RIMMINGTON, new WorldPoint(2981, 3276, 0), SPIN, item(ItemID.GNOME_HAT_GREEN), item(ItemID.GNOME_ROBETOP_CREAM), item(ItemID.LEATHER_CHAPS)),"
-emote,2989,3110,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,229,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE006, ""Wave on Mudskipper Point. Equip a black cape, leather chaps and a steel mace."", ""Mudskipper Point (AIQ)"", MUDSKIPPER_POINT, new WorldPoint(2989, 3110, 0), WAVE, item(ItemID.BLACK_CAPE), item(ItemID.LEATHER_CHAPS), item(ItemID.STEEL_MACE)),"
-emote,3026,3701,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,235,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE006, ""Yawn in the rogues' general store. Beware of double agents! Equip an adamant square shield, blue dragon vambraces and a rune pickaxe."", ""Rogues general store"", NOTERAZZOS_SHOP_IN_THE_WILDERNESS, new WorldPoint(3026, 3701, 0), DOUBLE_AGENT_65, YAWN, item(ItemID.ADAMANT_SQ_SHIELD), item(ItemID.BLUE_DRAGON_VAMBRACES), item(ItemID.RUNE_PICKAXE)),"
-emote,3030,4522,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,223,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Stamp in the Enchanted valley west of the waterfall. Beware of double agents! Equip a dragon axe."", ""Enchanted Valley (BKQ)"", NORTHWESTERN_CORNER_OF_THE_ENCHANTED_VALLEY, new WorldPoint(3030, 4522, 0), DOUBLE_AGENT_141, STAMP, any(""Dragon or Crystal axe"", item(ItemID.DRAGON_AXE), item(ItemID.TRAILBLAZER_AXE_NO_INFERNAL), item(ItemID.DRAGON_AXE_2H), item(ItemID.CRYSTAL_AXE), item(ItemID.CRYSTAL_AXE_INACTIVE), item(ItemID.CRYSTAL_AXE_2H), item(ItemID.CRYSTAL_AXE_2H_INACTIVE), item(ItemID.INFERNAL_AXE), item(ItemID.INFERNAL_AXE_EMPTY), item(ItemID.TRAILBLAZER_AXE), item(ItemID.TRAILBLAZER_AXE_EMPTY), item(ItemID.TRAILBLAZER_RELOADED_AXE), item(ItemID.TRAILBLAZER_RELOADED_AXE_EMPTY))),"
-emote,3043,4697,3,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,122,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_EXP5, ""Cheer at the top of the agility pyramid. Beware of double agents! Equip a blue mystic robe top and any rune heraldic shield."", ""Agility Pyramid"", AGILITY_PYRAMID, new WorldPoint(3043, 4697, 3), DOUBLE_AGENT_108, CHEER, item(ItemID.MYSTIC_ROBE_TOP), any(""Any rune heraldic shield"", item(ItemID.RUNE_HERALDIC_KITESHIELD1), item(ItemID.RUNE_HERALDIC_KITESHIELD2), item(ItemID.RUNE_HERALDIC_KITESHIELD3), item(ItemID.RUNE_HERALDIC_KITESHIELD4), item(ItemID.RUNE_HERALDIC_KITESHIELD5))),"
-emote,3045,3376,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,171,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE015, ""Dance in the Party Room. Equip a steel full helmet, steel platebody and an iron plateskirt."", ""Falador Party Room"", OUTSIDE_THE_FALADOR_PARTY_ROOM, new WorldPoint(3045, 3376, 0), DANCE, item(ItemID.STEEL_FULL_HELM), item(ItemID.STEEL_PLATEBODY), item(ItemID.IRON_PLATESKIRT)),"
-emote,3047,3237,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,158,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE007, ""Cheer for the monks at Port Sarim. Equip a coif, steel plateskirt and a sapphire necklace."", ""Port Sarim"", NEAR_THE_ENTRANA_FERRY_IN_PORT_SARIM, new WorldPoint(3047, 3237, 0), CHEER, item(ItemID.COIF), item(ItemID.STEEL_PLATESKIRT), item(ItemID.SAPPHIRE_NECKLACE)),"
-emote,3049,2966,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,247,"new EmoteClue(ItemID.TRAIL_EASY_EMOTE_SAIL, ""Dance a jig behind the bar on the Pandemonium. Equip a right eye patch and a bronze scimitar."", ""Pandemonium"", PANDEMONIUM_BAR, new WorldPoint(3049, 2966, 0), JIG, item(ItemID.EYE_PATCH), item(ItemID.BRONZE_SCIMITAR)),"
-emote,3056,3484,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,120,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP6, ""Bow upstairs in the Edgeville Monastery. Equip a completed prayer book."", ""Edgeville Monastery"", SOUTHEAST_CORNER_OF_THE_MONASTERY, new WorldPoint(3056, 3484, 1), BOW, any(""Any god book"", item(ItemID.SARADOMINBOOK_COMPLETE), item(ItemID.GUTHIXBOOK_COMPLETE), item(ItemID.ZAMORAKBOOK_COMPLETE), item(ItemID.ARMADYLBOOK_COMPLETE), item(ItemID.BANDOSBOOK_COMPLETE), item(ItemID.ZAROSBOOK_COMPLETE), item(ItemID.LEAGUE_3_BOOK_SARADOMIN), item(ItemID.LEAGUE_3_BOOK_GUTHIX), item(ItemID.LEAGUE_3_BOOK_ZAMORAK), item(ItemID.LEAGUE_3_BOOK_ARMADYL), item(ItemID.LEAGUE_3_BOOK_BANDOS), item(ItemID.LEAGUE_3_BOOK_ZAROS))),"
-emote,3069,3861,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,152,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP3, ""Blow a kiss in the heart of the lava maze. Equip black dragonhide chaps, a spotted cape and a rolling pin."", ""Lava maze"", NEAR_A_LADDER_IN_THE_WILDERNESS_LAVA_MAZE, new WorldPoint(3069, 3861, 0), BLOW_KISS, item(ItemID.BLACK_DRAGONHIDE_CHAPS), any(""Spotted cape"", item(ItemID.HUNTING_LIGHT_CAPE), item(ItemID.HUNTING_LIGHT_CAPE_WORN)), item(ItemID.HUNDRED_ROLLINGPIN)),"
-emote,3080,3509,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,155,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP6, ""Cheer in the Edgeville general store. Dance before you talk to me. Equip a brown apron, leather boots and leather gloves."", ""Edgeville"", NORTH_OF_EVIL_DAVES_HOUSE_IN_EDGEVILLE, new WorldPoint(3080, 3509, 0), CHEER, DANCE, item(ItemID.BROWN_APRON), item(ItemID.LEATHER_BOOTS), item(ItemID.LEATHER_GLOVES)),"
-emote,3083,3253,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,233,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE003, ""Yawn in Draynor marketplace. Equip studded leather chaps, an iron kiteshield and a steel longsword."", ""Draynor"", DRAYNOR_VILLAGE_MARKET, new WorldPoint(3083, 3253, 0), YAWN, item(ItemID.STUDDED_CHAPS), item(ItemID.IRON_KITESHIELD), item(ItemID.STEEL_LONGSWORD)),"
-emote,3088,3254,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,139,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Show your anger at the Wise old man. Beware of double agents! Equip an abyssal whip, a legend's cape and some spined chaps."", ""Draynor Village"", BEHIND_MISS_SCHISM_IN_DRAYNOR_VILLAGE, new WorldPoint(3088, 3254, 0), DOUBLE_AGENT_141, ANGRY, any(""Abyssal whip"", item(ItemID.ABYSSAL_WHIP), item(ItemID.ABYSSAL_WHIP_LAVA), item(ItemID.ABYSSAL_WHIP_ICE), item(ItemID.LEAGUE_3_WHIP), item(ItemID.ABYSSAL_TENTACLE), item(ItemID.LEAGUE_3_WHIP_TENTACLE)), item(ItemID.CAPE_OF_LEGENDS), item(ItemID.DAGGANOTH_RANGED_LEGS)),"
-emote,3088,3336,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,218,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE009, ""Spin in Draynor Manor by the fountain. Equip an iron platebody, studded leather chaps and a bronze full helmet."", ""Draynor Manor"", DRAYNOR_MANOR_BY_THE_FOUNTAIN, new WorldPoint(3088, 3336, 0), SPIN, item(ItemID.IRON_PLATEBODY), item(ItemID.STUDDED_CHAPS), item(ItemID.BRONZE_FULL_HELM)),"
-emote,3105,3420,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,222,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE003, ""Spin on the bridge by the Barbarian Village. Salute before you talk to me. Equip purple gloves, a steel kiteshield and a mithril full helmet."", ""Barbarian Village"", EAST_OF_THE_BARBARIAN_VILLAGE_BRIDGE, new WorldPoint(3105, 3420, 0), SPIN, SALUTE, item(ItemID.WOLFENGLOVES_PURPLE), item(ItemID.STEEL_KITESHIELD), item(ItemID.MITHRIL_FULL_HELM)),"
-emote,3109,3294,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,170,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE011, ""Dance at the crossroads north of Draynor. Equip an iron chain body, a sapphire ring and a longbow."", ""Draynor Village"", CROSSROADS_NORTH_OF_DRAYNOR_VILLAGE, new WorldPoint(3109, 3294, 0), DANCE, item(ItemID.IRON_CHAINBODY), item(ItemID.SAPPHIRE_RING), item(ItemID.LONGBOW)),"
-emote,3113,3196,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,160,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE002, ""Clap on the causeway to the Wizards' Tower. Equip an iron medium helmet, emerald ring and a white apron."", ""Wizards' Tower"", ON_THE_BRIDGE_TO_THE_MISTHALIN_WIZARDS_TOWER, new WorldPoint(3113, 3196, 0), CLAP, item(ItemID.IRON_MED_HELM), item(ItemID.EMERALD_RING), item(ItemID.WHITE_APRON)),"
-emote,3128,3245,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,169,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP9, ""Cry in the Draynor Village jail. Jump for joy before you talk to me. Equip an adamant sword, a sapphire amulet and an adamant plateskirt."", ""Draynor Village jail"", OUTSIDE_DRAYNOR_VILLAGE_JAIL, new WorldPoint(3128, 3245, 0), CRY, JUMP_FOR_JOY, item(ItemID.ADAMANT_SWORD), item(ItemID.STRUNG_SAPPHIRE_AMULET), item(ItemID.ADAMANT_PLATESKIRT)),"
-emote,3159,3298,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,224,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE010, ""Think in middle of the wheat field by the Lumbridge mill. Equip a blue gnome robetop, a turquoise gnome robe bottom and an oak shortbow."", ""Lumbridge mill"", WHEAT_FIELD_NEAR_THE_LUMBRIDGE_WINDMILL, new WorldPoint(3159, 3298, 0), THINK, item(ItemID.GNOME_ROBETOP_BLUE), item(ItemID.GNOME_ROBEBOTTOMS_TURQUOISE), item(ItemID.OAK_SHORTBOW)),"
-emote,3164,3477,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,241,"new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, ""Bow to Brugsen Bursen at the Grand Exchange."", ""Grand Exchange"", null, new WorldPoint(3164, 3477, 0), BOW),"
-emote,3165,3467,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,177,"new EmoteClue(ItemID.TRAIL_EASY_EMOTE_EXP3, ""Dance at the entrance to the Grand Exchange. Equip a pink skirt, pink robe top and a body tiara."", ""Grand Exchange"", SOUTH_OF_THE_GRAND_EXCHANGE, new WorldPoint(3165, 3467, 0), DANCE, item(ItemID.PINK_SKIRT), item(ItemID.GNOME_ROBETOP_PINK), item(ItemID.TIARA_BODY)),"
-emote,3168,9571,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,173,"new EmoteClue(ItemID.TRAIL_MEDIUM_EMOTE_EXP1, ""Dance in the dark caves beneath Lumbridge Swamp. Blow a kiss before you talk to me. Equip an air staff, Bronze full helm and an amulet of power."", ""Lumbridge swamp caves"", LUMBRIDGE_SWAMP_CAVES, new WorldPoint(3168, 9571, 0), DANCE, BLOW_KISS, VarbitID.MY2ARM_FIRE_LUMB, item(ItemID.STAFF_OF_AIR), item(ItemID.BRONZE_FULL_HELM), item(ItemID.AMULET_OF_POWER)),"
-emote,3191,3960,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,163,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Clap in the magic axe hut. Beware of double agents! Equip only some flared trousers."", ""Magic axe hut"", OUTSIDE_THE_WILDERNESS_AXE_HUT, new WorldPoint(3191, 3960, 0), DOUBLE_AGENT_141, CLAP, item(ItemID.TRAIL_FLARED_PANTS), item(ItemID.LOCKPICK), emptySlot(""Nothing else"", HEAD, CAPE, AMULET, WEAPON, BODY, SHIELD, GLOVES, BOOTS, RING, AMMO)),"
-emote,3203,3169,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,172,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE001, ""Dance in the shack in Lumbridge Swamp. Equip a bronze dagger, iron full helmet and a gold ring."", ""Lumbridge swamp"", NEAR_A_SHED_IN_LUMBRIDGE_SWAMP, new WorldPoint(3203, 3169, 0), DANCE, item(ItemID.BRONZE_DAGGER), item(ItemID.IRON_FULL_HELM), item(ItemID.GOLD_RING)),"
-emote,3203,3424,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,240,"new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, ""Blow a raspberry at Aris in her tent. Equip a gold ring and a gold necklace."", ""Varrock"", GYPSY_TENT_ENTRANCE, new WorldPoint(3203, 3424, 0), RASPBERRY, item(ItemID.GOLD_RING), item(ItemID.GOLD_NECKLACE)),"
-emote,3205,3416,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,242,"new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, ""Cheer at Iffie Nitter. Equip a chef hat and a red cape."", ""Varrock"", FINE_CLOTHES_ENTRANCE, new WorldPoint(3205, 3416, 0), CHEER, item(ItemID.CHEFS_HAT), item(ItemID.RED_CAPE)),"
-emote,3209,3492,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,232,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE013, ""Yawn in the Varrock library. Equip a green gnome robe top, HAM robe bottom and an iron warhammer."", ""Varrock Castle"", VARROCK_PALACE_LIBRARY, new WorldPoint(3209, 3492, 0), YAWN, item(ItemID.GNOME_ROBETOP_GREEN), item(ItemID.HAM_ROBE), item(ItemID.IRON_WARHAMMER)),"
-emote,3213,3463,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,220,"new EmoteClue(ItemID.TRAIL_EASY_EMOTE_EXP1, ""Spin in the Varrock Castle courtyard. Equip a black axe, a coif and a ruby ring."", ""Varrock Castle"", OUTSIDE_VARROCK_PALACE_COURTYARD, new WorldPoint(3213, 3463, 0), SPIN, item(ItemID.BLACK_AXE), item(ItemID.COIF), item(ItemID.RUBY_RING)),"
-emote,3227,3831,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,201,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Panic by the big egg where no one dare goes and the ground is burnt. Beware of double agents! Equip a dragon med helm, a TokTz-Ket-Xil, a brine sabre, rune platebody and an uncharged amulet of glory."", ""Lava dragon isle"", SOUTHEAST_CORNER_OF_LAVA_DRAGON_ISLE, new WorldPoint(3227, 3831, 0), DOUBLE_AGENT_141, PANIC, item(ItemID.DRAGON_MED_HELM), item(ItemID.TZHAAR_SPIKESHIELD), item(ItemID.OLAF2_BRINE_SABRE), item(ItemID.RUNE_PLATEBODY), any(""Uncharged Amulet of glory"", item(ItemID.AMULET_OF_GLORY))),"
-emote,3230,3478,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,138,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Show your anger towards the Statue of Saradomin in Ellamaria's garden. Beware of double agents! Equip a zamorak godsword."", ""Varrock Castle"", BY_THE_BEAR_CAGE_IN_VARROCK_PALACE_GARDENS, new WorldPoint(3230, 3478, 0), DOUBLE_AGENT_141, ANGRY, any(""Zamorak godsword"", item(ItemID.ZGS), item(ItemID.ZGSG))),"
-emote,3231,3203,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,243,"new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, ""Clap at Bob's Brilliant Axes. Equip a bronze axe and leather boots."", ""Lumbridge"", BOB_AXES_ENTRANCE, new WorldPoint(3231, 3203, 0), CLAP, item(ItemID.BRONZE_AXE), item(ItemID.LEATHER_BOOTS)),"
-emote,3241,3672,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,214,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE001, ""Shrug in the woods east of the Level 19 Wilderness Obelisk. Beware of double agents! Equip rune platelegs, an iron platebody and blue dragonhide vambraces."", ""East of the Level 19 Wilderness Obelisk"", EAST_OF_THE_LEVEL_19_WILDERNESS_OBELISK, new WorldPoint(3241, 3672, 0), DOUBLE_AGENT_65, SHRUG, item(ItemID.RUNE_PLATELEGS), item(ItemID.IRON_PLATEBODY), item(ItemID.BLUE_DRAGON_VAMBRACES)),"
-emote,3253,3401,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,184,"new EmoteClue(ItemID.TRAIL_EASY_EMOTE_EXP4, ""Do a jig in Varrock's rune store. Equip an air tiara and a staff of water."", ""Varrock rune store"", AUBURYS_SHOP_IN_VARROCK, new WorldPoint(3253, 3401, 0), JIG, item(ItemID.TIARA_AIR), item(ItemID.STAFF_OF_WATER)),"
-emote,3294,2781,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,174,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE005, ""Dance at the cat-doored pyramid in Sophanem. Beware of double agents! Equip a ring of life, an uncharged amulet of glory and an adamant two-handed sword."", ""Pyramid Of Sophanem"", OUTSIDE_THE_GREAT_PYRAMID_OF_SOPHANEM, new WorldPoint(3294, 2781, 0), DOUBLE_AGENT_108, DANCE, item(ItemID.RING_OF_LIFE), item(ItemID.AMULET_OF_GLORY), item(ItemID.ADAMANT_2H_SWORD)),"
-emote,3299,3289,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,179,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE008, ""Headbang in the mine north of Al Kharid. Equip a desert shirt, leather gloves and leather boots."", ""Al Kharid mine"", AL_KHARID_SCORPION_MINE, new WorldPoint(3299, 3289, 0), HEADBANG, item(ItemID.DESERT_SHIRT), item(ItemID.LEATHER_GLOVES), item(ItemID.LEATHER_BOOTS)),"
-emote,3303,3271,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,244,"new EmoteClue(ItemID.TRAIL_CLUE_BEGINNER, ""Panic at Al Kharid mine."", ""Al Kharid mine"", null, new WorldPoint(3303, 3271, 0), PANIC),"
-emote,3304,3124,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,183,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE013, ""Dance a jig under Shantay's Awning. Bow before you talk to me. Equip a pointed blue snail helmet, an air staff and a bronze square shield."", ""Shantay Pass"", SHANTAY_PASS, new WorldPoint(3304, 3124, 0), JIG, BOW, item(ItemID.SNELM_POINT_BLUE), item(ItemID.STAFF_OF_AIR), item(ItemID.BRONZE_SQ_SHIELD)),"
-emote,3307,3491,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,227,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE026, ""Wave along the south fence of the Lumber Yard. Equip a hard leather body, leather chaps and a bronze axe."", ""Lumber Yard"", NEAR_THE_SAWMILL_OPERATORS_BOOTH, new WorldPoint(3307, 3491, 0), WAVE, item(ItemID.HARDLEATHER_BODY), item(ItemID.LEATHER_CHAPS), item(ItemID.BRONZE_AXE)),"
-emote,3314,3241,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,148,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE027, ""Bow in the office of the Emir's Arena. Equip an iron chain body, leather chaps and coif."", ""Emir's Arena"", EMIRS_ARENA_TICKET_OFFICE, new WorldPoint(3314, 3241, 0), BOW, item(ItemID.IRON_CHAINBODY), item(ItemID.LEATHER_CHAPS), item(ItemID.COIF)),"
-emote,3361,3339,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,159,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE025, ""Clap in the main exam room in the Exam Centre. Equip a white apron, green gnome boots and leather gloves."", ""Exam Centre"", OUTSIDE_THE_DIGSITE_EXAM_CENTRE, new WorldPoint(3361, 3339, 0), CLAP, item(ItemID.WHITE_APRON), item(ItemID.GNOME_BOOTS_GREEN), item(ItemID.LEATHER_GLOVES)),"
-emote,3362,3340,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,180,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_EXP1, ""Headbang at the exam centre. Beware of double agents! Equip a mystic fire staff, a diamond bracelet and rune boots."", ""Exam Centre"", INSIDE_THE_DIGSITE_EXAM_CENTRE, new WorldPoint(3362, 3340, 0), DOUBLE_AGENT_108, HEADBANG, item(ItemID.MYSTIC_FIRE_STAFF), item(ItemID.JEWL_DIAMOND_BRACELET), item(ItemID.RUNE_ARMOURED_BOOTS)),"
-emote,3368,3935,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,199,"new EmoteClue(ItemID.TRAIL_HARD_EMOTE_EXP3, ""Panic on the Wilderness volcano bridge. Beware of double agents! Equip any headband and crozier."", ""Wilderness volcano"", VOLCANO_IN_THE_NORTHEASTERN_WILDERNESS, new WorldPoint(3368, 3935, 0), DOUBLE_AGENT_65, PANIC, any(""Any headband"", range(ItemID.HEADBAND_RED, ItemID.HEADBAND_BROWN), range(ItemID.HEADBAND_WHITE, ItemID.HEADBAND_GREEN)), any(""Any crozier"", item(ItemID.TRAIL_ANCIENT_STAFF), item(ItemID.TRAIL_ARMADYL_STAFF), item(ItemID.TRAIL_BANDOS_STAFF), range(ItemID.TRAIL_SARADOMIN_STAFF, ItemID.TRAIL_ZAMORAK_STAFF))),"
-emote,3370,3425,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,141,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE011, ""Beckon in the Digsite, near the eastern winch. Bow before you talk to me. Equip a green gnome hat, snakeskin boots and an iron pickaxe."", ""Digsite"", DIGSITE, new WorldPoint(3370, 3425, 0), BECKON, BOW, item(ItemID.GNOME_HAT_GREEN), item(ItemID.SNAKESKIN_BOOTS), item(ItemID.IRON_PICKAXE)),"
-emote,3372,3498,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,197,"new EmoteClue(ItemID.TRAIL_CLUE_EASY_EMOTE004, ""Panic in the Limestone Mine. Equip bronze platelegs, a steel pickaxe and a steel medium helmet."", ""Limestone Mine"", LIMESTONE_MINE, new WorldPoint(3372, 3498, 0), PANIC, item(ItemID.BRONZE_PLATELEGS), item(ItemID.STEEL_PICKAXE), item(ItemID.STEEL_MED_HELM)),"
-emote,3421,3537,2,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,181,"new EmoteClue(ItemID.TRAIL_ELITE_EMOTE_EXP8, ""Headbang at the top of Slayer Tower. Equip a seercull, a combat bracelet and helm of Neitiznot."", ""Slayer Tower"", OUTSIDE_THE_SLAYER_TOWER_GARGOYLE_ROOM, new WorldPoint(3421, 3537, 2), HEADBANG, item(ItemID.DAGANOTH_CAVE_MAGIC_SHORTBOW), any(""Combat bracelet"", range(ItemID.JEWL_BRACELET_OF_COMBAT_4, ItemID.JEWL_BRACELET_OF_COMBAT), item(ItemID.JEWL_BRACELET_OF_COMBAT_5), item(ItemID.JEWL_BRACELET_OF_COMBAT_6)), item(ItemID.FRIS_KINGLY_HELM)),"
-emote,3492,3488,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,175,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE001, ""Dance in the centre of Canifis. Bow before you talk to me. Equip a green gnome robe top, mithril plate legs and an iron two-handed sword."", ""Canifis"", CENTRE_OF_CANIFIS, new WorldPoint(3492, 3488, 0), DANCE, BOW, item(ItemID.GNOME_ROBETOP_GREEN), item(ItemID.MITHRIL_PLATELEGS), item(ItemID.IRON_2H_SWORD)),"
-emote,3504,3576,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,198,"new EmoteClue(ItemID.TRAIL_CLUE_MEDIUM_EMOTE002, ""Panic by the mausoleum in Morytania. Wave before you speak to me. Equip a mithril plate skirt, a maple longbow and no boots."", ""Morytania mausoleum, access via the experiments cave"", MAUSOLEUM_OFF_THE_MORYTANIA_COAST, new WorldPoint(3504, 3576, 0), PANIC, WAVE, item(ItemID.MITHRIL_PLATESKIRT), item(ItemID.MAPLE_LONGBOW), emptySlot(""No boots"", BOOTS)),"
-emote,3551,9694,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,127,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Do a jig at the barrows chest. Beware of double agents! Equip any full barrows set."", ""Barrows chest"", BARROWS_CHEST, new WorldPoint(3551, 9694, 0), DOUBLE_AGENT_141, JIG, any(""Any full barrows set"","
-emote,3562,3379,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,230,"new EmoteClue(ItemID.TRAIL_CLUE_MASTER, ""Wave on the northern wall of Castle Drakan. Beware of double agents! Wear a dragon sq shield, splitbark body and any boater."", ""Castle Drakan"", NORTHERN_WALL_OF_CASTLE_DRAKAN, new WorldPoint(3562, 3379, 0), DOUBLE_AGENT_141, WAVE, any(""Dragon sq shield"", item(ItemID.DRAGON_SQ_SHIELD), item(ItemID.DRAGON_SQ_SHIELD_GOLD)), item(ItemID.SPLITBARK_BODY), any(""Any boater"", item(ItemID.STRAWBOATER_RED), item(ItemID.STRAWBOATER_ORANGE), item(ItemID.STRAWBOATER_GREEN), item(ItemID.STRAWBOATER_BLUE), item(ItemID.STRAWBOATER_BLACK), item(ItemID.STRAWBOATER_PINK), item(ItemID.STRAWBOATER_PURPLE), item(ItemID.STRAWBOATER_WHITE))),"
-emote,3611,3492,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,137,"new EmoteClue(ItemID.TRAIL_CLUE_HARD_EMOTE004, ""Panic in the heart of the Haunted Woods. Beware of double agents! Have no items equipped when you do."", ""Haunted Woods (ALQ)"", null, new WorldPoint(3611, 3492, 0), DOUBLE_AGENT_108, PANIC, emptySlot(""Nothing at all"", EquipmentInventorySlot.values())),"
-fairy_ring,1630,3868,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,53,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY010, ""C I S 0 0 0 9"", new WorldPoint(1630, 3868, 0)),"
-fairy_ring,1646,3012,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,48,"new FairyRingClue(ItemID.TRAIL_HARD_FAIRY_VM01, ""A J P 3 0 1 5"", new WorldPoint(1646, 3012, 0)),"
-fairy_ring,2073,4846,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,54,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY007, ""C K P 0 2 2 4"", new WorldPoint(2073, 4846, 0)),"
-fairy_ring,2439,5132,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,50,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY006, ""B L P 6 2 0 0"", new WorldPoint(2439, 5132, 0)),"
-fairy_ring,2504,3633,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,49,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY003, ""A L P 1 1 4 0"", new WorldPoint(2504, 3633, 0)),"
-fairy_ring,2648,4729,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,51,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY005, ""B J R 1 1 2 3"", new WorldPoint(2648, 4729, 0)),"
-fairy_ring,2702,3246,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,46,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY002, ""A I R 2 3 3 1"", new WorldPoint(2702, 3246, 0)),"
-fairy_ring,2747,3720,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,56,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY009, ""D K S 2 3 1 0"", new WorldPoint(2747, 3720, 0))"
-fairy_ring,3000,3110,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,47,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY001, ""A I Q 0 4 4 0"", new WorldPoint(3000, 3110, 0)),"
-fairy_ring,3041,4770,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,55,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY008, ""D I P 8 5 1 1"", new WorldPoint(3041, 4770, 0)),"
-fairy_ring,3407,3330,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,52,"new FairyRingClue(ItemID.TRAIL_CLUE_HARD_FAIRY004, ""B I P 7 0 1 3"", new WorldPoint(3407, 3330, 0)),"
-hot_cold,2436,3347,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java,67,"new WorldPoint(2436, 3347, 0),"
-hot_cold,3211,3494,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java,62,"new WorldPoint(3211, 3494, 0),"
-hot_cold_possible,1187,3580,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,203,"ZEAH_CRIMSON_SWIFTS(MASTER, new WorldPoint(1187, 3580, 0), ZEAH, ""South-west of the Kebos Swamp, below the crimson swifts."", BRASSICAN_MAGE);"
-hot_cold_possible,1208,3736,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,201,"ZEAH_FARMING_GUILD_W(MASTER, new WorldPoint(1208, 3736, 0), ZEAH, ""West of the Farming Guild."", BRASSICAN_MAGE),"
-hot_cold_possible,1312,3108,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,158,"VARLAMORE_RAINFOREST_CENTRE(MASTER, new WorldPoint(1312, 3108, 0), VARLAMORE, ""In the centre of the Tlati Rainforest."", BRASSICAN_MAGE),"
-hot_cold_possible,1324,3722,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,202,"ZEAH_DAIRY_COW(MASTER, new WorldPoint(1324, 3722, 0), ZEAH, ""North-east of the Kebos Lowlands, east of the dairy cow."", BRASSICAN_MAGE),"
-hot_cold_possible,1428,3869,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,185,"ZEAH_SULPHR_MINE(MASTER, new WorldPoint(1428, 3869, 0), ZEAH, ""Western entrance in the Lovakengj sulphur mine. Facemask or Slayer Helmet recommended."", BRASSICAN_MAGE),"
-hot_cold_possible,1467,3714,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,187,"ZEAH_OVERPASS(MASTER, new WorldPoint(1467, 3714, 0), ZEAH, ""Overpass between Lovakengj and Shayzien."", BRASSICAN_MAGE),"
-hot_cold_possible,1469,2933,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,160,"VARLAMORE_VILLA_LUCENS(MASTER, new WorldPoint(1469, 2933, 0), VARLAMORE, ""On the Villa Lucens theatre stage in Aldarin. Completion of Death on the Isle is required."", BRASSICAN_MAGE),"
-hot_cold_possible,1477,3778,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,184,"ZEAH_LOVAKENGJ_MINE(MASTER, new WorldPoint(1477, 3778, 0), ZEAH, ""Next to mithril rock in the Lovakengj mine."", BRASSICAN_MAGE),"
-hot_cold_possible,1488,3881,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,182,"ZEAH_BLASTMINE_NORTH(MASTER, new WorldPoint(1488, 3881, 0), ZEAH, ""Northern part of the Lovakengj blast mine."", BRASSICAN_MAGE),"
-hot_cold_possible,1490,3602,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,190,"ZEAH_SHAYZIEN_BANK_2(MASTER, new WorldPoint(1490, 3602, 0), ZEAH, ""North of the bank in Shayzien."", BRASSICAN_MAGE),"
-hot_cold_possible,1490,3698,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,188,"ZEAH_LIZARDMAN(MASTER, new WorldPoint(1490, 3698, 0), ZEAH, ""Within Lizardman Canyon, east of the ladder."", ANCIENT_WIZARDS),"
-hot_cold_possible,1498,3627,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,186,"ZEAH_SHAYZIEN_BANK(MASTER, new WorldPoint(1498, 3627, 0), ZEAH, ""South-east of the bank in Shayzien Encampment."", BRASSICAN_MAGE),"
-hot_cold_possible,1504,3859,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,181,"ZEAH_BLASTMINE_BANK(MASTER, new WorldPoint(1504, 3859, 0), ZEAH, ""Next to the bank in the Lovakengj blast mine."", BRASSICAN_MAGE),"
-hot_cold_possible,1507,3819,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,183,"ZEAH_LOVAKITE_FURNACE(MASTER, new WorldPoint(1507, 3819, 0), ZEAH, ""Next to the lovakite furnace in Lovakengj."", BRASSICAN_MAGE),"
-hot_cold_possible,1534,2997,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,159,"VARLAMORE_SUNSET_COAST(MASTER, new WorldPoint(1534, 2997, 0), VARLAMORE, ""North-east corner of Sunset Coast."", ANCIENT_WIZARDS),"
-hot_cold_possible,1557,3624,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,189,"ZEAH_COMBAT_RING(MASTER, new WorldPoint(1557, 3624, 0), ZEAH, ""Shayzien Encampment, south-east of the Combat Ring."", BRASSICAN_MAGE),"
-hot_cold_possible,1603,3843,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,191,"ZEAH_LIBRARY(MASTER, new WorldPoint(1603, 3843, 0), ZEAH, ""North-west of the Arceuus Library."", BRASSICAN_MAGE),"
-hot_cold_possible,1653,3572,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,199,"ZEAH_WATSONS_HOUSE(MASTER, new WorldPoint(1653, 3572, 0), ZEAH, ""East of Watson's house."", BRASSICAN_MAGE),"
-hot_cold_possible,1656,3621,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,198,"ZEAH_MESS_HALL(MASTER, new WorldPoint(1656, 3621, 0), ZEAH, ""East of the Mess hall."", BRASSICAN_MAGE),"
-hot_cold_possible,1680,3107,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,156,"VARLAMORE_BAZAAR(MASTER, new WorldPoint(1680, 3107, 0), VARLAMORE, ""In the centre of the Bazaar in Civitas illa Fortis."", BRASSICAN_MAGE),"
-hot_cold_possible,1681,3794,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,192,"ZEAH_HOUSECHURCH(MASTER, new WorldPoint(1681, 3794, 0), ZEAH, ""By the entrance to the Arceuus church."", ANCIENT_WIZARDS),"
-hot_cold_possible,1695,2990,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,157,"VARLAMORE_LOCUS_OASIS(MASTER, new WorldPoint(1695, 2990, 0), VARLAMORE, ""Amongst the trees at the Locus Oasis."", BRASSICAN_MAGE),"
-hot_cold_possible,1698,3880,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,193,"ZEAH_DARK_ALTAR(MASTER, new WorldPoint(1698, 3880, 0), ZEAH, ""West of the Dark Altar."", BRASSICAN_MAGE),"
-hot_cold_possible,1710,3700,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,194,"ZEAH_ARCEUUS_HOUSE(MASTER, new WorldPoint(1710, 3700, 0), ZEAH, ""By the south-eastern entrance to Arceuus."", BRASSICAN_MAGE),"
-hot_cold_possible,1718,3643,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,197,"ZEAH_GOLDEN_FIELD_TAVERN(MASTER, new WorldPoint(1718, 3643, 0), ZEAH, ""South of the gravestone in Kingstown."", BRASSICAN_MAGE),"
-hot_cold_possible,1768,3705,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,196,"ZEAH_PISCARILUS_MINE(MASTER, new WorldPoint(1768, 3705, 0), ZEAH, ""South of the Piscarilius mine."", ANCIENT_WIZARDS),"
-hot_cold_possible,1773,3867,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,195,"ZEAH_ESSENCE_MINE_NE(MASTER, new WorldPoint(1773, 3867, 0), ZEAH, ""North-east of the Arceuus essence mine."", BRASSICAN_MAGE),"
-hot_cold_possible,1807,3523,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,200,"ZEAH_VANNAHS_FARM_STORE(MASTER, new WorldPoint(1807, 3523, 0), ZEAH, ""North of Tithe Farm, next to the pond."", BRASSICAN_MAGE),"
-hot_cold_possible,1856,2415,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,153,"SAIL_ISLE_OF_SERPENTS(MASTER, new WorldPoint(1856, 2415, 0), OCEAN, ""On the Isle of Serpents"", BRASSICAN_MAGE),"
-hot_cold_possible,2078,3665,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,155,"SAIL_BUCCANEERS_HAVEN(MASTER, new WorldPoint(2078, 3665, 0), OCEAN, ""On Buccaneers' Haven"", BRASSICAN_MAGE),"
-hot_cold_possible,2084,3916,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,104,"FREMENNIK_PROVINCE_LUNAR_VILLAGE(MASTER, new WorldPoint(2084, 3916, 0), FREMENNIK_PROVINCE, ""Lunar Isle, inside the village."", ANCIENT_WIZARDS),"
-hot_cold_possible,2106,3949,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,105,"FREMENNIK_PROVINCE_LUNAR_NORTH(MASTER, new WorldPoint(2106, 3949, 0), FREMENNIK_PROVINCE, ""Lunar Isle, north of the village."", ANCIENT_WIZARDS),"
-hot_cold_possible,2139,3562,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,154,"SAIL_DRUMSTICK_ISLE(MASTER, new WorldPoint(2139, 3562, 0), OCEAN, ""On Drumstick Isle"", BRASSICAN_MAGE),"
-hot_cold_possible,2149,3865,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,103,"FREMENNIK_PROVINCE_ASTRAL_ALTER(MASTER, new WorldPoint(2149, 3865, 0), FREMENNIK_PROVINCE, ""Astral altar"", ANCIENT_WIZARDS),"
-hot_cold_possible,2177,3282,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,166,"WESTERN_PROVINCE_ELF_CAMP_NW(MASTER, new WorldPoint(2177, 3282, 0), WESTERN_PROVINCE, ""North-west of Iorwerth Camp."", BRASSICAN_MAGE),"
-hot_cold_possible,2189,2794,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,107,"ISLE_OF_SOULS_MINE(MASTER, new WorldPoint(2189, 2794, 0), KANDARIN, ""Isle of Souls Mine, south of the Soul Wars lobby"", BRASSICAN_MAGE),"
-hot_cold_possible,2196,3057,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,169,"WESTERN_PROVINCE_ZULANDRA(MASTER, new WorldPoint(2196, 3057, 0), WESTERN_PROVINCE, ""The northern house at Zul-Andra."", BRASSICAN_MAGE),"
-hot_cold_possible,2206,3158,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,168,"WESTERN_PROVINCE_TYRAS(MASTER, new WorldPoint(2206, 3158, 0), WESTERN_PROVINCE, ""Near Tyras Camp."", BRASSICAN_MAGE),"
-hot_cold_possible,2211,3817,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,102,"FREMENNIK_PROVINCE_PIRATES_COVE(MASTER, new WorldPoint(2211, 3817, 0), FREMENNIK_PROVINCE, ""Pirates' Cove"", ANCIENT_WIZARDS),"
-hot_cold_possible,2268,3242,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,165,"WESTERN_PROVINCE_ELF_CAMP_EAST(MASTER, new WorldPoint(2268, 3242, 0), WESTERN_PROVINCE, ""East of Iorwerth Camp."", BRASSICAN_MAGE),"
-hot_cold_possible,2297,3529,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,161,"WESTERN_PROVINCE_EAGLES_PEAK(MASTER, new WorldPoint(2297, 3529, 0), WESTERN_PROVINCE, ""North-west of Eagles' Peak."", BRASSICAN_MAGE),"
-hot_cold_possible,2313,3850,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,100,"FREMENNIK_PROVINCE_WEST_ISLES_MINE(MASTER, new WorldPoint(2313, 3850, 0), FREMENNIK_PROVINCE, ""West Fremennik Isles mine."", ANCIENT_WIZARDS),"
-hot_cold_possible,2334,3685,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,162,"WESTERN_PROVINCE_PISCATORIS(MASTER, new WorldPoint(2334, 3685, 0), WESTERN_PROVINCE, ""Piscatoris Fishing Colony"", ANCIENT_WIZARDS),"
-hot_cold_possible,2337,3166,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,167,"WESTERN_PROVINCE_LLETYA(MASTER, new WorldPoint(2337, 3166, 0), WESTERN_PROVINCE, ""In Lletya."", BRASSICAN_MAGE),"
-hot_cold_possible,2359,3564,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,163,"WESTERN_PROVINCE_PISCATORIS_HUNTER_AREA(MASTER, new WorldPoint(2359, 3564, 0), WESTERN_PROVINCE, ""Eastern part of Piscatoris Hunter area, south-west of the Falconry."", BRASSICAN_MAGE),"
-hot_cold_possible,2370,3319,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,164,"WESTERN_PROVINCE_ARANDAR(MASTER, new WorldPoint(2370, 3319, 0), WESTERN_PROVINCE, ""South-west of the crystal gate to Arandar."", BRASSICAN_OR_WIZARDS),"
-hot_cold_possible,2374,3850,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,99,"FREMENNIK_PROVINCE_FREMMY_ISLES_MINE(MASTER, new WorldPoint(2374, 3850, 0), FREMENNIK_PROVINCE, ""Central Fremennik Isles mine."", ANCIENT_WIZARDS),"
-hot_cold_possible,2393,3812,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,101,"FREMENNIK_PROVINCE_WEST_JATIZSO_ENTRANCE(MASTER, new WorldPoint(2393, 3812, 0), FREMENNIK_PROVINCE, ""West of the Jatizso mine entrance."", BRASSICAN_MAGE),"
-hot_cold_possible,2409,3053,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,84,"FELDIP_HILLS_JIGGIG(MASTER, new WorldPoint(2409, 3053, 0), FELDIP_HILLS, ""West of Jiggig, east of the fairy ring BKP."", BRASSICAN_MAGE),"
-hot_cold_possible,2411,3429,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,121,"KANDARIN_SW_TREE_GNOME_STRONGHOLD(MASTER, new WorldPoint(2411, 3429, 0), KANDARIN, ""South-west Tree Gnome Stronghold"", BRASSICAN_MAGE),"
-hot_cold_possible,2448,3503,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,110,"KANDARIN_GRAND_TREE(MASTER, new WorldPoint(2448, 3503, 0), KANDARIN, ""Grand Tree, just east of the terrorchick gnome enclosure."", BRASSICAN_MAGE),"
-hot_cold_possible,2451,3112,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,91,"FELDIP_HILLS_CW_BALLOON(MASTER, new WorldPoint(2451, 3112, 0), FELDIP_HILLS, ""Directly west of the Castle Wars balloon."", BRASSICAN_MAGE),"
-hot_cold_possible,2457,3362,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,122,"KANDARIN_OUTPOST(MASTER, new WorldPoint(2457, 3362, 0), KANDARIN, ""South of the Tree Gnome Stronghold, north-east of the Outpost."", BRASSICAN_MAGE),"
-hot_cold_possible,2467,3227,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,118,"KANDARIN_GRAVE_OF_SCORPIUS(MASTER, new WorldPoint(2467, 3227, 0), KANDARIN, ""Grave of Scorpius"", BRASSICAN_MAGE),"
-hot_cold_possible,2486,3007,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,88,"FELDIP_HILLS_SOUTH(MASTER, new WorldPoint(2486, 3007, 0), FELDIP_HILLS, ""South of Jiggig."", BRASSICAN_MAGE),"
-hot_cold_possible,2522,3252,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,119,"KANDARIN_KHAZARD_BATTLEFIELD(MASTER, new WorldPoint(2522, 3252, 0), KANDARIN, ""Khazard Battlefield, south of Tracker gnome 2."", BRASSICAN_MAGE),"
-hot_cold_possible,2527,3868,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,98,"FREMENNIK_PROVINCE_MISC_COURTYARD(MASTER, new WorldPoint(2527, 3868, 0), FREMENNIK_PROVINCE, ""Outside Miscellania's courtyard."", BRASSICAN_MAGE),"
-hot_cold_possible,2530,2901,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,89,"FELDIP_HILLS_RED_CHIN(MASTER, new WorldPoint(2530, 2901, 0), FELDIP_HILLS, ""Outside the red chinchompa hunting ground entrance, south of the Hunting expert's hut."", BRASSICAN_MAGE),"
-hot_cold_possible,2530,3164,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,117,"KANDARIN_TREE_GNOME_VILLAGE(MASTER, new WorldPoint(2530, 3164, 0), KANDARIN, ""Tree Gnome Village, near the general store icon."", BRASSICAN_MAGE),"
-hot_cold_possible,2530,3477,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,123,"KANDARIN_BAXTORIAN_FALLS(MASTER, new WorldPoint(2530, 3477, 0), KANDARIN, ""South-east of Almera's house on Baxtorian Falls."", BRASSICAN_MAGE),"
-hot_cold_possible,2535,3322,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,120,"KANDARIN_WEST_ARDY(MASTER, new WorldPoint(2535, 3322, 0), KANDARIN, ""West Ardougne, near the staircase outside the Civic Office."", BRASSICAN_MAGE),"
-hot_cold_possible,2540,3548,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,124,"KANDARIN_BA_AGILITY_COURSE(MASTER, new WorldPoint(2540, 3548, 0), KANDARIN, ""Inside the Barbarian Agility Course. Completion of Alfred Grimhand's Barcrawl is required."", BRASSICAN_MAGE),"
-hot_cold_possible,2555,2972,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,86,"FELDIP_HILLS_GNOME_GLITER(MASTER, new WorldPoint(2555, 2972, 0), FELDIP_HILLS, ""East of the gnome glider (Lemantolly Undri)."", BRASSICAN_MAGE),"
-hot_cold_possible,2569,2918,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,90,"FELDIP_HILLS_SE(MASTER, new WorldPoint(2569, 2918, 0), FELDIP_HILLS, ""South-east of the ∩-shaped lake, near the Hunter icon."", BRASSICAN_MAGE),"
-hot_cold_possible,2585,3601,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,96,"FREMENNIK_PROVINCE_LIGHTHOUSE(MASTER, new WorldPoint(2585, 3601, 0), FREMENNIK_PROVINCE, ""South-east of the Lighthouse."", BRASSICAN_MAGE),"
-hot_cold_possible,2586,2897,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,85,"FELDIP_HILLS_SW(MASTER, new WorldPoint(2586, 2897, 0), FELDIP_HILLS, ""West of the southeasternmost lake in Feldip Hills."", BRASSICAN_MAGE),"
-hot_cold_possible,2587,3135,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,116,"KANDARIN_FIGHT_ARENA(MASTER, new WorldPoint(2587, 3135, 0), KANDARIN, ""South of the Fight Arena, north-west of the Nightmare Zone."", BRASSICAN_MAGE),"
-hot_cold_possible,2590,3369,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,113,"KANDARIN_FISHING_BUILD(MASTER, new WorldPoint(2590, 3369, 0), KANDARIN, ""South of Fishing Guild"", BRASSICAN_MAGE),"
-hot_cold_possible,2604,3648,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,95,"FREMENNIK_PROVINCE_SW(MASTER, new WorldPoint(2604, 3648, 0), FREMENNIK_PROVINCE, ""Outside the fence in the south-western corner of Rellekka."", BRASSICAN_MAGE),"
-hot_cold_possible,2611,2950,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,87,"FELDIP_HILLS_RANTZ(MASTER, new WorldPoint(2611, 2950, 0), FELDIP_HILLS, ""South of Rantz, west of the empty glass bottles."", BRASSICAN_MAGE),"
-hot_cold_possible,2617,3862,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,97,"FREMENNIK_PROVINCE_ETCETERIA_CASTLE(MASTER, new WorldPoint(2617, 3862, 0), FREMENNIK_PROVINCE, ""South-east of Etceteria's castle."", BRASSICAN_MAGE),"
-hot_cold_possible,2653,3485,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,112,"KANDARIN_MCGRUBORS_WOOD(MASTER, new WorldPoint(2653, 3485, 0), KANDARIN, ""McGrubor's Wood"", BRASSICAN_MAGE),"
-hot_cold_possible,2667,3241,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,115,"KANDARIN_NECRO_TOWER(MASTER, new WorldPoint(2667, 3241, 0), KANDARIN, ""Ground floor inside the Necromancer Tower. Easily accessed by using fairy ring code DJP."", ANCIENT_WIZARDS),"
-hot_cold_possible,2707,3306,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,114,"KANDARIN_WITCHHAVEN(MASTER, new WorldPoint(2707, 3306, 0), KANDARIN, ""Outside Witchaven, west of Jeb, Holgart, and Caroline."", BRASSICAN_MAGE),"
-hot_cold_possible,2711,3689,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,94,"FREMENNIK_PROVINCE_KELGADRIM_ENTRANCE(MASTER, new WorldPoint(2711, 3689, 0), FREMENNIK_PROVINCE, ""West of the Keldagrim entrance mine."", BRASSICAN_MAGE),"
-hot_cold_possible,2718,3167,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,127,"KARAMJA_WEST_BRIMHAVEN(MASTER, new WorldPoint(2718, 3167, 0), KARAMJA, ""West of Brimhaven."", BRASSICAN_MAGE),"
-hot_cold_possible,2720,3784,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,93,"FREMENNIK_PROVINCE_RELLEKKA_HUNTER(MASTER, new WorldPoint(2720, 3784, 0), FREMENNIK_PROVINCE, ""At the Rellekka Hunter area, near the Hunter icon."", BRASSICAN_MAGE),"
-hot_cold_possible,2730,3588,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,108,"KANDARIN_SINCLAR_MANSION(MASTER, new WorldPoint(2730, 3588, 0), KANDARIN, ""North-west of the Sinclair Mansion, near the log balance shortcut."", BRASSICAN_MAGE),"
-hot_cold_possible,2732,3485,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,111,"KANDARIN_SEERS(MASTER, new WorldPoint(2732, 3485, 0), KANDARIN, ""Outside Seers' Village bank."", BRASSICAN_MAGE),"
-hot_cold_possible,2774,3436,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,109,"KANDARIN_CATHERBY(MASTER, new WorldPoint(2774, 3436, 0), KANDARIN, ""Catherby, between the bank and the beehives, near small rock formation."", BRASSICAN_MAGE),"
-hot_cold_possible,2782,3215,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,126,"KARAMJA_BRIMHAVEN_FRUIT_TREE(MASTER, new WorldPoint(2782, 3215, 0), KARAMJA, ""Brimhaven, east of the fruit tree patch."", BRASSICAN_MAGE),"
-hot_cold_possible,2786,2899,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,130,"KARAMJA_KHARAZI_SW(MASTER, new WorldPoint(2786, 2899, 0), KARAMJA, ""South-western part of Kharazi Jungle."", ANCIENT_WIZARDS),"
-hot_cold_possible,2800,3669,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,92,"FREMENNIK_PROVINCE_MTN_CAMP(MASTER, new WorldPoint(2800, 3669, 0), FREMENNIK_PROVINCE, ""At the Mountain Camp."", BRASSICAN_MAGE),"
-hot_cold_possible,2860,3562,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,63,"ASGARNIA_WARRIORS(MASTER, new WorldPoint(2860, 3562, 0), ASGARNIA, ""North of the Warriors' Guild in Burthorpe."", BRASSICAN_MAGE),"
-hot_cold_possible,2904,2925,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,129,"KARAMJA_KHARAZI_NE(MASTER, new WorldPoint(2904, 2925, 0), KARAMJA, ""North-eastern part of Kharazi Jungle."", BRASSICAN_MAGE),"
-hot_cold_possible,2909,2737,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,131,"KARAMJA_CRASH_ISLAND(MASTER, new WorldPoint(2909, 2737, 0), KARAMJA, ""Northern part of Crash Island."", BRASSICAN_MAGE),"
-hot_cold_possible,2910,3615,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,72,"ASGARNIA_TROLL(MASTER, new WorldPoint(2910, 3615, 0), ASGARNIA, ""The Troll arena, where the player fights Dad during the Troll Stronghold quest. Bring climbing boots if travelling from Burthorpe."", BRASSICAN_MAGE),"
-hot_cold_possible,2913,3169,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,125,"KARAMJA_MUSA_POINT(MASTER, new WorldPoint(2913, 3169, 0), KARAMJA, ""Musa Point, banana plantation."", BRASSICAN_MAGE),"
-hot_cold_possible,2915,3425,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,64,"ASGARNIA_JATIX(MASTER, new WorldPoint(2915, 3425, 0), ASGARNIA, ""East of Jatix's Herblore Shop in Taverley."", BRASSICAN_MAGE),"
-hot_cold_possible,2917,3295,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,69,"ASGARNIA_CRAFT_GUILD(MASTER, new WorldPoint(2917, 3295, 0), ASGARNIA, ""Outside the Crafting Guild cow pen."", BRASSICAN_MAGE),"
-hot_cold_possible,2966,2976,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,128,"KARAMJA_GLIDER(MASTER, new WorldPoint(2966, 2976, 0), KARAMJA, ""West of the gnome glider."", BRASSICAN_MAGE),"
-hot_cold_possible,2972,3486,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,66,"ASGARNIA_MIAZRQA(MASTER, new WorldPoint(2972, 3486, 0), ASGARNIA, ""North of Miazrqa's tower, outside Goblin Village."", BRASSICAN_MAGE),"
-hot_cold_possible,2974,3814,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,177,"WILDERNESS_37(MASTER, new WorldPoint(2974, 3814, 0), WILDERNESS, ""South-east of the Chaos Temple, level 37 Wilderness."", BRASSICAN_MAGE),"
-hot_cold_possible,2976,3239,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,70,"ASGARNIA_RIMMINGTON(MASTER, new WorldPoint(2976, 3239, 0), ASGARNIA, ""In the centre of the Rimmington mine."", BRASSICAN_MAGE),"
-hot_cold_possible,2981,3944,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,180,"WILDERNESS_54(MASTER, new WorldPoint(2981, 3944, 0), WILDERNESS, ""West of the Wilderness Agility Course, level 54 Wilderness."", BRASSICAN_MAGE),"
-hot_cold_possible,2987,3110,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,71,"ASGARNIA_MUDSKIPPER(MASTER, new WorldPoint(2987, 3110, 0), ASGARNIA, ""Mudskipper Point, near the starfish in the south-west corner."", BRASSICAN_MAGE),"
-hot_cold_possible,3007,3475,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,106,"ICE_MOUNTAIN(BEGINNER, new WorldPoint(3007, 3475, 0), MISTHALIN, ""Atop Ice Mountain""),"
-hot_cold_possible,3030,3364,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,68,"ASGARNIA_PARTY_ROOM(MASTER, new WorldPoint(3030, 3364, 0), ASGARNIA, ""Outside the Falador Party Room."", BRASSICAN_MAGE),"
-hot_cold_possible,3031,3304,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,67,"ASGARNIA_COW(MASTER, new WorldPoint(3031, 3304, 0), ASGARNIA, ""In the cow pen north of Sarah's Farming Shop."", ANCIENT_WIZARDS),"
-hot_cold_possible,3033,3438,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,65,"ASGARNIA_BARB(MASTER, new WorldPoint(3033, 3438, 0), ASGARNIA, ""West of Barbarian Village."", BRASSICAN_MAGE),"
-hot_cold_possible,3036,3612,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,171,"WILDERNESS_12(MASTER, new WorldPoint(3036, 3612, 0), WILDERNESS, ""South-east of the Dark Warriors' Fortress, level 12 Wilderness."", ANCIENT_WIZARDS),"
-hot_cold_possible,3096,3379,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,82,"DRAYNOR_MANOR_MUSHROOMS(BEGINNER, new WorldPoint(3096, 3379, 0), MISTHALIN, ""Patch of mushrooms just northwest of Draynor Manor""),"
-hot_cold_possible,3098,3234,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,137,"MISTHALIN_DRAYNOR_BANK(MASTER, new WorldPoint(3098, 3234, 0), MISTHALIN, ""South of Draynor Village bank."", BRASSICAN_MAGE),"
-hot_cold_possible,3120,3282,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,83,"DRAYNOR_WHEAT_FIELD(BEGINNER, new WorldPoint(3120, 3282, 0), MISTHALIN, ""Inside the wheat field next to Draynor Village""),"
-hot_cold_possible,3136,3914,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,179,"WILDERNESS_49(MASTER, new WorldPoint(3136, 3914, 0), WILDERNESS, ""South-west of the Deserted Keep, level 49 Wilderness."", BRASSICAN_MAGE),"
-hot_cold_possible,3152,3796,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,176,"WILDERNESS_35(MASTER, new WorldPoint(3152, 3796, 0), WILDERNESS, ""East of the Wilderness canoe exit, level 35 Wilderness."", BRASSICAN_OR_WIZARDS),"
-hot_cold_possible,3154,3421,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,136,"MISTHALIN_GERTUDES(MASTER, new WorldPoint(3154, 3421, 0), MISTHALIN, ""North-east of Gertrude's house west of Varrock."", BRASSICAN_MAGE),"
-hot_cold_possible,3161,3047,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,76,"DESERT_BEDABIN_CAMP(MASTER, new WorldPoint(3161, 3047, 0), DESERT, ""Bedabin Camp, near the north tent."", BRASSICAN_MAGE),"
-hot_cold_possible,3169,3279,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,135,"MISTHALIN_LUMBRIDGE_2(MASTER, new WorldPoint(3169, 3279, 0), MISTHALIN, ""North of the pond between Lumbridge and Draynor Village."", BRASSICAN_MAGE),"
-hot_cold_possible,3173,3556,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,170,"WILDERNESS_5(MASTER, new WorldPoint(3173, 3556, 0), WILDERNESS, ""North of the Grand Exchange, level 5 Wilderness."", ANCIENT_WIZARDS),"
-hot_cold_possible,3174,3336,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,132,"LUMBRIDGE_COW_FIELD(BEGINNER,  new WorldPoint(3174, 3336, 0), MISTHALIN, ""Cow field north of Lumbridge""),"
-hot_cold_possible,3174,3736,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,173,"WILDERNESS_27(MASTER, new WorldPoint(3174, 3736, 0), WILDERNESS, ""Inside the Ruins north of the Graveyard of Shadows, level 27 Wilderness."", BRASSICAN_MAGE),"
-hot_cold_possible,3222,3679,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,172,"WILDERNESS_20(MASTER, new WorldPoint(3222, 3679, 0), WILDERNESS, ""East of the Corporeal Beast's lair, level 20 Wilderness."", ANCIENT_WIZARDS),"
-hot_cold_possible,3223,2820,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,75,"DESERT_MENAPHOS_GATE(MASTER, new WorldPoint(3223, 2820, 0), DESERT, ""North of Menaphos gate."", BRASSICAN_MAGE),"
-hot_cold_possible,3225,3356,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,133,"MISTHALIN_VARROCK_STONE_CIRCLE(MASTER, new WorldPoint(3225, 3356, 0), MISTHALIN, ""South of the stone circle near Varrock's entrance."", BRASSICAN_MAGE),"
-hot_cold_possible,3234,3169,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,134,"MISTHALIN_LUMBRIDGE(MASTER, new WorldPoint(3234, 3169, 0), MISTHALIN, ""Just north-west of the Lumbridge Fishing tutor."", BRASSICAN_MAGE),"
-hot_cold_possible,3249,2349,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,152,"SAIL_GREAT_CONCH(MASTER, new WorldPoint(3249, 2349, 0), OCEAN, ""In the south-eastern mine of the Great Conch"", BRASSICAN_MAGE),"
-hot_cold_possible,3279,3263,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,74,"DESERT_ALKHARID_MINE(MASTER, new WorldPoint(3279, 3263, 0), DESERT, ""West of Al Kharid mine."", BRASSICAN_MAGE),"
-hot_cold_possible,3288,2976,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,78,"DESERT_POLLNIVNEACH(MASTER, new WorldPoint(3288, 2976, 0), DESERT, ""West of Pollnivneach."", BRASSICAN_MAGE),"
-hot_cold_possible,3292,3107,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,81,"DESERT_SHANTY(MASTER, new WorldPoint(3292, 3107, 0), DESERT, ""South-west of Shantay Pass."", BRASSICAN_MAGE),"
-hot_cold_possible,3293,3813,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,178,"WILDERNESS_38(MASTER, new WorldPoint(3293, 3813, 0), WILDERNESS, ""Among the poison spiders south of Callisto's den, level 38 Wilderness."", ANCIENT_WIZARDS),"
-hot_cold_possible,3301,3484,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,138,"MISTHALIN_LUMBER_YARD(MASTER, new WorldPoint(3301, 3484, 0), MISTHALIN, ""South of Lumber Yard, east of Assistant Serf."", BRASSICAN_MAGE),"
-hot_cold_possible,3311,3773,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,175,"WILDERNESS_32(MASTER, new WorldPoint(3311, 3773, 0), WILDERNESS, ""South of the Silk Chasm near the black knights, level 32 Wilderness."", ANCIENT_WIZARDS),"
-hot_cold_possible,3332,3313,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,151,"NORTHEAST_OF_AL_KHARID_MINE(BEGINNER, new WorldPoint(3332, 3313, 0), MISTHALIN, ""Northeast of Al Kharid Mine""),"
-hot_cold_possible,3347,3295,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,79,"DESERT_MTA(MASTER, new WorldPoint(3347, 3295, 0), DESERT, ""Next to Mage Training Arena."", BRASSICAN_MAGE),"
-hot_cold_possible,3359,2912,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,73,"DESERT_GENIE(MASTER, new WorldPoint(3359, 2912, 0), DESERT, ""West of Nardah genie cave."", BRASSICAN_MAGE),"
-hot_cold_possible,3377,3737,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,174,"WILDERNESS_28(MASTER, new WorldPoint(3377, 3737, 0), WILDERNESS, ""South-east of wilderness crabs teleport, level 28 Wilderness."", BRASSICAN_MAGE),"
-hot_cold_possible,3418,3372,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,143,"MORYTANIA_SWAMP(MASTER, new WorldPoint(3418, 3372, 0), MORYTANIA, ""Inside the Mort Myre Swamp, north-west of the Nature Grotto."", BRASSICAN_MAGE),"
-hot_cold_possible,3428,2773,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,80,"DESERT_RUINS_OF_ULLEK(MASTER, new WorldPoint(3428, 2773, 0), DESERT, ""South-east of Ruins of Ullek."", BRASSICAN_MAGE),"
-hot_cold_possible,3432,3105,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,77,"DESERT_UZER(MASTER, new WorldPoint(3432, 3105, 0), DESERT, ""West of Uzer."", BRASSICAN_MAGE),"
-hot_cold_possible,3444,3255,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,144,"MORYTANIA_HAUNTED_MINE(MASTER, new WorldPoint(3444, 3255, 0), MORYTANIA, ""At Haunted Mine quest start."", BRASSICAN_MAGE),"
-hot_cold_possible,3499,3421,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,142,"MORYTANIA_HOLLOWS(MASTER, new WorldPoint(3499, 3421, 0), MORYTANIA, ""Inside The Hollows, south of the bridge which was repaired in a quest."", BRASSICAN_MAGE),"
-hot_cold_possible,3499,3539,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,145,"MORYTANIA_MAUSOLEUM(MASTER, new WorldPoint(3499, 3539, 0), MORYTANIA, ""South of the Mausoleum."", BRASSICAN_MAGE),"
-hot_cold_possible,3546,3252,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,139,"MORYTANIA_BURGH_DE_ROTT(MASTER, new WorldPoint(3546, 3252, 0), MORYTANIA, ""In the north-east area of Burgh de Rott, by the reverse-L-shaped ruins."", BRASSICAN_MAGE),"
-hot_cold_possible,3604,3326,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,140,"MORYTANIA_DARKMEYER(MASTER, new WorldPoint(3604, 3326, 0), MORYTANIA, ""Southwestern part of Darkmeyer."", BRASSICAN_MAGE),"
-hot_cold_possible,3611,3485,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,141,"MORYTANIA_PORT_PHASMATYS(MASTER, new WorldPoint(3611, 3485, 0), MORYTANIA, ""West of Port Phasmatys, south-east of fairy ring ALQ."", BRASSICAN_MAGE),"
-hot_cold_possible,3666,2972,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,147,"MORYTANIA_MOS_LES_HARMLESS_BAR(MASTER, new WorldPoint(3666, 2972, 0), MORYTANIA, ""Near Mos Le'Harmless southern bar."", BRASSICAN_MAGE),"
-hot_cold_possible,3740,3041,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,146,"MORYTANIA_MOS_LES_HARMLESS(MASTER, new WorldPoint(3740, 3041, 0), MORYTANIA, ""Northern area of Mos Le'Harmless, between the lakes."", BRASSICAN_MAGE),"
-hot_cold_possible,3769,3383,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,150,"MORYTANIA_SLEPE_TENTS(MASTER, new WorldPoint(3769, 3383, 0), MORYTANIA, ""North-east of Slepe, near the tents."", BRASSICAN_MAGE),"
-hot_cold_possible,3803,3532,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,149,"MORYTANIA_DRAGONTOOTH_SOUTH(MASTER, new WorldPoint(3803, 3532, 0), MORYTANIA, ""Southern part of Dragontooth Island."", BRASSICAN_MAGE),"
-hot_cold_possible,3811,3569,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,148,"MORYTANIA_DRAGONTOOTH_NORTH(MASTER, new WorldPoint(3811, 3569, 0), MORYTANIA, ""Northern part of Dragontooth Island."", BRASSICAN_MAGE),"
-map,1815,3852,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,87,"new MapClue(ItemID.TRAIL_ELITE_MAP_EXP4, new WorldPoint(1815, 3852, 0), ""At the Soul Altar, north-east of the Arceuus essence mine.""),"
-map,2202,3062,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,86,"new MapClue(ItemID.TRAIL_ELITE_MAP_EXP3, new WorldPoint(2202, 3062, 0), ""Zul-Andra. Fairy ring BJS""),"
-map,2449,3130,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,84,"new MapClue(ItemID.TRAIL_ELITE_MAP_EXP1, new WorldPoint(2449, 3130, 0), ""South-west of Tree Gnome Village.""),"
-map,2454,3230,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,74,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP010, new WorldPoint(2454, 3230, 0), ""At the entrance to the Ourania Cave.""),"
-map,2457,3182,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,80,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP004, new WorldPoint(2457, 3182, 0), ObjectID.ELEM_CRATE_1, ""In a crate by the stairs to the Observatory Dungeon.""),"
-map,2488,3308,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,79,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP003, new WorldPoint(2488, 3308, 0), ""In the western section of West Ardougne.""),"
-map,2536,3865,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,72,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP008, new WorldPoint(2536, 3865, 0), ""Miscellania. Fairy ring CIP""),"
-map,2565,3248,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,70,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP006, new WorldPoint(2565, 3248, 0), ObjectID.CRATE2, ""The crate west of the Clocktower.""),"
-map,2578,3597,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,75,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP011, new WorldPoint(2578, 3597, 0), ""South-east of the Lighthouse. Fairy ring ALP""),"
-map,2612,3482,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,63,"new MapClue(ItemID.TRAIL_CLUE_EASY_MAP004, new WorldPoint(2612, 3482, 0), ""Brother Galahad's house, West of McGrubor's Wood.""),"
-map,2615,3078,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,78,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP002, new WorldPoint(2615, 3078, 0), ""Yanille anvils, south of the bank. You can dig from inside the building.""),"
-map,2651,3231,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,69,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP005, new WorldPoint(2651, 3231, 0), ""North of the Tower of Life. Fairy ring DJP""),"
-map,2658,3488,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,68,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP004, new WorldPoint(2658, 3488, 0), ObjectID.CRATE2_OLD, ""The crate in McGrubor's Wood. Fairy ring ALS""),"
-map,2666,3562,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,76,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP012, new WorldPoint(2666, 3562, 0), ""Between Seers' Village and Rellekka. South-west of Fairy ring CJR""),"
-map,2703,2716,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,89,"new MapClue(ItemID.TRAIL_ELITE_MAP_EXP6, new WorldPoint(2703, 2716, 0), ObjectID.MM_CRATE, ""The crate in south-western Ape Atoll""),"
-map,2722,3338,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,83,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP007, new WorldPoint(2722, 3338, 0), ""South of the Legends' Guild. Fairy ring BLR""),"
-map,2907,3295,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,67,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP003, new WorldPoint(2907, 3295, 0), ""West of the Crafting Guild""),"
-map,2924,3210,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,71,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP007, new WorldPoint(2924, 3210, 0), ""Behind the Chemist's house in Rimmington.""),"
-map,2953,9523,1,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,85,"new MapClue(ItemID.TRAIL_ELITE_MAP_EXP2, new WorldPoint(2953, 9523, 1), ""In the Mogre Camp, near Port Khazard. You require a Diving Apparatus and a Fishbowl Helmet""),"
-map,2970,3415,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,65,"new MapClue(ItemID.TRAIL_CLUE_EASY_MAP006, new WorldPoint(2970, 3415, 0), ""North of Falador.""),"
-map,3021,3912,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,82,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP006, new WorldPoint(3021, 3912, 0), ""South-east of the Wilderness Agility Course in level 50 Wilderness.""),"
-map,3026,3628,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,81,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP005, new WorldPoint(3026, 3628, 0), ObjectID.CRATE2, ""In a crate at the Dark Warriors' Fortress in level 14 Wilderness.""),"
-map,3043,3398,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,62,"new MapClue(ItemID.TRAIL_CLUE_EASY_MAP003, new WorldPoint(3043, 3398, 0), STANDING_STONES),"
-map,3091,3227,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,66,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP001, new WorldPoint(3091, 3227, 0), SOUTH_OF_DRAYNOR_BANK),"
-map,3108,3262,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,91,"new MapClue(ItemID.CLUEQUEST_CLUE3, new WorldPoint(3108, 3262, 0), ""South-west of the wheat field east of Draynor Village."")"
-map,3110,3152,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,64,"new MapClue(ItemID.TRAIL_CLUE_EASY_MAP005, new WorldPoint(3110, 3152, 0), WIZARDS_TOWER_DIS),"
-map,3166,3361,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,60,"new MapClue(ItemID.TRAIL_CLUE_EASY_MAP001, new WorldPoint(3166, 3361, 0), CHAMPIONS_GUILD),"
-map,3203,3213,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,90,"new MapClue(ItemID.CLUEQUEST_CLUE2, new WorldPoint(3203, 3213, 0), ""Behind Lumbridge Castle, just outside the kitchen door""),"
-map,3290,3374,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,61,"new MapClue(ItemID.TRAIL_CLUE_EASY_MAP002, new WorldPoint(3290, 3374, 0), VARROCK_EAST_MINE),"
-map,3300,3291,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,59,"new MapClue(ItemID.TRAIL_EASY_MAP_EXP1, new WorldPoint(3300, 3291, 0), ""Al Kharid mine""),"
-map,3309,3503,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,77,"new MapClue(ItemID.TRAIL_CLUE_HARD_MAP001, new WorldPoint(3309, 3503, 0), ObjectID.GERTRUDEEMPTY_CRATE, ""A crate in the Lumber Yard, north-east of Varrock.""),"
-map,3434,3265,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,73,"new MapClue(ItemID.TRAIL_CLUE_MEDIUM_MAP009, new WorldPoint(3434, 3265, 0), ""Mort Myre Swamp, west of Mort'ton. Fairy ring BIP""),"
-map,3538,3208,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,88,"new MapClue(ItemID.TRAIL_ELITE_MAP_EXP5, new WorldPoint(3538, 3208, 0), ""East of Burgh de Rott.""),"
-music,2990,3384,0,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MusicClue.java,51,"private static final WorldPoint LOCATION = new WorldPoint(2990, 3384, 0);"
+name,category,start_x,start_y,start_plane,x,y,plane,teleports,source_file,source_line
+manual (3567 4381 0),manual,2964,3378,0,3567,4381,0,ALL,from discord,
+anagram (1212 3119 0),anagram,3213,3428,0,1212,3119,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,899
+anagram (1503 3553 0),anagram,3087,3496,0,1503,3553,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,738
+anagram (1504 3632 0),anagram,2662,3305,0,1504,3632,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,593
+anagram (1512 3619 0),anagram,2662,3305,0,1512,3619,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,584
+anagram (1529 3567 0),anagram,2964,3378,0,1529,3567,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,861
+anagram (1551 3565 0),anagram,3165,3487,0,1551,3565,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,868
+anagram (1639 3812 0),anagram,3038,3192,0,1639,3812,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,400
+anagram (1649 3498 0),anagram,3165,3487,0,1649,3498,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,688
+anagram (1688 3540 0),anagram,2442,3096,0,1688,3540,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,541
+anagram (1719 3723 0),anagram,3298,3290,0,1719,3723,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,136
+anagram (1737 3557 0),anagram,3213,3428,0,1737,3557,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,409
+anagram (1742 2977 0),anagram,3213,3428,0,1742,2977,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,877
+anagram (1761 3850 0),anagram,3165,3487,0,1761,3850,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,663
+anagram (1805 3566 0),anagram,2662,3305,0,1805,3566,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,477
+anagram (1814 3851 0),anagram,2662,3305,0,1814,3851,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,93
+anagram (1822 3739 0),anagram,3038,3192,0,1822,3739,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,713
+anagram (1841 3803 0),anagram,2442,3096,0,1841,3803,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,216
+anagram (2150 3866 0),anagram,3213,3428,0,2150,3866,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,207
+anagram (2209 3056 0),anagram,3038,3192,0,2209,3056,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,200
+anagram (2326 3178 0),anagram,2662,3305,0,2326,3178,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,548
+anagram (2335 3162 0),anagram,3038,3192,0,2335,3162,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,854
+anagram (2351 3801 0),anagram,3298,3290,0,2351,3801,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,704
+anagram (2395 3486 0),anagram,2662,3305,0,2395,3486,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,225
+anagram (2402 3419 0),anagram,3304,3124,0,2402,3419,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,161
+anagram (2432 3422 0),anagram,2442,3096,0,2432,3422,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,434
+anagram (2447 3418 1),anagram,3087,3496,0,2447,3418,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,486
+anagram (2454 2853 1),anagram,3213,3428,0,2454,2853,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,672
+anagram (2461 3382 0),anagram,2964,3378,0,2461,3382,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,511
+anagram (2501 3487 0),anagram,3298,3290,0,2501,3487,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,375
+anagram (2512 10256 0),anagram,2757,3478,0,2512,10256,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,352
+anagram (2526 3162 0),anagram,3087,3496,0,2526,3162,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,182
+anagram (2541 3170 0),anagram,2964,3378,0,2541,3170,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,359
+anagram (2541 3305 0),anagram,2662,3305,0,2541,3305,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,845
+anagram (2553 2868 0),anagram,2757,3478,0,2553,2868,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,191
+anagram (2566 3332 0),anagram,3165,3487,0,2566,3332,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,557
+anagram (2592 4324 0),anagram,3165,3487,0,2592,4324,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,443
+anagram (2606 3211 0),anagram,3298,3290,0,2606,3211,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,525
+anagram (2609 3116 0),anagram,3165,3487,0,2609,3116,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,425
+anagram (2613 3269 0),anagram,2757,3478,0,2613,3269,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,332
+anagram (2630 2997 0),anagram,2757,3478,0,2630,2997,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,418
+anagram (2658 3670 0),anagram,2442,3096,0,2658,3670,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,316
+anagram (2660 3654 0),anagram,3087,3496,0,2660,3654,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,745
+anagram (2715 3302 0),anagram,3213,3428,0,2715,3302,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,109
+anagram (2726 3368 0),anagram,3304,3124,0,2726,3368,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,534
+anagram (2736 5351 1),anagram,3038,3192,0,2736,5351,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,773
+anagram (2744 3444 0),anagram,3165,3487,0,2744,3444,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,602
+anagram (2760 3496 0),anagram,3298,3290,0,2760,3496,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,450
+anagram (2783 3861 0),anagram,3165,3487,0,2783,3861,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,168
+anagram (2790 3066 0),anagram,3038,3192,0,2790,3066,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,366
+anagram (2802 2765 0),anagram,3087,3496,0,2802,2765,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,764
+anagram (2803 2744 0),anagram,2442,3096,0,2803,2744,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,325
+anagram (2807 3191 0),anagram,2757,3478,0,2807,3191,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,566
+anagram (2822 3442 0),anagram,2442,3096,0,2822,3442,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,729
+anagram (2858 3577 0),anagram,2662,3305,0,2858,3577,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,145
+anagram (2872 3934 0),anagram,3165,3487,0,2872,3934,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,86
+anagram (2897 3565 0),anagram,3213,3428,0,2897,3565,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,391
+anagram (2906 3537 0),anagram,2662,3305,0,2906,3537,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,645
+anagram (2913 10221 0),anagram,3087,3496,0,2913,10221,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,300
+anagram (2919 3574 0),anagram,3165,3487,0,2919,3574,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,679
+anagram (2938 3152 0),anagram,2662,3305,0,2938,3152,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,384
+anagram (2940 3223 0),anagram,3165,3487,0,2940,3223,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,654
+anagram (2944 3381 0),anagram,3298,3290,0,2944,3381,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,831
+anagram (2951 3450 0),anagram,3087,3496,0,2951,3450,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,803
+anagram (2957 3370 0),anagram,3304,3124,0,2957,3370,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,459
+anagram (2975 3343 0),anagram,2757,3478,0,2975,3343,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,627
+anagram (3013 3501 0),anagram,2964,3378,0,3013,3501,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,118
+anagram (3026 3216 0),anagram,2757,3478,0,3026,3216,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,77
+anagram (3026 3246 0),anagram,2757,3478,0,3026,3246,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,810
+anagram (3039 4834 0),anagram,2662,3305,0,3039,4834,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,266
+anagram (3047 3376 0),anagram,3087,3496,0,3047,3376,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,611
+anagram (3061 3377 0),anagram,3165,3487,0,3061,3377,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,243
+anagram (3079 9892 0),anagram,2442,3096,0,3079,9892,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,754
+anagram (3080 3250 0),anagram,2964,3378,0,3080,3250,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,838
+anagram (3088 3253 0),anagram,3038,3192,0,3088,3253,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,695
+anagram (3102 9570 0),anagram,2662,3305,0,3102,9570,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,796
+anagram (3110 3330 0),anagram,2964,3378,0,3110,3330,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,817
+anagram (3143 2423 0),anagram,3304,3124,0,3143,2423,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,908
+anagram (3151 3412 0),anagram,3298,3290,0,3151,3412,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,824
+anagram (3182 3946 0),anagram,3087,3496,0,3182,3946,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,284
+anagram (3195 3404 0),anagram,3038,3192,0,3195,3404,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,789
+anagram (3207 3214 0),anagram,2662,3305,0,3207,3214,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,575
+anagram (3209 3392 0),anagram,2757,3478,0,3209,3392,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,127
+anagram (3217 3434 0),anagram,3213,3428,0,3217,3434,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,68
+anagram (3220 3476 0),anagram,2662,3305,0,3220,3476,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,468
+anagram (3230 3230 0),anagram,3213,3428,0,3230,3230,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,275
+anagram (3233 3423 0),anagram,2757,3478,0,3233,3423,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,345
+anagram (3238 3220 0),anagram,3298,3290,0,3238,3220,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,175
+anagram (3243 3208 0),anagram,3087,3496,0,3243,3208,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,152
+anagram (3273 3181 0),anagram,3165,3487,0,3273,3181,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,636
+anagram (3284 3943 0),anagram,2662,3305,0,3284,3943,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,259
+anagram (3300 3231 0),anagram,2442,3096,0,3300,3231,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,502
+anagram (3315 3163 0),anagram,2757,3478,0,3315,3163,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,782
+anagram (3359 3276 0),anagram,2662,3305,0,3359,3276,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,102
+anagram (3389 2877 0),anagram,3304,3124,0,3389,2877,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,722
+anagram (3462 3557 0),anagram,3298,3290,0,3462,3557,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,234
+anagram (3508 3237 0),anagram,3304,3124,0,3508,3237,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,495
+anagram (3564 3288 0),anagram,2964,3378,0,3564,3288,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,307
+anagram (3602 3209 0),anagram,3087,3496,0,3602,3209,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,518
+anagram (3661 3849 0),anagram,2964,3378,0,3661,3849,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,889
+anagram (3681 2963 0),anagram,2662,3305,0,3681,2963,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,618
+anagram (3719 3810 0),anagram,3038,3192,0,3719,3810,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,888
+anagram (3728 3302 0),anagram,3038,3192,0,3728,3302,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/AnagramClue.java,252
+beginner_map (3043 3398 0),beginner_map,3222,3218,0,3043,3398,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,39
+beginner_map (3093 3226 0),beginner_map,3222,3218,0,3093,3226,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,38
+beginner_map (3110 3152 0),beginner_map,3222,3218,0,3110,3152,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,40
+beginner_map (3166 3361 0),beginner_map,3222,3218,0,3166,3361,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,36
+beginner_map (3290 3374 0),beginner_map,3222,3218,0,3290,3374,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/BeginnerMapClue.java,37
+cipher (1376 3037 0),cipher,2662,3305,0,1376,3037,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,199
+cipher (1559 3045 0),cipher,2442,3096,0,1559,3045,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,192
+cipher (1625 3802 0),cipher,2760,3178,0,1625,3802,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,163
+cipher (1845 3754 0),cipher,3165,3487,0,1845,3754,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,95
+cipher (2289 3144 0),cipher,3213,3428,0,2289,3144,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,104
+cipher (2329 3689 0),cipher,2964,3378,0,2329,3689,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,179
+cipher (2347 4435 0),cipher,2662,3305,0,2347,4435,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,156
+cipher (2446 4428 0),cipher,3087,3496,0,2446,4428,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,140
+cipher (2541 3548 0),cipher,1700,3141,0,2541,3548,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,172
+cipher (2634 4682 1),cipher,3165,3487,0,2634,4682,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,113
+cipher (3077 3260 0),cipher,1750,3590,0,3077,3260,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,185
+cipher (3112 3162 0),cipher,1750,3590,0,3112,3162,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,131
+cipher (3224 3112 0),cipher,3038,3192,0,3224,3112,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,86
+cipher (3227 3227 0),cipher,2442,3096,0,3227,3227,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,77
+cipher (3229 6062 0),cipher,3702,3503,0,3229,6062,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,104
+cipher (3354 2974 0),cipher,3222,3218,0,3354,2974,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,59
+cipher (3440 9895 0),cipher,2964,3378,0,3440,9895,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,68
+cipher (3680 3537 0),cipher,3702,3503,0,3680,3537,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CipherClue.java,149
+coordinate (1193 2774 0),coordinate,2660,3657,0,1193,2774,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,603
+coordinate (1247 3726 0),coordinate,2964,3378,0,1247,3726,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,266
+coordinate (1248 3751 0),coordinate,2757,3478,0,1248,3751,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,955
+coordinate (1321 3323 0),coordinate,1700,3141,0,1321,3323,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,851
+coordinate (1409 3483 0),coordinate,3087,3496,0,1409,3483,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,597
+coordinate (1410 3611 0),coordinate,3038,3192,0,1410,3611,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,591
+coordinate (1442 3878 0),coordinate,3222,3218,0,1442,3878,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,991
+coordinate (1451 3509 0),coordinate,3702,3503,0,1451,3509,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,827
+coordinate (1451 3695 0),coordinate,2442,3096,0,1451,3695,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,943
+coordinate (1460 3782 0),coordinate,3087,3496,0,1460,3782,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,484
+coordinate (1476 3566 0),coordinate,2442,3096,0,1476,3566,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,241
+coordinate (1479 3699 0),coordinate,2964,3378,0,1479,3699,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,454
+coordinate (1557 3183 0),coordinate,2757,3478,0,1557,3183,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,839
+coordinate (1571 3245 0),coordinate,2442,3096,0,1571,3245,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,845
+coordinate (1659 3111 0),coordinate,3298,3290,0,1659,3111,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,276
+coordinate (1698 3792 0),coordinate,2662,3305,0,1698,3792,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,961
+coordinate (1761 3853 0),coordinate,3304,3124,0,1761,3853,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,979
+coordinate (1769 3418 0),coordinate,3087,3496,0,1769,3418,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1021
+coordinate (1773 3510 0),coordinate,2442,3096,0,1773,3510,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,683
+coordinate (2065 3923 0),coordinate,3222,3218,0,2065,3923,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,755
+coordinate (2081 3184 0),coordinate,2660,3657,0,2081,3184,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,857
+coordinate (2090 3863 0),coordinate,2760,3178,0,2090,3863,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,985
+coordinate (2094 2889 0),coordinate,3222,3218,0,2094,2889,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,821
+coordinate (2155 3100 0),coordinate,2964,3378,0,2155,3100,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,870
+coordinate (2178 3209 0),coordinate,3304,3124,0,2178,3209,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,864
+coordinate (2180 3282 0),coordinate,2757,3478,0,2180,3282,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,635
+coordinate (2181 3206 0),coordinate,3505,3488,0,2181,3206,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,293
+coordinate (2194 3807 0),coordinate,3213,3428,0,2194,3807,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,731
+coordinate (2202 3825 0),coordinate,3505,3488,0,2202,3825,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,973
+coordinate (2209 3161 0),coordinate,3165,3487,0,2209,3161,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,287
+coordinate (2217 3092 0),coordinate,3165,3487,0,2217,3092,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,876
+coordinate (2222 3331 0),coordinate,2760,3178,0,2222,3331,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,803
+coordinate (2303 3328 0),coordinate,3165,3487,0,2303,3328,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,907
+coordinate (2316 3814 0),coordinate,2662,3305,0,2316,3814,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,785
+coordinate (2318 2954 0),coordinate,2662,3305,0,2318,2954,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,815
+coordinate (2322 3061 0),coordinate,2760,3178,0,2322,3061,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,126
+coordinate (2339 3311 0),coordinate,3087,3496,0,2339,3311,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,358
+coordinate (2341 3697 0),coordinate,3702,3503,0,2341,3697,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,574
+coordinate (2357 3151 0),coordinate,2442,3096,0,2357,3151,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,610
+coordinate (2359 3799 0),coordinate,1700,3141,0,2359,3799,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,725
+coordinate (2363 3531 0),coordinate,3298,3290,0,2363,3531,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,226
+coordinate (2381 3468 0),coordinate,3298,3290,0,2381,3468,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,196
+coordinate (2383 3370 0),coordinate,2757,3478,0,2383,3370,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,156
+coordinate (2387 3435 0),coordinate,1750,3590,0,2387,3435,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,186
+coordinate (2416 3516 0),coordinate,3304,3124,0,2416,3516,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,216
+coordinate (2479 3158 0),coordinate,3038,3192,0,2479,3158,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,66
+coordinate (2484 4016 0),coordinate,2442,3096,0,2484,4016,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,797
+coordinate (2505 3899 0),coordinate,3038,3192,0,2505,3899,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,538
+coordinate (2511 2980 0),coordinate,2964,3378,0,2511,2980,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,653
+coordinate (2512 3467 0),coordinate,3505,3488,0,2512,3467,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,191
+coordinate (2537 3881 0),coordinate,3505,3488,0,2537,3881,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,256
+coordinate (2538 3739 0),coordinate,3165,3487,0,2538,3739,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,949
+coordinate (2542 3031 0),coordinate,2660,3657,0,2542,3031,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,340
+coordinate (2581 3030 0),coordinate,3222,3218,0,2581,3030,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,346
+coordinate (2583 2990 0),coordinate,3505,3488,0,2583,2990,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,146
+coordinate (2585 3505 0),coordinate,3505,3488,0,2585,3505,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,206
+coordinate (2594 2899 0),coordinate,3222,3218,0,2594,2899,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,181
+coordinate (2643 3252 0),coordinate,3165,3487,0,2643,3252,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,121
+coordinate (2679 3110 0),coordinate,3213,3428,0,2679,3110,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,106
+coordinate (2681 3653 0),coordinate,3505,3488,0,2681,3653,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,251
+coordinate (2697 2705 0),coordinate,3165,3487,0,2697,2705,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,707
+coordinate (2697 3207 0),coordinate,3213,3428,0,2697,3207,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,101
+coordinate (2699 3251 0),coordinate,2660,3657,0,2699,3251,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,310
+coordinate (2700 3808 0),coordinate,3165,3487,0,2700,3808,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,737
+coordinate (2712 3732 0),coordinate,2442,3096,0,2712,3732,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,460
+coordinate (2732 3284 0),coordinate,3505,3488,0,2732,3284,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,895
+coordinate (2732 3372 0),coordinate,3702,3503,0,2732,3372,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,659
+coordinate (2735 3638 0),coordinate,2760,3178,0,2735,3638,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,246
+coordinate (2743 3151 0),coordinate,3298,3290,0,2743,3151,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,76
+coordinate (2763 2974 0),coordinate,2662,3305,0,2763,2974,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,370
+coordinate (2775 2891 0),coordinate,2760,3178,0,2775,2891,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,406
+coordinate (2778 3678 0),coordinate,3505,3488,0,2778,3678,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,713
+coordinate (2820 3078 0),coordinate,2760,3178,0,2820,3078,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,622
+coordinate (2827 3740 0),coordinate,1700,3141,0,2827,3740,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,719
+coordinate (2828 3234 0),coordinate,3298,3290,0,2828,3234,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,261
+coordinate (2834 3271 0),coordinate,2964,3378,0,2834,3271,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,889
+coordinate (2838 2914 0),coordinate,2964,3378,0,2838,2914,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,388
+coordinate (2840 3423 0),coordinate,1700,3141,0,2840,3423,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,919
+coordinate (2841 3267 0),coordinate,3304,3124,0,2841,3267,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,328
+coordinate (2848 3296 0),coordinate,1700,3141,0,2848,3296,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,141
+coordinate (2849 3033 0),coordinate,1700,3141,0,2849,3033,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,136
+coordinate (2853 3690 0),coordinate,3038,3192,0,2853,3690,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,430
+coordinate (2870 2997 0),coordinate,3213,3428,0,2870,2997,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,641
+coordinate (2872 3937 0),coordinate,2964,3378,0,2872,3937,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,791
+coordinate (2875 3046 0),coordinate,3213,3428,0,2875,3046,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,131
+coordinate (2887 3154 0),coordinate,1750,3590,0,2887,3154,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,71
+coordinate (2892 3675 0),coordinate,2660,3657,0,2892,3675,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,418
+coordinate (2896 3119 0),coordinate,2964,3378,0,2896,3119,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,96
+coordinate (2919 3535 0),coordinate,3505,3488,0,2919,3535,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,231
+coordinate (2920 3403 0),coordinate,3298,3290,0,2920,3403,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,176
+coordinate (2924 2963 0),coordinate,3298,3290,0,2924,2963,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,382
+coordinate (2934 2727 0),coordinate,3038,3192,0,2934,2727,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,937
+coordinate (2936 2721 0),coordinate,2662,3305,0,2936,2721,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,701
+coordinate (2946 3819 0),coordinate,1700,3141,0,2946,3819,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,502
+coordinate (2950 2902 0),coordinate,3087,3496,0,2950,2902,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,400
+coordinate (2951 3820 0),coordinate,3702,3503,0,2951,3820,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,967
+coordinate (2961 3024 0),coordinate,3038,3192,0,2961,3024,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,352
+coordinate (2970 3749 0),coordinate,3505,3488,0,2970,3749,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,466
+coordinate (2970 3913 0),coordinate,3165,3487,0,2970,3913,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,586
+coordinate (2987 3963 0),coordinate,3038,3192,0,2987,3963,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,562
+coordinate (3005 3475 0),coordinate,2964,3378,0,3005,3475,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,201
+coordinate (3007 3144 0),coordinate,3213,3428,0,3007,3144,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,91
+coordinate (3013 3846 0),coordinate,3222,3218,0,3013,3846,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,514
+coordinate (3028 3928 0),coordinate,3165,3487,0,3028,3928,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1015
+coordinate (3039 3960 0),coordinate,3505,3488,0,3039,3960,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,556
+coordinate (3043 3940 0),coordinate,3087,3496,0,3043,3940,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,767
+coordinate (3051 3736 0),coordinate,1700,3141,0,3051,3736,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,779
+coordinate (3055 3696 0),coordinate,2760,3178,0,3055,3696,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,442
+coordinate (3058 3884 0),coordinate,2760,3178,0,3058,3884,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,520
+coordinate (3081 3209 0),coordinate,3298,3290,0,3081,3209,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,299
+coordinate (3085 3569 0),coordinate,1750,3590,0,3085,3569,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,931
+coordinate (3094 3764 0),coordinate,3213,3428,0,3094,3764,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,472
+coordinate (3113 3602 0),coordinate,3087,3496,0,3113,3602,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,412
+coordinate (3121 3384 0),coordinate,1750,3590,0,3121,3384,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,166
+coordinate (3138 2969 0),coordinate,3222,3218,0,3138,2969,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,376
+coordinate (3140 3804 0),coordinate,1750,3590,0,3140,3804,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,496
+coordinate (3143 3774 0),coordinate,3702,3503,0,3143,3774,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,580
+coordinate (3159 3959 0),coordinate,3038,3192,0,3159,3959,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,550
+coordinate (3160 3251 0),coordinate,2757,3478,0,3160,3251,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,116
+coordinate (3168 3041 0),coordinate,1700,3141,0,3168,3041,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,334
+coordinate (3168 3677 0),coordinate,2760,3178,0,3168,3677,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,424
+coordinate (3179 3344 0),coordinate,2662,3305,0,3179,3344,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,151
+coordinate (3183 2453 0),coordinate,3298,3290,0,3183,2453,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,281
+coordinate (3184 3150 0),coordinate,2757,3478,0,3184,3150,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,81
+coordinate (3188 3933 0),coordinate,3298,3290,0,3188,3933,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,761
+coordinate (3188 3939 0),coordinate,3213,3428,0,3188,3939,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1003
+coordinate (3189 3963 0),coordinate,3213,3428,0,3189,3963,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,568
+coordinate (3215 3835 0),coordinate,2660,3657,0,3215,3835,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,743
+coordinate (3217 3177 0),coordinate,3213,3428,0,3217,3177,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,86
+coordinate (3225 2838 0),coordinate,3213,3428,0,3225,2838,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,677
+coordinate (3244 3792 0),coordinate,2760,3178,0,3244,3792,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,490
+coordinate (3285 3942 0),coordinate,2442,3096,0,3285,3942,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,544
+coordinate (3290 3889 0),coordinate,2442,3096,0,3290,3889,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,526
+coordinate (3302 2988 0),coordinate,3087,3496,0,3302,2988,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,647
+coordinate (3302 3696 0),coordinate,3213,3428,0,3302,3696,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,448
+coordinate (3304 3941 0),coordinate,2442,3096,0,3304,3941,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,1009
+coordinate (3305 3692 0),coordinate,3165,3487,0,3305,3692,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,436
+coordinate (3311 3769 0),coordinate,3087,3496,0,3311,3769,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,478
+coordinate (3312 3375 0),coordinate,3165,3487,0,3312,3375,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,161
+coordinate (3318 2706 0),coordinate,3165,3487,0,3318,2706,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,833
+coordinate (3369 3894 0),coordinate,3505,3488,0,3369,3894,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,749
+coordinate (3380 3929 0),coordinate,1750,3590,0,3380,3929,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,997
+coordinate (3380 3963 0),coordinate,2964,3378,0,3380,3963,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,773
+coordinate (3399 3246 0),coordinate,3505,3488,0,3399,3246,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,305
+coordinate (3429 3523 0),coordinate,3213,3428,0,3429,3523,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,221
+coordinate (3430 3388 0),coordinate,3165,3487,0,3430,3388,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,171
+coordinate (3440 3341 0),coordinate,1700,3141,0,3440,3341,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,364
+coordinate (3441 3419 0),coordinate,2442,3096,0,3441,3419,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,394
+coordinate (3443 3515 0),coordinate,2660,3657,0,3443,3515,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,211
+coordinate (3510 3074 0),coordinate,3702,3503,0,3510,3074,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,111
+coordinate (3544 3256 0),coordinate,3298,3290,0,3544,3256,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,322
+coordinate (3546 3251 0),coordinate,2660,3657,0,3546,3251,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,316
+coordinate (3548 3560 0),coordinate,3505,3488,0,3548,3560,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,236
+coordinate (3560 3987 0),coordinate,3702,3503,0,3560,3987,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,809
+coordinate (3570 3405 0),coordinate,1750,3590,0,3570,3405,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,913
+coordinate (3573 3425 0),coordinate,2662,3305,0,3573,3425,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,665
+coordinate (3587 3180 0),coordinate,2757,3478,0,3587,3180,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,616
+coordinate (3603 3564 0),coordinate,3038,3192,0,3603,3564,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,695
+coordinate (3604 3564 0),coordinate,2660,3657,0,3604,3564,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,925
+coordinate (3622 3320 0),coordinate,3165,3487,0,3622,3320,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,901
+coordinate (3764 3900 0),coordinate,3222,3218,0,3764,3900,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,271
+coordinate (3765 3899 0),coordinate,3038,3192,0,3765,3899,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,532
+coordinate (3771 3825 0),coordinate,2964,3378,0,3771,3825,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,508
+coordinate (3811 3060 0),coordinate,3165,3487,0,3811,3060,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,628
+coordinate (3822 3562 0),coordinate,3298,3290,0,3822,3562,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,689
+coordinate (3828 2848 0),coordinate,2442,3096,0,3828,2848,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,671
+coordinate (3830 3060 0),coordinate,3702,3503,0,3830,3060,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CoordinateClue.java,882
+cryptic (1179 3626 0),cryptic,2662,3305,0,1179,3626,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1761
+cryptic (1310 1251 0),cryptic,3304,3124,0,1310,1251,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1068
+cryptic (1367 3367 0),cryptic,3165,3487,0,1367,3367,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2014
+cryptic (1388 3216 0),cryptic,3505,3488,0,1388,3216,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2026
+cryptic (1390 2926 0),cryptic,3304,3124,0,1390,2926,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2007
+cryptic (1418 3591 0),cryptic,2757,3478,0,1418,3591,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1921
+cryptic (1432 9584 1),cryptic,3087,3496,0,1432,9584,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1988
+cryptic (1486 3834 0),cryptic,3038,3192,0,1486,3834,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1369
+cryptic (1490 3257 0),cryptic,2757,3478,0,1490,3257,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1995
+cryptic (1506 3590 2),cryptic,2442,3096,0,1506,3590,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1934
+cryptic (1560 3048 2),cryptic,3222,3218,0,1560,3048,2,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1974
+cryptic (1633 3808 0),cryptic,2757,3478,0,1633,3808,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1586
+cryptic (1633 3825 2),cryptic,2964,3378,0,1633,3825,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1712
+cryptic (1639 3673 0),cryptic,2662,3305,0,1639,3673,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1693
+cryptic (1646 3631 0),cryptic,3702,3503,0,1646,3631,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1255
+cryptic (1683 3616 0),cryptic,2964,3378,0,1683,3616,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1732
+cryptic (1703 3524 0),cryptic,2964,3378,0,1703,3524,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1593
+cryptic (1718 3626 0),cryptic,2662,3305,0,1718,3626,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1942
+cryptic (1720 3652 1),cryptic,3702,3503,0,1720,3652,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1619
+cryptic (1734 3576 0),cryptic,2757,3478,0,1734,3576,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,274
+cryptic (1746 3490 0),cryptic,3298,3290,0,1746,3490,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1472
+cryptic (1756 4940 0),cryptic,2660,3657,0,1756,4940,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1145
+cryptic (1799 3613 0),cryptic,3298,3290,0,1799,3613,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1927
+cryptic (1802 9504 0),cryptic,3702,3503,0,1802,9504,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1981
+cryptic (1820 9935 0),cryptic,2442,3096,0,1820,9935,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1949
+cryptic (1821 3690 0),cryptic,2760,3178,0,1821,3690,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1824
+cryptic (1836 3786 0),cryptic,3702,3503,0,1836,3786,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1522
+cryptic (1863 4639 0),cryptic,3213,3428,0,1863,4639,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1307
+cryptic (1910 4367 0),cryptic,3165,3487,0,1910,4367,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1249
+cryptic (1934 4427 0),cryptic,1700,3141,0,1934,4427,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,789
+cryptic (2186 3148 0),cryptic,3702,3503,0,2186,3148,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1901
+cryptic (2204 3050 0),cryptic,3213,3428,0,2204,3050,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,445
+cryptic (2221 3091 0),cryptic,3222,3218,0,2221,3091,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1895
+cryptic (2288 4702 0),cryptic,2660,3657,0,2288,4702,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1241
+cryptic (2324 2772 0),cryptic,2662,3305,0,2324,2772,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2040
+cryptic (2333 3165 0),cryptic,3702,3503,0,2333,3165,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1908
+cryptic (2336 3799 0),cryptic,3087,3496,0,2336,3799,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,932
+cryptic (2342 3677 0),cryptic,3038,3192,0,2342,3677,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1706
+cryptic (2386 3487 0),cryptic,1700,3141,0,2386,3487,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1170
+cryptic (2410 4714 0),cryptic,3222,3218,0,2410,4714,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1294
+cryptic (2444 3049 0),cryptic,2964,3378,0,2444,3049,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1752
+cryptic (2458 3504 0),cryptic,3165,3487,0,2458,3504,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1119
+cryptic (2476 3428 0),cryptic,2662,3305,0,2476,3428,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,649
+cryptic (2488 3409 1),cryptic,3213,3428,0,2488,3409,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1021
+cryptic (2490 3488 0),cryptic,3304,3124,0,2490,3488,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,149
+cryptic (2512 3641 1),cryptic,2662,3305,0,2512,3641,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1110
+cryptic (2523 3493 1),cryptic,1700,3141,0,2523,3493,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,693
+cryptic (2523 3739 0),cryptic,2662,3305,0,2523,3739,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1321
+cryptic (2527 3891 0),cryptic,3213,3428,0,2527,3891,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,140
+cryptic (2529 2838 0),cryptic,2757,3478,0,2529,2838,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1739
+cryptic (2544 3170 0),cryptic,3304,3124,0,2544,3170,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,479
+cryptic (2561 3323 0),cryptic,3213,3428,0,2561,3323,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1961
+cryptic (2570 3085 0),cryptic,3304,3124,0,2570,3085,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1327
+cryptic (2570 3250 0),cryptic,3298,3290,0,2570,3250,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,684
+cryptic (2574 3326 1),cryptic,3505,3488,0,2574,3326,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,604
+cryptic (2576 3464 0),cryptic,2964,3378,0,2576,3464,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,748
+cryptic (2576 9583 0),cryptic,3304,3124,0,2576,9583,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,904
+cryptic (2591 3879 0),cryptic,1700,3141,0,2591,3879,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,557
+cryptic (2593 3108 1),cryptic,2662,3305,0,2593,3108,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,495
+cryptic (2598 3105 0),cryptic,3505,3488,0,2598,3105,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,714
+cryptic (2598 3267 0),cryptic,3087,3496,0,2598,3267,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,232
+cryptic (2608 3116 0),cryptic,3087,3496,0,2608,3116,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,959
+cryptic (2611 3324 1),cryptic,1700,3141,0,2611,3324,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,213
+cryptic (2612 3304 1),cryptic,3222,3218,0,2612,3304,1,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,419
+cryptic (2614 3204 0),cryptic,3087,3496,0,2614,3204,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,199
+cryptic (2615 3291 0),cryptic,2660,3657,0,2615,3291,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1537
+cryptic (2617 3347 0),cryptic,1700,3141,0,2617,3347,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,267
+cryptic (2635 3310 0),cryptic,3505,3488,0,2635,3310,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,987
+cryptic (2636 3453 0),cryptic,3702,3503,0,2636,3453,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,98
+cryptic (2638 2656 0),cryptic,3087,3496,0,2638,2656,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1314
+cryptic (2645 3338 0),cryptic,2964,3378,0,2645,3338,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1349
+cryptic (2653 3320 0),cryptic,1750,3590,0,2653,3320,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1089
+cryptic (2654 3299 0),cryptic,3213,3428,0,2654,3299,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1458
+cryptic (2660 3149 0),cryptic,2760,3178,0,2660,3149,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,245
+cryptic (2671 3437 0),cryptic,3505,3488,0,2671,3437,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1179
+cryptic (2671 10396 0),cryptic,3298,3290,0,2671,10396,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1551
+cryptic (2672 3416 0),cryptic,3038,3192,0,2672,3416,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,635
+cryptic (2682 3325 0),cryptic,3304,3124,0,2682,3325,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1674
+cryptic (2689 3550 0),cryptic,2757,3478,0,2689,3550,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,126
+cryptic (2699 3470 0),cryptic,3505,3488,0,2699,3470,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,171
+cryptic (2703 3409 1),cryptic,3505,3488,0,2703,3409,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,762
+cryptic (2707 3488 2),cryptic,3222,3218,0,2707,3488,2,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,514
+cryptic (2709 3478 0),cryptic,3298,3290,0,2709,3478,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1529
+cryptic (2716 3471 1),cryptic,1750,3590,0,2716,3471,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,925
+cryptic (2723 9891 0),cryptic,2660,3657,0,2723,9891,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1681
+cryptic (2733 3415 0),cryptic,3702,3503,0,2733,3415,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,69
+cryptic (2736 3578 0),cryptic,3165,3487,0,2736,3578,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,721
+cryptic (2737 3580 0),cryptic,3702,3503,0,2737,3580,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,563
+cryptic (2744 5116 0),cryptic,3304,3124,0,2744,5116,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1403
+cryptic (2745 3151 0),cryptic,2442,3096,0,2745,3151,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,192
+cryptic (2748 3495 2),cryptic,1750,3590,0,2748,3495,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1493
+cryptic (2759 2775 0),cryptic,2660,3657,0,2759,2775,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1193
+cryptic (2759 3497 0),cryptic,3222,3218,0,2759,3497,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,185
+cryptic (2764 3273 0),cryptic,2964,3378,0,2764,3273,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,966
+cryptic (2779 3211 0),cryptic,3702,3503,0,2779,3211,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,741
+cryptic (2780 3783 0),cryptic,3087,3496,0,2780,3783,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,671
+cryptic (2791 3183 0),cryptic,3702,3503,0,2791,3183,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,734
+cryptic (2799 3438 0),cryptic,3213,3428,0,2799,3438,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,156
+cryptic (2800 3074 0),cryptic,2964,3378,0,2800,3074,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,584
+cryptic (2803 3430 0),cryptic,1700,3141,0,2803,3430,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,939
+cryptic (2809 3165 1),cryptic,3304,3124,0,2809,3165,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1429
+cryptic (2809 3451 1),cryptic,2660,3657,0,2809,3451,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1613
+cryptic (2818 3351 0),cryptic,1700,3141,0,2818,3351,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,707
+cryptic (2825 3442 0),cryptic,2442,3096,0,2825,3442,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1479
+cryptic (2832 9586 0),cryptic,2964,3378,0,2832,9586,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,544
+cryptic (2833 2992 0),cryptic,1750,3590,0,2833,2992,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,980
+cryptic (2840 3538 0),cryptic,3298,3290,0,2840,3538,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,488
+cryptic (2847 3499 0),cryptic,3702,3503,0,2847,3499,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,260
+cryptic (2857 2966 0),cryptic,3213,3428,0,2857,2966,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1508
+cryptic (2860 3431 0),cryptic,1700,3141,0,2860,3431,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,452
+cryptic (2867 3546 0),cryptic,3222,3218,0,2867,3546,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,809
+cryptic (2874 3757 0),cryptic,2442,3096,0,2874,3757,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1376
+cryptic (2878 3546 0),cryptic,3298,3290,0,2878,3546,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1579
+cryptic (2884 3450 0),cryptic,3304,3124,0,2884,3450,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,836
+cryptic (2885 3540 0),cryptic,1700,3141,0,2885,3540,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1300
+cryptic (2886 3449 0),cryptic,3165,3487,0,2886,3449,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1416
+cryptic (2894 3418 0),cryptic,2660,3657,0,2894,3418,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1221
+cryptic (2898 3428 0),cryptic,2660,3657,0,2898,3428,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,829
+cryptic (2913 3536 0),cryptic,2964,3378,0,2913,3536,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,281
+cryptic (2914 3433 0),cryptic,2757,3478,0,2914,3433,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1014
+cryptic (2914 5300 1),cryptic,2442,3096,0,2914,5300,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1423
+cryptic (2915 3452 0),cryptic,2757,3478,0,2915,3452,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1875
+cryptic (2921 3577 0),cryptic,1700,3141,0,2921,3577,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1356
+cryptic (2922 3484 0),cryptic,2660,3657,0,2922,3484,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,350
+cryptic (2924 3405 0),cryptic,1750,3590,0,2924,3405,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,776
+cryptic (2927 3761 0),cryptic,2757,3478,0,2927,3761,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1644
+cryptic (2929 3570 0),cryptic,2662,3305,0,2929,3570,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1334
+cryptic (2930 3536 0),cryptic,3298,3290,0,2930,3536,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1882
+cryptic (2932 3212 0),cryptic,1700,3141,0,2932,3212,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1719
+cryptic (2945 3335 0),cryptic,1750,3590,0,2945,3335,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1465
+cryptic (2945 3379 0),cryptic,3087,3496,0,2945,3379,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,857
+cryptic (2946 3207 0),cryptic,2757,3478,0,2946,3207,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1832
+cryptic (2951 3451 0),cryptic,1750,3590,0,2951,3451,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,946
+cryptic (2955 3390 0),cryptic,3222,3218,0,2955,3390,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,577
+cryptic (2957 3511 0),cryptic,2757,3478,0,2957,3511,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,871
+cryptic (2969 3311 0),cryptic,2757,3478,0,2969,3311,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,850
+cryptic (2970 3214 1),cryptic,3298,3290,0,2970,3214,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,621
+cryptic (2971 3386 1),cryptic,1700,3141,0,2971,3386,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1103
+cryptic (2972 3312 0),cryptic,2660,3657,0,2972,3312,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1868
+cryptic (2975 3383 0),cryptic,3038,3192,0,2975,3383,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1281
+cryptic (2977 3343 0),cryptic,3038,3192,0,2977,3343,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1514
+cryptic (2978 3239 0),cryptic,3038,3192,0,2978,3239,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1557
+cryptic (2979 3340 0),cryptic,3298,3290,0,2979,3340,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,537
+cryptic (2979 3435 0),cryptic,2442,3096,0,2979,3435,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,465
+cryptic (2982 3336 2),cryptic,2760,3178,0,2982,3336,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1699
+cryptic (2983 3338 0),cryptic,3087,3496,0,2983,3338,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,815
+cryptic (3000 9798 0),cryptic,3165,3487,0,3000,9798,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1662
+cryptic (3012 3222 0),cryptic,2757,3478,0,3012,3222,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,769
+cryptic (3013 3179 0),cryptic,2442,3096,0,3013,3179,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,112
+cryptic (3014 3222 0),cryptic,2660,3657,0,3014,3222,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,843
+cryptic (3016 3205 1),cryptic,3165,3487,0,3016,3205,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,288
+cryptic (3019 3232 0),cryptic,3505,3488,0,3019,3232,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1486
+cryptic (3024 3259 0),cryptic,2757,3478,0,3024,3259,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1186
+cryptic (3026 3378 0),cryptic,3505,3488,0,3026,3378,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,521
+cryptic (3029 3355 0),cryptic,3298,3290,0,3029,3355,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,322
+cryptic (3035 9849 0),cryptic,2662,3305,0,3035,9849,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,412
+cryptic (3038 3292 0),cryptic,3222,3218,0,3038,3292,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,163
+cryptic (3039 3342 0),cryptic,3213,3428,0,3039,3342,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1389
+cryptic (3040 3399 0),cryptic,3505,3488,0,3040,3399,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,459
+cryptic (3041 3364 1),cryptic,2760,3178,0,3041,3364,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1033
+cryptic (3041 9820 0),cryptic,3165,3487,0,3041,9820,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,892
+cryptic (3042 3236 0),cryptic,3038,3192,0,3042,3236,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1500
+cryptic (3043 4974 1),cryptic,1700,3141,0,3043,4974,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1062
+cryptic (3045 3256 0),cryptic,3298,3290,0,3045,3256,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,76
+cryptic (3045 10265 0),cryptic,1750,3590,0,3045,10265,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1151
+cryptic (3046 3382 0),cryptic,2760,3178,0,3046,3382,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,677
+cryptic (3049 4839 0),cryptic,1750,3590,0,3049,4839,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,796
+cryptic (3054 3484 0),cryptic,3505,3488,0,3054,3484,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,911
+cryptic (3055 10338 0),cryptic,2662,3305,0,3055,10338,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1288
+cryptic (3058 3487 0),cryptic,3222,3218,0,3058,3487,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1096
+cryptic (3068 3516 0),cryptic,2964,3378,0,3068,3516,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,84
+cryptic (3069 3935 0),cryptic,1700,3141,0,3069,3935,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1607
+cryptic (3073 3430 0),cryptic,3505,3488,0,3073,3430,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,570
+cryptic (3079 3493 0),cryptic,3087,3496,0,3079,3493,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,384
+cryptic (3081 3421 0),cryptic,2442,3096,0,3081,3421,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,378
+cryptic (3085 3255 0),cryptic,3038,3192,0,3085,3255,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1001
+cryptic (3085 3429 0),cryptic,3213,3428,0,3085,3429,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1007
+cryptic (3087 3261 0),cryptic,3505,3488,0,3087,3261,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,472
+cryptic (3088 3357 0),cryptic,2964,3378,0,3088,3357,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1564
+cryptic (3089 3468 0),cryptic,3038,3192,0,3089,3468,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,316
+cryptic (3091 3477 0),cryptic,2662,3305,0,3091,3477,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,700
+cryptic (3096 9572 0),cryptic,3038,3192,0,3096,9572,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,628
+cryptic (3097 3277 0),cryptic,2442,3096,0,3097,3277,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1409
+cryptic (3097 3432 2),cryptic,2660,3657,0,3097,3432,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1782
+cryptic (3098 3258 0),cryptic,3038,3192,0,3098,3258,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,391
+cryptic (3098 3268 0),cryptic,2442,3096,0,3098,3268,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1817
+cryptic (3103 3163 2),cryptic,1700,3141,0,3103,3163,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,994
+cryptic (3106 3369 2),cryptic,3038,3192,0,3106,3369,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,336
+cryptic (3113 3159 0),cryptic,3087,3496,0,3113,3159,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,133
+cryptic (3116 9562 0),cryptic,2760,3178,0,3116,9562,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,504
+cryptic (3121 9995 0),cryptic,3038,3192,0,3121,9995,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2047
+cryptic (3139 4554 0),cryptic,3702,3503,0,3139,4554,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1275
+cryptic (3143 3445 0),cryptic,3505,3488,0,3143,3445,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,438
+cryptic (3146 3177 0),cryptic,3702,3503,0,3146,3177,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1050
+cryptic (3146 9913 0),cryptic,2442,3096,0,3146,9913,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,329
+cryptic (3149 3177 0),cryptic,2760,3178,0,3149,3177,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1810
+cryptic (3156 3406 0),cryptic,3505,3488,0,3156,3406,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1138
+cryptic (3161 9904 0),cryptic,3702,3503,0,3161,9904,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1157
+cryptic (3166 3309 2),cryptic,3038,3192,0,3166,3309,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,614
+cryptic (3170 3885 0),cryptic,3165,3487,0,3170,3885,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,665
+cryptic (3174 3663 0),cryptic,2757,3478,0,3174,3663,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,432
+cryptic (3176 2478 0),cryptic,3505,3488,0,3176,2478,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2033
+cryptic (3178 2987 0),cryptic,3702,3503,0,3178,2987,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,973
+cryptic (3183 3941 0),cryptic,2660,3657,0,3183,3941,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1889
+cryptic (3185 3274 0),cryptic,2660,3657,0,3185,3274,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1803
+cryptic (3186 3936 0),cryptic,3165,3487,0,3186,3936,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1082
+cryptic (3187 9825 0),cryptic,2662,3305,0,3187,9825,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,119
+cryptic (3191 9825 0),cryptic,2662,3305,0,3191,9825,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,728
+cryptic (3194 3403 0),cryptic,3505,3488,0,3194,3403,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1200
+cryptic (3195 3357 0),cryptic,1750,3590,0,3195,3357,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,598
+cryptic (3203 3384 0),cryptic,2662,3305,0,3203,3384,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,357
+cryptic (3203 3424 0),cryptic,3298,3290,0,3203,3424,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1163
+cryptic (3205 3474 0),cryptic,3165,3487,0,3205,3474,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,918
+cryptic (3206 3419 1),cryptic,1700,3141,0,3206,3419,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1131
+cryptic (3208 3213 0),cryptic,1700,3141,0,3208,3213,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1774
+cryptic (3209 3218 1),cryptic,2660,3657,0,3209,3218,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1437
+cryptic (3209 3390 0),cryptic,3038,3192,0,3209,3390,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1789
+cryptic (3211 3219 0),cryptic,1700,3141,0,3211,3219,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,178
+cryptic (3213 3216 1),cryptic,3213,3428,0,3213,3216,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,309
+cryptic (3219 9617 0),cryptic,3298,3290,0,3219,9617,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1214
+cryptic (3221 3218 0),cryptic,1700,3141,0,3221,3218,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1767
+cryptic (3221 3219 0),cryptic,1750,3590,0,3221,3219,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1235
+cryptic (3221 3435 0),cryptic,3222,3218,0,3221,3435,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,822
+cryptic (3224 3492 0),cryptic,1750,3590,0,3224,3492,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,550
+cryptic (3226 3399 0),cryptic,2760,3178,0,3226,3399,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,252
+cryptic (3226 3452 0),cryptic,3222,3218,0,3226,3452,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,343
+cryptic (3228 3212 1),cryptic,3304,3124,0,3228,3212,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,642
+cryptic (3228 3433 0),cryptic,2757,3478,0,3228,3433,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1572
+cryptic (3230 3209 0),cryptic,1750,3590,0,3230,3209,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1955
+cryptic (3230 3401 0),cryptic,1700,3141,0,3230,3401,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1846
+cryptic (3232 3228 0),cryptic,3505,3488,0,3232,3228,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1444
+cryptic (3242 3207 0),cryptic,2760,3178,0,3242,3207,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,105
+cryptic (3245 3245 0),cryptic,3505,3488,0,3245,3245,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,802
+cryptic (3250 3420 1),cryptic,3702,3503,0,3250,3420,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1745
+cryptic (3252 9517 2),cryptic,1700,3141,0,3252,9517,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1262
+cryptic (3256 3487 0),cryptic,2760,3178,0,3256,3487,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,528
+cryptic (3260 3385 0),cryptic,3222,3218,0,3260,3385,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1341
+cryptic (3276 3191 0),cryptic,1750,3590,0,3276,3191,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1655
+cryptic (3283 3329 0),cryptic,2660,3657,0,3283,3329,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1839
+cryptic (3287 3190 0),cryptic,1750,3590,0,3287,3190,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1600
+cryptic (3289 3022 0),cryptic,3087,3496,0,3289,3022,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,591
+cryptic (3289 3202 0),cryptic,3038,3192,0,3289,3202,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1632
+cryptic (3295 3934 1),cryptic,2662,3305,0,3295,3934,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2045
+cryptic (3297 3890 0),cryptic,3222,3218,0,3297,3890,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1125
+cryptic (3301 3169 1),cryptic,1750,3590,0,3301,3169,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1451
+cryptic (3303 3123 0),cryptic,3222,3218,0,3303,3123,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1796
+cryptic (3303 6092 0),cryptic,3165,3487,0,3303,6092,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1915
+cryptic (3307 9505 0),cryptic,1700,3141,0,3307,9505,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1626
+cryptic (3308 3206 0),cryptic,2662,3305,0,3308,3206,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1075
+cryptic (3345 3378 0),cryptic,3038,3192,0,3345,3378,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,878
+cryptic (3353 3332 0),cryptic,3087,3496,0,3353,3332,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,301
+cryptic (3362 3341 0),cryptic,3213,3428,0,3362,3341,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,864
+cryptic (3367 3221 0),cryptic,3702,3503,0,3367,3221,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,885
+cryptic (3371 9320 0),cryptic,1750,3590,0,3371,9320,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,656
+cryptic (3376 3284 0),cryptic,2660,3657,0,3376,3284,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,206
+cryptic (3388 3152 0),cryptic,3298,3290,0,3388,3152,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,953
+cryptic (3410 3324 0),cryptic,3038,3192,0,3410,3324,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,295
+cryptic (3444 3461 0),cryptic,2660,3657,0,3444,3461,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,91
+cryptic (3447 3547 1),cryptic,2660,3657,0,3447,3547,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,2046
+cryptic (3478 3091 0),cryptic,1750,3590,0,3478,3091,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,364
+cryptic (3488 3289 0),cryptic,3702,3503,0,3488,3289,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,426
+cryptic (3494 3474 0),cryptic,1700,3141,0,3494,3474,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1382
+cryptic (3498 3507 0),cryptic,3702,3503,0,3498,3507,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,238
+cryptic (3499 3503 0),cryptic,3165,3487,0,3499,3503,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,225
+cryptic (3509 3497 0),cryptic,2760,3178,0,3509,3497,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,405
+cryptic (3547 3183 0),cryptic,3222,3218,0,3547,3183,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,783
+cryptic (3572 4372 0),cryptic,3213,3428,0,3572,4372,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1968
+cryptic (3673 3492 0),cryptic,3304,3124,0,3673,3492,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1207
+cryptic (3816 3810 0),cryptic,3505,3488,0,3816,3810,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/CrypticClue.java,1726
+emote (1306 3839 0),emote,3165,3487,0,1306,3839,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,164
+emote (1436 3115 0),emote,3213,3428,0,1436,3115,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,211
+emote (1487 3635 0),emote,3213,3428,0,1487,3635,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,215
+emote (1543 3623 0),emote,2662,3305,0,1543,3623,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,143
+emote (1610 3302 0),emote,2662,3305,0,1610,3302,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,226
+emote (1626 3241 0),emote,3213,3428,0,1626,3241,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,196
+emote (1632 3807 0),emote,2442,3096,0,1632,3807,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,237
+emote (1663 10045 0),emote,2964,3378,0,1663,10045,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,216
+emote (1694 3247 0),emote,2662,3305,0,1694,3247,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,203
+emote (1699 3087 0),emote,2964,3378,0,1699,3087,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,150
+emote (1712 3163 0),emote,3304,3124,0,1712,3163,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,238
+emote (1714 3467 0),emote,3165,3487,0,1714,3467,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,246
+emote (1768 5366 1),emote,2442,3096,0,1768,5366,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,188
+emote (1815 3856 0),emote,2662,3305,0,1815,3856,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,219
+emote (1944 4427 0),emote,3304,3124,0,1944,4427,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,231
+emote (1946 4074 0),emote,3087,3496,0,1946,4074,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,249
+emote (2011 4712 0),emote,2757,3478,0,2011,4712,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,123
+emote (2069 2608 0),emote,2964,3378,0,2069,2608,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,248
+emote (2199 3056 0),emote,2442,3096,0,2199,3056,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,190
+emote (2205 3252 0),emote,2442,3096,0,2205,3252,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,144
+emote (2205 4838 0),emote,3165,3487,0,2205,4838,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,125
+emote (2207 4952 0),emote,2964,3378,0,2207,4952,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,135
+emote (2211 3427 0),emote,3087,3496,0,2211,3427,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,140
+emote (2271 4680 0),emote,3165,3487,0,2271,4680,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,176
+emote (2375 3850 0),emote,2442,3096,0,2375,3850,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,189
+emote (2439 3161 0),emote,3213,3428,0,2439,3161,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,225
+emote (2440 3092 0),emote,3087,3496,0,2440,3092,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,234
+emote (2463 5149 0),emote,2442,3096,0,2463,5149,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,168
+emote (2473 3420 2),emote,3298,3290,0,2473,3420,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,167
+emote (2477 3047 0),emote,3298,3290,0,2477,3047,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,134
+emote (2477 5146 0),emote,2662,3305,0,2477,5146,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,187
+emote (2511 3641 2),emote,3165,3487,0,2511,3641,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,149
+emote (2527 3375 0),emote,2442,3096,0,2527,3375,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,156
+emote (2530 3290 0),emote,2662,3305,0,2530,3290,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,221
+emote (2552 3556 0),emote,3165,3487,0,2552,3556,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,119
+emote (2568 3149 0),emote,3087,3496,0,2568,3149,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,126
+emote (2588 3419 0),emote,2442,3096,0,2588,3419,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,207
+emote (2607 3282 0),emote,3165,3487,0,2607,3282,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,205
+emote (2610 3092 0),emote,2442,3096,0,2610,3092,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,186
+emote (2610 3391 0),emote,3213,3428,0,2610,3391,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,182
+emote (2629 5071 0),emote,2757,3478,0,2629,5071,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,121
+emote (2635 3385 2),emote,3038,3192,0,2635,3385,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,161
+emote (2666 3304 0),emote,3298,3290,0,2666,3304,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,195
+emote (2676 3169 0),emote,2757,3478,0,2676,3169,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,136
+emote (2728 3377 0),emote,3165,3487,0,2728,3377,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,147
+emote (2729 3349 0),emote,3038,3192,0,2729,3349,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,146
+emote (2735 3469 0),emote,2757,3478,0,2735,3469,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,162
+emote (2741 3536 0),emote,3213,3428,0,2741,3536,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,194
+emote (2757 3401 0),emote,3298,3290,0,2757,3401,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,206
+emote (2759 3445 0),emote,3304,3124,0,2759,3445,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,185
+emote (2776 3781 0),emote,3165,3487,0,2776,3781,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,202
+emote (2782 3273 0),emote,3298,3290,0,2782,3273,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,124
+emote (2803 3073 0),emote,2757,3478,0,2803,3073,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,142
+emote (2808 3440 0),emote,3304,3124,0,2808,3440,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,213
+emote (2812 3681 0),emote,2964,3378,0,2812,3681,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,193
+emote (2823 3443 0),emote,3298,3290,0,2823,3443,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,165
+emote (2843 3543 0),emote,2964,3378,0,2843,3543,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,204
+emote (2844 3542 0),emote,3038,3192,0,2844,3542,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,209
+emote (2851 2954 0),emote,3087,3496,0,2851,2954,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,151
+emote (2852 3349 0),emote,2442,3096,0,2852,3349,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,157
+emote (2852 3429 0),emote,3038,3192,0,2852,3429,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,166
+emote (2887 3676 0),emote,3304,3124,0,2887,3676,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,236
+emote (2914 3168 0),emote,3304,3124,0,2914,3168,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,208
+emote (2920 9893 0),emote,3298,3290,0,2920,9893,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,192
+emote (2924 3478 0),emote,2442,3096,0,2924,3478,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,154
+emote (2925 5333 2),emote,3087,3496,0,2925,5333,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,153
+emote (2930 4717 2),emote,2757,3478,0,2930,4717,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,239
+emote (2950 3387 0),emote,2662,3305,0,2950,3387,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,245
+emote (2954 2933 0),emote,3165,3487,0,2954,2933,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,118
+emote (2956 3505 0),emote,3087,3496,0,2956,3505,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,178
+emote (2976 3238 0),emote,3304,3124,0,2976,3238,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,212
+emote (2981 3276 0),emote,2662,3305,0,2981,3276,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,217
+emote (2989 3110 0),emote,3304,3124,0,2989,3110,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,229
+emote (3026 3701 0),emote,2442,3096,0,3026,3701,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,235
+emote (3030 4522 0),emote,2442,3096,0,3030,4522,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,223
+emote (3043 4697 3),emote,3298,3290,0,3043,4697,3,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,122
+emote (3045 3376 0),emote,2757,3478,0,3045,3376,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,171
+emote (3047 3237 0),emote,3213,3428,0,3047,3237,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,158
+emote (3049 2966 0),emote,3304,3124,0,3049,2966,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,247
+emote (3056 3484 1),emote,2757,3478,0,3056,3484,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,120
+emote (3069 3861 0),emote,2964,3378,0,3069,3861,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,152
+emote (3080 3509 0),emote,3304,3124,0,3080,3509,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,155
+emote (3083 3253 0),emote,2662,3305,0,3083,3253,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,233
+emote (3088 3254 0),emote,2757,3478,0,3088,3254,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,139
+emote (3088 3336 0),emote,3087,3496,0,3088,3336,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,218
+emote (3105 3420 0),emote,2757,3478,0,3105,3420,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,222
+emote (3109 3294 0),emote,3087,3496,0,3109,3294,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,170
+emote (3113 3196 0),emote,2442,3096,0,3113,3196,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,160
+emote (3128 3245 0),emote,3087,3496,0,3128,3245,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,169
+emote (3159 3298 0),emote,3038,3192,0,3159,3298,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,224
+emote (3164 3477 0),emote,3213,3428,0,3164,3477,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,241
+emote (3165 3467 0),emote,3038,3192,0,3165,3467,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,177
+emote (3168 9571 0),emote,2662,3305,0,3168,9571,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,173
+emote (3191 3960 0),emote,3165,3487,0,3191,3960,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,163
+emote (3203 3169 0),emote,2662,3305,0,3203,3169,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,172
+emote (3205 3416 0),emote,3298,3290,0,3205,3416,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,242
+emote (3209 3492 0),emote,3304,3124,0,3209,3492,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,232
+emote (3213 3463 0),emote,3038,3192,0,3213,3463,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,220
+emote (3227 3831 0),emote,2662,3305,0,3227,3831,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,201
+emote (3230 3478 0),emote,3304,3124,0,3230,3478,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,138
+emote (3231 3203 0),emote,3304,3124,0,3231,3203,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,243
+emote (3241 3672 0),emote,3304,3124,0,3241,3672,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,214
+emote (3253 3401 0),emote,3213,3428,0,3253,3401,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,184
+emote (3294 2781 0),emote,3165,3487,0,3294,2781,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,174
+emote (3299 3289 0),emote,3087,3496,0,3299,3289,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,179
+emote (3303 3271 0),emote,2662,3305,0,3303,3271,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,244
+emote (3304 3124 0),emote,3298,3290,0,3304,3124,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,183
+emote (3307 3491 0),emote,2662,3305,0,3307,3491,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,227
+emote (3314 3241 0),emote,3087,3496,0,3314,3241,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,148
+emote (3361 3339 0),emote,2442,3096,0,3361,3339,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,159
+emote (3362 3340 0),emote,2757,3478,0,3362,3340,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,180
+emote (3368 3935 0),emote,3304,3124,0,3368,3935,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,199
+emote (3370 3425 0),emote,3038,3192,0,3370,3425,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,141
+emote (3372 3498 0),emote,3038,3192,0,3372,3498,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,197
+emote (3421 3537 2),emote,2757,3478,0,3421,3537,2,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,181
+emote (3492 3488 0),emote,3298,3290,0,3492,3488,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,175
+emote (3504 3576 0),emote,3038,3192,0,3504,3576,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,198
+emote (3551 9694 0),emote,2757,3478,0,3551,9694,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,127
+emote (3562 3379 0),emote,2757,3478,0,3562,3379,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,230
+emote (3611 3492 0),emote,3304,3124,0,3611,3492,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/EmoteClue.java,137
+fairy_ring (1630 3868 0),fairy_ring,3702,3503,0,1630,3868,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,53
+fairy_ring (1646 3012 0),fairy_ring,2757,3478,0,1646,3012,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,48
+fairy_ring (2073 4846 0),fairy_ring,3702,3503,0,2073,4846,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,54
+fairy_ring (2439 5132 0),fairy_ring,3505,3488,0,2439,5132,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,50
+fairy_ring (2504 3633 0),fairy_ring,2964,3378,0,2504,3633,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,49
+fairy_ring (2648 4729 0),fairy_ring,3298,3290,0,2648,4729,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,51
+fairy_ring (2702 3246 0),fairy_ring,2660,3657,0,2702,3246,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,46
+fairy_ring (2747 3720 0),fairy_ring,2964,3378,0,2747,3720,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,56
+fairy_ring (3000 3110 0),fairy_ring,3087,3496,0,3000,3110,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,47
+fairy_ring (3041 4770 0),fairy_ring,3298,3290,0,3041,4770,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,55
+fairy_ring (3407 3330 0),fairy_ring,3298,3290,0,3407,3330,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/FairyRingClue.java,52
+hot_cold (2436 3347 0),hot_cold,2760,3178,0,2436,3347,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java,67
+hot_cold (3211 3494 0),hot_cold,3702,3503,0,3211,3494,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/HotColdClue.java,62
+hot_cold_possible (1187 3580 0),hot_cold_possible,2442,3096,0,1187,3580,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,203
+hot_cold_possible (1208 3736 0),hot_cold_possible,2757,3478,0,1208,3736,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,201
+hot_cold_possible (1312 3108 0),hot_cold_possible,2964,3378,0,1312,3108,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,158
+hot_cold_possible (1324 3722 0),hot_cold_possible,3298,3290,0,1324,3722,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,202
+hot_cold_possible (1428 3869 0),hot_cold_possible,2757,3478,0,1428,3869,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,185
+hot_cold_possible (1467 3714 0),hot_cold_possible,3505,3488,0,1467,3714,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,187
+hot_cold_possible (1469 2933 0),hot_cold_possible,3304,3124,0,1469,2933,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,160
+hot_cold_possible (1477 3778 0),hot_cold_possible,3087,3496,0,1477,3778,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,184
+hot_cold_possible (1488 3881 0),hot_cold_possible,2757,3478,0,1488,3881,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,182
+hot_cold_possible (1490 3602 0),hot_cold_possible,3222,3218,0,1490,3602,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,190
+hot_cold_possible (1490 3698 0),hot_cold_possible,2662,3305,0,1490,3698,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,188
+hot_cold_possible (1498 3627 0),hot_cold_possible,3702,3503,0,1498,3627,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,186
+hot_cold_possible (1504 3859 0),hot_cold_possible,3213,3428,0,1504,3859,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,181
+hot_cold_possible (1507 3819 0),hot_cold_possible,3213,3428,0,1507,3819,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,183
+hot_cold_possible (1534 2997 0),hot_cold_possible,2757,3478,0,1534,2997,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,159
+hot_cold_possible (1557 3624 0),hot_cold_possible,2662,3305,0,1557,3624,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,189
+hot_cold_possible (1603 3843 0),hot_cold_possible,2760,3178,0,1603,3843,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,191
+hot_cold_possible (1653 3572 0),hot_cold_possible,2964,3378,0,1653,3572,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,199
+hot_cold_possible (1656 3621 0),hot_cold_possible,3222,3218,0,1656,3621,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,198
+hot_cold_possible (1680 3107 0),hot_cold_possible,2757,3478,0,1680,3107,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,156
+hot_cold_possible (1681 3794 0),hot_cold_possible,2760,3178,0,1681,3794,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,192
+hot_cold_possible (1695 2990 0),hot_cold_possible,2760,3178,0,1695,2990,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,157
+hot_cold_possible (1698 3880 0),hot_cold_possible,3038,3192,0,1698,3880,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,193
+hot_cold_possible (1710 3700 0),hot_cold_possible,2660,3657,0,1710,3700,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,194
+hot_cold_possible (1718 3643 0),hot_cold_possible,3087,3496,0,1718,3643,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,197
+hot_cold_possible (1768 3705 0),hot_cold_possible,3213,3428,0,1768,3705,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,196
+hot_cold_possible (1773 3867 0),hot_cold_possible,3702,3503,0,1773,3867,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,195
+hot_cold_possible (1807 3523 0),hot_cold_possible,2760,3178,0,1807,3523,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,200
+hot_cold_possible (1856 2415 0),hot_cold_possible,2964,3378,0,1856,2415,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,153
+hot_cold_possible (2078 3665 0),hot_cold_possible,3165,3487,0,2078,3665,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,155
+hot_cold_possible (2084 3916 0),hot_cold_possible,1750,3590,0,2084,3916,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,104
+hot_cold_possible (2106 3949 0),hot_cold_possible,2760,3178,0,2106,3949,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,105
+hot_cold_possible (2139 3562 0),hot_cold_possible,3165,3487,0,2139,3562,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,154
+hot_cold_possible (2149 3865 0),hot_cold_possible,3213,3428,0,2149,3865,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,103
+hot_cold_possible (2177 3282 0),hot_cold_possible,2662,3305,0,2177,3282,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,166
+hot_cold_possible (2189 2794 0),hot_cold_possible,2662,3305,0,2189,2794,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,107
+hot_cold_possible (2196 3057 0),hot_cold_possible,2757,3478,0,2196,3057,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,169
+hot_cold_possible (2206 3158 0),hot_cold_possible,3165,3487,0,2206,3158,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,168
+hot_cold_possible (2211 3817 0),hot_cold_possible,3505,3488,0,2211,3817,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,102
+hot_cold_possible (2268 3242 0),hot_cold_possible,2964,3378,0,2268,3242,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,165
+hot_cold_possible (2297 3529 0),hot_cold_possible,1700,3141,0,2297,3529,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,161
+hot_cold_possible (2313 3850 0),hot_cold_possible,3505,3488,0,2313,3850,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,100
+hot_cold_possible (2334 3685 0),hot_cold_possible,2442,3096,0,2334,3685,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,162
+hot_cold_possible (2337 3166 0),hot_cold_possible,1750,3590,0,2337,3166,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,167
+hot_cold_possible (2359 3564 0),hot_cold_possible,3038,3192,0,2359,3564,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,163
+hot_cold_possible (2370 3319 0),hot_cold_possible,3038,3192,0,2370,3319,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,164
+hot_cold_possible (2374 3850 0),hot_cold_possible,2757,3478,0,2374,3850,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,99
+hot_cold_possible (2393 3812 0),hot_cold_possible,1700,3141,0,2393,3812,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,101
+hot_cold_possible (2409 3053 0),hot_cold_possible,2757,3478,0,2409,3053,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,84
+hot_cold_possible (2411 3429 0),hot_cold_possible,3213,3428,0,2411,3429,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,121
+hot_cold_possible (2448 3503 0),hot_cold_possible,2964,3378,0,2448,3503,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,110
+hot_cold_possible (2451 3112 0),hot_cold_possible,3298,3290,0,2451,3112,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,91
+hot_cold_possible (2457 3362 0),hot_cold_possible,3298,3290,0,2457,3362,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,122
+hot_cold_possible (2467 3227 0),hot_cold_possible,3702,3503,0,2467,3227,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,118
+hot_cold_possible (2486 3007 0),hot_cold_possible,3165,3487,0,2486,3007,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,88
+hot_cold_possible (2522 3252 0),hot_cold_possible,3087,3496,0,2522,3252,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,119
+hot_cold_possible (2527 3868 0),hot_cold_possible,3505,3488,0,2527,3868,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,98
+hot_cold_possible (2530 2901 0),hot_cold_possible,3087,3496,0,2530,2901,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,89
+hot_cold_possible (2530 3164 0),hot_cold_possible,3165,3487,0,2530,3164,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,117
+hot_cold_possible (2530 3477 0),hot_cold_possible,3087,3496,0,2530,3477,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,123
+hot_cold_possible (2535 3322 0),hot_cold_possible,3222,3218,0,2535,3322,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,120
+hot_cold_possible (2540 3548 0),hot_cold_possible,1700,3141,0,2540,3548,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,124
+hot_cold_possible (2555 2972 0),hot_cold_possible,3038,3192,0,2555,2972,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,86
+hot_cold_possible (2569 2918 0),hot_cold_possible,2760,3178,0,2569,2918,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,90
+hot_cold_possible (2585 3601 0),hot_cold_possible,2757,3478,0,2585,3601,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,96
+hot_cold_possible (2586 2897 0),hot_cold_possible,3213,3428,0,2586,2897,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,85
+hot_cold_possible (2587 3135 0),hot_cold_possible,3505,3488,0,2587,3135,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,116
+hot_cold_possible (2590 3369 0),hot_cold_possible,2757,3478,0,2590,3369,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,113
+hot_cold_possible (2604 3648 0),hot_cold_possible,2757,3478,0,2604,3648,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,95
+hot_cold_possible (2611 2950 0),hot_cold_possible,3038,3192,0,2611,2950,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,87
+hot_cold_possible (2617 3862 0),hot_cold_possible,3165,3487,0,2617,3862,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,97
+hot_cold_possible (2653 3485 0),hot_cold_possible,3505,3488,0,2653,3485,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,112
+hot_cold_possible (2667 3241 0),hot_cold_possible,3702,3503,0,2667,3241,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,115
+hot_cold_possible (2707 3306 0),hot_cold_possible,3298,3290,0,2707,3306,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,114
+hot_cold_possible (2711 3689 0),hot_cold_possible,1700,3141,0,2711,3689,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,94
+hot_cold_possible (2718 3167 0),hot_cold_possible,2964,3378,0,2718,3167,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,127
+hot_cold_possible (2720 3784 0),hot_cold_possible,3505,3488,0,2720,3784,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,93
+hot_cold_possible (2730 3588 0),hot_cold_possible,2662,3305,0,2730,3588,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,108
+hot_cold_possible (2732 3485 0),hot_cold_possible,3702,3503,0,2732,3485,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,111
+hot_cold_possible (2774 3436 0),hot_cold_possible,2662,3305,0,2774,3436,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,109
+hot_cold_possible (2782 3215 0),hot_cold_possible,3165,3487,0,2782,3215,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,126
+hot_cold_possible (2786 2899 0),hot_cold_possible,3213,3428,0,2786,2899,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,130
+hot_cold_possible (2800 3669 0),hot_cold_possible,3087,3496,0,2800,3669,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,92
+hot_cold_possible (2860 3562 0),hot_cold_possible,2757,3478,0,2860,3562,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,63
+hot_cold_possible (2904 2925 0),hot_cold_possible,2757,3478,0,2904,2925,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,129
+hot_cold_possible (2909 2737 0),hot_cold_possible,3038,3192,0,2909,2737,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,131
+hot_cold_possible (2910 3615 0),hot_cold_possible,2964,3378,0,2910,3615,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,72
+hot_cold_possible (2913 3169 0),hot_cold_possible,3038,3192,0,2913,3169,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,125
+hot_cold_possible (2915 3425 0),hot_cold_possible,2757,3478,0,2915,3425,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,64
+hot_cold_possible (2917 3295 0),hot_cold_possible,1750,3590,0,2917,3295,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,69
+hot_cold_possible (2966 2976 0),hot_cold_possible,3702,3503,0,2966,2976,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,128
+hot_cold_possible (2972 3486 0),hot_cold_possible,2442,3096,0,2972,3486,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,66
+hot_cold_possible (2974 3814 0),hot_cold_possible,2760,3178,0,2974,3814,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,177
+hot_cold_possible (2976 3239 0),hot_cold_possible,3038,3192,0,2976,3239,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,70
+hot_cold_possible (2981 3944 0),hot_cold_possible,3165,3487,0,2981,3944,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,180
+hot_cold_possible (2987 3110 0),hot_cold_possible,3213,3428,0,2987,3110,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,71
+hot_cold_possible (3007 3475 0),hot_cold_possible,1700,3141,0,3007,3475,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,106
+hot_cold_possible (3030 3364 0),hot_cold_possible,2660,3657,0,3030,3364,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,68
+hot_cold_possible (3031 3304 0),hot_cold_possible,3702,3503,0,3031,3304,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,67
+hot_cold_possible (3033 3438 0),hot_cold_possible,3222,3218,0,3033,3438,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,65
+hot_cold_possible (3036 3612 0),hot_cold_possible,3165,3487,0,3036,3612,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,171
+hot_cold_possible (3096 3379 0),hot_cold_possible,3505,3488,0,3096,3379,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,82
+hot_cold_possible (3098 3234 0),hot_cold_possible,3222,3218,0,3098,3234,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,137
+hot_cold_possible (3120 3282 0),hot_cold_possible,3702,3503,0,3120,3282,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,83
+hot_cold_possible (3136 3914 0),hot_cold_possible,3213,3428,0,3136,3914,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,179
+hot_cold_possible (3152 3796 0),hot_cold_possible,3087,3496,0,3152,3796,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,176
+hot_cold_possible (3154 3421 0),hot_cold_possible,2760,3178,0,3154,3421,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,136
+hot_cold_possible (3161 3047 0),hot_cold_possible,2442,3096,0,3161,3047,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,76
+hot_cold_possible (3169 3279 0),hot_cold_possible,3038,3192,0,3169,3279,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,135
+hot_cold_possible (3173 3556 0),hot_cold_possible,3702,3503,0,3173,3556,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,170
+hot_cold_possible (3174 3336 0),hot_cold_possible,3087,3496,0,3174,3336,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,132
+hot_cold_possible (3174 3736 0),hot_cold_possible,1700,3141,0,3174,3736,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,173
+hot_cold_possible (3222 3679 0),hot_cold_possible,2760,3178,0,3222,3679,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,172
+hot_cold_possible (3223 2820 0),hot_cold_possible,3165,3487,0,3223,2820,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,75
+hot_cold_possible (3225 3356 0),hot_cold_possible,2760,3178,0,3225,3356,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,133
+hot_cold_possible (3234 3169 0),hot_cold_possible,3304,3124,0,3234,3169,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,134
+hot_cold_possible (3249 2349 0),hot_cold_possible,1700,3141,0,3249,2349,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,152
+hot_cold_possible (3279 3263 0),hot_cold_possible,2660,3657,0,3279,3263,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,74
+hot_cold_possible (3288 2976 0),hot_cold_possible,2660,3657,0,3288,2976,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,78
+hot_cold_possible (3292 3107 0),hot_cold_possible,2964,3378,0,3292,3107,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,81
+hot_cold_possible (3293 3813 0),hot_cold_possible,3087,3496,0,3293,3813,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,178
+hot_cold_possible (3301 3484 0),hot_cold_possible,2660,3657,0,3301,3484,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,138
+hot_cold_possible (3311 3773 0),hot_cold_possible,1700,3141,0,3311,3773,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,175
+hot_cold_possible (3332 3313 0),hot_cold_possible,2760,3178,0,3332,3313,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,151
+hot_cold_possible (3347 3295 0),hot_cold_possible,2757,3478,0,3347,3295,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,79
+hot_cold_possible (3359 2912 0),hot_cold_possible,1750,3590,0,3359,2912,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,73
+hot_cold_possible (3377 3737 0),hot_cold_possible,3213,3428,0,3377,3737,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,174
+hot_cold_possible (3418 3372 0),hot_cold_possible,3038,3192,0,3418,3372,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,143
+hot_cold_possible (3428 2773 0),hot_cold_possible,3165,3487,0,3428,2773,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,80
+hot_cold_possible (3432 3105 0),hot_cold_possible,2660,3657,0,3432,3105,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,77
+hot_cold_possible (3444 3255 0),hot_cold_possible,3702,3503,0,3444,3255,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,144
+hot_cold_possible (3499 3421 0),hot_cold_possible,2660,3657,0,3499,3421,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,142
+hot_cold_possible (3499 3539 0),hot_cold_possible,2964,3378,0,3499,3539,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,145
+hot_cold_possible (3546 3252 0),hot_cold_possible,1750,3590,0,3546,3252,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,139
+hot_cold_possible (3604 3326 0),hot_cold_possible,2442,3096,0,3604,3326,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,140
+hot_cold_possible (3611 3485 0),hot_cold_possible,3222,3218,0,3611,3485,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,141
+hot_cold_possible (3666 2972 0),hot_cold_possible,3038,3192,0,3666,2972,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,147
+hot_cold_possible (3740 3041 0),hot_cold_possible,1700,3141,0,3740,3041,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,146
+hot_cold_possible (3769 3383 0),hot_cold_possible,3213,3428,0,3769,3383,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,150
+hot_cold_possible (3803 3532 0),hot_cold_possible,3298,3290,0,3803,3532,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,149
+hot_cold_possible (3811 3569 0),hot_cold_possible,2442,3096,0,3811,3569,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/hotcold/HotColdLocation.java,148
+map (1815 3852 0),map,2964,3378,0,1815,3852,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,87
+map (2202 3062 0),map,3038,3192,0,2202,3062,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,86
+map (2449 3130 0),map,3222,3218,0,2449,3130,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,84
+map (2454 3230 0),map,3298,3290,0,2454,3230,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,74
+map (2457 3182 0),map,3222,3218,0,2457,3182,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,80
+map (2488 3308 0),map,3213,3428,0,2488,3308,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,79
+map (2536 3865 0),map,3165,3487,0,2536,3865,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,72
+map (2565 3248 0),map,2964,3378,0,2565,3248,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,70
+map (2578 3597 0),map,3038,3192,0,2578,3597,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,75
+map (2612 3482 0),map,3165,3487,0,2612,3482,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,63
+map (2615 3078 0),map,2964,3378,0,2615,3078,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,78
+map (2651 3231 0),map,3222,3218,0,2651,3231,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,69
+map (2658 3488 0),map,3298,3290,0,2658,3488,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,68
+map (2666 3562 0),map,3222,3218,0,2666,3562,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,76
+map (2703 2716 0),map,3213,3428,0,2703,2716,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,89
+map (2722 3338 0),map,3213,3428,0,2722,3338,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,83
+map (2907 3295 0),map,3298,3290,0,2907,3295,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,67
+map (2924 3210 0),map,3038,3192,0,2924,3210,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,71
+map (2953 9523 1),map,3165,3487,0,2953,9523,1,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,85
+map (2970 3415 0),map,3298,3290,0,2970,3415,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,65
+map (3021 3912 0),map,3165,3487,0,3021,3912,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,82
+map (3026 3628 0),map,2964,3378,0,3026,3628,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,81
+map (3091 3227 0),map,3038,3192,0,3091,3227,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,66
+map (3108 3262 0),map,3213,3428,0,3108,3262,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,91
+map (3203 3213 0),map,3038,3192,0,3203,3213,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,90
+map (3300 3291 0),map,3222,3218,0,3300,3291,0,NONE,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,59
+map (3309 3503 0),map,3213,3428,0,3309,3503,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,77
+map (3434 3265 0),map,3165,3487,0,3434,3265,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,73
+map (3538 3208 0),map,3213,3428,0,3538,3208,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MapClue.java,88
+music (2990 3384 0),music,3038,3192,0,2990,3384,0,ALL,runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/clues/MusicClue.java,51

--- a/src/test/resources/reachability/quetzal_whistle_routes.csv
+++ b/src/test/resources/reachability/quetzal_whistle_routes.csv
@@ -1,0 +1,11 @@
+name,category,start_x,start_y,start_plane,x,y,plane,teleports
+Varrock → Auburnvale,quetzal-whistle,3213,3428,0,1411,3361,0,ALL
+Lumbridge → Hunter Guild,quetzal-whistle,3222,3218,0,1585,3053,0,ALL
+GE → Civitas illa Fortis,quetzal-whistle,3165,3487,0,1697,3140,0,ALL
+Varrock → Aldarin,quetzal-whistle,3213,3428,0,1389,2901,0,ALL
+Ardougne → Sunset Coast,quetzal-whistle,2662,3305,0,1548,2995,0,ALL
+Hunter Guild → Auburnvale,quetzal,1585,3053,0,1411,3361,0,ALL
+Civitas illa Fortis → Hunter Guild,quetzal,1697,3140,0,1585,3053,0,ALL
+Auburnvale → Civitas illa Fortis,quetzal,1411,3361,0,1697,3140,0,ALL
+Sunset Coast → Aldarin,quetzal,1548,2995,0,1389,2901,0,ALL
+Hunter Guild → Outer Fortis,quetzal,1585,3053,0,1700,3037,0,ALL

--- a/src/test/resources/reachability/quetzal_whistle_routes.csv
+++ b/src/test/resources/reachability/quetzal_whistle_routes.csv
@@ -7,10 +7,10 @@ Ardougne → Sunset Coast,quetzal-whistle,2662,3305,0,1548,2995,0,ALL
 Falador → Quetzacalli Gorge,quetzal-whistle,2964,3378,0,1510,3222,0,ALL
 Canifis → Tal Teklan,quetzal-whistle,3507,3496,0,1226,3091,0,ALL
 Edgeville → The Teomat,quetzal-whistle,3087,3496,0,1437,3171,0,ALL
-Hunter Guild → Auburnvale,quetzal,1585,3053,0,1411,3361,0,ALL
-Civitas illa Fortis → Hunter Guild,quetzal,1697,3140,0,1585,3053,0,ALL
-Auburnvale → Civitas illa Fortis,quetzal,1411,3361,0,1697,3140,0,ALL
-Sunset Coast → Aldarin,quetzal,1548,2995,0,1389,2901,0,ALL
-Hunter Guild → Outer Fortis,quetzal,1585,3053,0,1700,3037,0,ALL
-Quetzacalli Gorge → The Teomat,quetzal,1510,3222,0,1437,3171,0,ALL
-The Teomat → Tal Teklan,quetzal,1437,3171,0,1226,3091,0,ALL
+Hunter Guild → Auburnvale,quetzal,1593,3053,0,1411,3361,0,ALL
+Civitas illa Fortis → Hunter Guild,quetzal,1697,3148,0,1585,3053,0,ALL
+Auburnvale → Civitas illa Fortis,quetzal,1411,3353,0,1697,3140,0,ALL
+Sunset Coast → Aldarin,quetzal,1548,3003,0,1389,2901,0,ALL
+Hunter Guild → Outer Fortis,quetzal,1593,3053,0,1700,3037,0,ALL
+Quetzacalli Gorge → The Teomat,quetzal,1518,3222,0,1437,3171,0,ALL
+The Teomat → Tal Teklan,quetzal,1445,3171,0,1226,3091,0,ALL

--- a/src/test/resources/reachability/quetzal_whistle_routes.csv
+++ b/src/test/resources/reachability/quetzal_whistle_routes.csv
@@ -1,11 +1,16 @@
 name,category,start_x,start_y,start_plane,x,y,plane,teleports
 Varrock → Auburnvale,quetzal-whistle,3213,3428,0,1411,3361,0,ALL
 Lumbridge → Hunter Guild,quetzal-whistle,3222,3218,0,1585,3053,0,ALL
-GE → Civitas illa Fortis,quetzal-whistle,3165,3487,0,1697,3140,0,ALL
-Varrock → Aldarin,quetzal-whistle,3213,3428,0,1389,2901,0,ALL
+GE → Civitas illa Fortis,primo-quetzal,3165,3487,0,1697,3140,0,ALL
+Camelot → Aldarin,quetzal-whistle,2757,3478,0,1389,2901,0,ALL
 Ardougne → Sunset Coast,quetzal-whistle,2662,3305,0,1548,2995,0,ALL
+Falador → Quetzacalli Gorge,quetzal-whistle,2964,3378,0,1510,3222,0,ALL
+Canifis → Tal Teklan,quetzal-whistle,3507,3496,0,1226,3091,0,ALL
+Edgeville → The Teomat,quetzal-whistle,3087,3496,0,1437,3171,0,ALL
 Hunter Guild → Auburnvale,quetzal,1585,3053,0,1411,3361,0,ALL
 Civitas illa Fortis → Hunter Guild,quetzal,1697,3140,0,1585,3053,0,ALL
 Auburnvale → Civitas illa Fortis,quetzal,1411,3361,0,1697,3140,0,ALL
 Sunset Coast → Aldarin,quetzal,1548,2995,0,1389,2901,0,ALL
 Hunter Guild → Outer Fortis,quetzal,1585,3053,0,1700,3037,0,ALL
+Quetzacalli Gorge → The Teomat,quetzal,1510,3222,0,1437,3171,0,ALL
+The Teomat → Tal Teklan,quetzal,1437,3171,0,1226,3091,0,ALL

--- a/src/test/resources/reachability/routes.csv
+++ b/src/test/resources/reachability/routes.csv
@@ -1,0 +1,26 @@
+name,category,start_x,start_y,start_plane,x,y,plane,teleports
+Lumbridge → Draynor Village,walk,3222,3218,0,3105,3251,0,NONE
+Varrock → Barbarian Village,walk,3213,3428,0,3082,3420,0,NONE
+Falador → Rimmington,walk,2964,3378,0,2957,3214,0,NONE
+Lumbridge → Varrock,teleport,3222,3218,0,3213,3428,0,ALL
+Lumbridge → Ardougne,teleport,3222,3218,0,2662,3305,0,ALL
+Edgeville → Legends Guild,fairy-ring,3087,3496,0,2729,3348,0,ALL
+GE → Canifis,fairy-ring,3165,3487,0,3507,3496,0,ALL
+Varrock → Gnome Stronghold,spirit-tree,3213,3428,0,2461,3382,0,ALL
+Gnome Stronghold → Digsite,gnome-glider,2461,3382,0,3370,3425,0,ALL
+Port Sarim → Musa Point,ship,3038,3192,0,2956,3146,0,ALL
+Rellekka → Waterbirth Island,boat,2660,3657,0,2544,3759,0,ALL
+Port Phasmatys → Mos Le'Harmless,boat,3702,3503,0,3671,2931,0,ALL
+Brimhaven → Port Khazard,charter-ship,2760,3178,0,2674,3141,0,ALL
+Lumbridge → Edgeville,canoe,3222,3218,0,3087,3496,0,NONE
+Shantay Pass → Pollnivneach,magic-carpet,3304,3124,0,3360,2970,0,ALL
+GE → Keldagrim,minecart,3165,3487,0,2838,10170,0,ALL
+Varrock → Civitas illa Fortis,quetzal,3213,3428,0,1700,3141,0,ALL
+Edgeville → Mage Arena,wilderness,3087,3496,0,3105,3951,0,ALL
+Deep Wilderness → GE,wilderness,3340,3828,0,3158,3509,0,NONE
+Falador → White Knight 2F,multi-plane,2964,3378,0,2961,3339,2,ALL
+Castle Wars → GE,cross-map,2442,3096,0,3162,3489,0,ALL
+Port Sarim → Land's End,cross-map,3038,3192,0,1496,3403,0,ALL
+GE → Zul-Andra,cross-map,3165,3487,0,2200,3056,0,ALL
+Al Kharid → Hosidius,cross-map,3298,3290,0,1750,3590,0,ALL
+Ardougne → Deep Wilderness,teleport-lever,2562,3311,0,3154,3924,0,ALL


### PR DESCRIPTION
## Overview

Adds a pathfinder profiling infrastructure and an automated dashboard CI pipeline with profiled route datasets (including Quetzal Whistle routes).

The Quetzal Whistle routing changes (delayed visit, differential cost, `PathfinderConfig` bypass) are already merged in #402 and are not part of this PR.

## Changes

### Profiler
- **`ProfilingPathfinder` + `PathfinderProfile`**: test-only pathfinder mirroring `Pathfinder` exactly, recording per-step transport data (type, origin, destination, cost) for dashboard output.
- **Profiler counters**: `delayedVisitEnqueued` / `delayedVisitSkipped` counters added to `PathfinderProfile`.
- **Profiler unit test + sync test** (`PathfinderProfilerTest`): validates profiler output and ensures `ProfilingPathfinder` stays in sync with `Pathfinder`.

### Dashboard
- **Abstract node support** (`pathfinder: Introduce abstract nodes for global teleports`): teleports with `UNDEFINED` origin flow through a usable-teleports set — required for the profiler to correctly annotate teleport steps.
- **Profiler frontend** (`profiler.js`): visualises per-route transport steps and cost breakdowns.
- **Frontend integration**: updated `app.js` and `index.html` to wire profiler data into the existing dashboard UI.
- **Report pipeline** (`PathfinderDashboardReportWriter`): profiler output fed into the JSON report; transport step deduplication (physical transport takes priority over usable teleport when both cover the same destination).
- **Route datasets**: `routes.csv` (general routes) and `quetzal_whistle_routes.csv` (15 routes covering long-distance whistle teleports and intra-Varlamore station hops).

### Build / CI
- **Auto-derive bundle name/title** from the dataset filename.
- **Dashboard CI step**: `dashboard-pages.yml` builds the profiled routes dashboard (general + quetzal whistle) and publishes to GitHub Pages on push to master.

### Misc
- JMH benchmarks for `Pathfinder`, `CollisionMap`, and `VisitedTiles`.
- Updated datasets.