### PR TITLE
transports: align teleport destinations with OSRS wiki coords

### DIFF
--- a/src/main/resources/transports/teleportation_boxes.tsv
+++ b/src/main/resources/transports/teleportation_boxes.tsv
@@ -16,7 +16,7 @@
 1870 5698 0	2440 3090 0	Teleport Menu Basic Jewellery Box 37492	4	2: Castle Wars
 1870 5698 0	3151 3635 0	Teleport Menu Basic Jewellery Box 37492	4	3: Ferox Enclave
 1870 5698 0	1793 3107 0	Teleport Menu Basic Jewellery Box 37492	4	4: Fortis Colosseum
-1870 5698 0	2898 3553 0	Teleport Menu Basic Jewellery Box 37492	4	5: Burthorpe
+1870 5698 0	2899 3553 0	Teleport Menu Basic Jewellery Box 37492	4	5: Burthorpe
 1870 5698 0	2520 3571 0	Teleport Menu Basic Jewellery Box 37492	4	6: Barbarian Outpost
 1870 5698 0	2967 4254 0	Teleport Menu Basic Jewellery Box 37492	4	7: Corporeal Beast
 1870 5698 0	3245 9500 0	Teleport Menu Basic Jewellery Box 37492	4	8: Chasm of Tears

--- a/src/main/resources/transports/teleportation_items.tsv
+++ b/src/main/resources/transports/teleportation_items.tsv
@@ -1,9 +1,9 @@
 # Destination	menuOption menuTarget objectID	Skills	Items	Quests	Duration	Display info	Consumable	Wilderness level	Varbits	VarPlayers
 # Ardougne cloaks (2 has 3 teleports to farm, 3 has 5 teleports to farm, 4 has unlimited teleports to farm) PS: varbit 6069 is only lowbits, highbits is not transmitted										
-2606 3221 0			13121=1||13122=1||13123=1||13124=1||20760=1		4	Ardougne cloak: Kandarin Monastery	F	20	4458=1	
-2664 3374 0			13122=1		4	Ardougne cloak: Ardougne Farm	T	20	4459=1;6069<3	
-2664 3374 0			13123=1		4	Ardougne cloak: Ardougne Farm	T	20	4460=1;6069<5	
-2664 3374 0			13124=1||20760=1		4	Ardougne cloak: Ardougne Farm	F	20	4461=1	
+2607 3221 0			13121=1||13122=1||13123=1||13124=1||20760=1		4	Ardougne cloak: Kandarin Monastery	F	20	4458=1	
+2665 3374 0			13122=1		4	Ardougne cloak: Ardougne Farm	T	20	4459=1;6069<3	
+2665 3374 0			13123=1		4	Ardougne cloak: Ardougne Farm	T	20	4460=1;6069<5	
+2665 3374 0			13124=1||20760=1		4	Ardougne cloak: Ardougne Farm	F	20	4461=1	
 # Karamja gloves										
 2840 9387 0			11140=1||13103=1		4	Karamja gloves: Gem Mine	F	20	3611=2	
 2869 2982 1			13103=1		4	Karamja gloves 4: Slayer Master	F	20	4566=1	
@@ -22,27 +22,27 @@
 2643 3675 0			13131=1		4	Fremennik sea boots: Teleport	T	20	4491=1;5005<5	
 2643 3675 0			13132=1		4	Fremennik sea boots: Teleport	F	20	4494=1	
 # Kandarin headgear (3 has 1 teleport per day, 4 is unlimited)										
-2729 3409 0			13139=1		4	Kandarin headgear 3: Teleport	T	20	4477=1;4561=0	
-2729 3409 0			13140=1		4	Kandarin headgear 4: Teleport	F	20	4478=1	
+2730 3420 0			13139=1		4	Kandarin headgear 3: Teleport	T	20	4477=1;4561=0	
+2730 3420 0			13140=1		4	Kandarin headgear 4: Teleport	F	20	4478=1	
 # Wilderness sword (3 has 1 teleport per day, 4 is unlimited)										
 3377 3890 0			13110=1		4	Wilderness sword 3: Teleport	T	20	4468=1;4541=0	
 3377 3890 0			13111=1		4	Wilderness sword 4: Teleport	F	20	4469=1	
 # Western banner (3 has 1 teleport per day, 4 is unlimited)										
-2339 3649 0			13143=1		4	Western banner 3: Teleport	T	20	4473=1;4564=0	
-2339 3649 0			13144=1		4	Western banner 4: Teleport	F	20	4474=1	
+2332 3681 0			13143=1		4	Western banner 3: Teleport	T	20	4473=1;4564=0	
+2332 3681 0			13144=1		4	Western banner 4: Teleport	F	20	4474=1	
 # Explorer's ring (2 has 3 teleports per day, 3 and 4 are unlimited)										
 3052 3291 0			13126=1		4	Explorer's ring 2: Teleport	T	20	4496=1;4552<3	
 3052 3291 0			13127=1||13128=1		4	Explorer's ring: Teleport	F	20	4497=1	
 # Rada's blessing (Kourend Woodland, 1 has 3 teleports, 2 has 5 teleports, 3 and 4 have unlimited. For Mount Karuulum, 3 has 3 teleports and 4 has unlimited)										
-1554 3457 0			22941=1		4	Rada's blessing: Kourend Woodland	T	20	7925=1;7937<3	
-1554 3457 0			22943=1		4	Rada's blessing: Kourend Woodland	T	20	7926=1;7937<5	
-1554 3457 0			22945=1||22947=1		4	Rada's blessing: Kourend Woodland	F	20	7927=1	
-1311 3799 0			22945=1		4	Rada's blessing: Mount Karuulm	T	20	7927=1;7938<3	
-1311 3799 0			22947=1		4	Rada's blessing: Mount Karuulm	F	20	7928=1	
+1554 3461 0			22941=1		4	Rada's blessing: Kourend Woodland	T	20	7925=1;7937<3	
+1554 3461 0			22943=1		4	Rada's blessing: Kourend Woodland	T	20	7926=1;7937<5	
+1554 3461 0			22945=1||22947=1		4	Rada's blessing: Kourend Woodland	F	20	7927=1	
+1311 3806 0			22945=1		4	Rada's blessing: Mount Karuulm	T	20	7927=1;7938<3	
+1311 3806 0			22947=1		4	Rada's blessing: Mount Karuulm	F	20	7928=1	
 										
 # Games necklace										
 2520 3571 0			3853=1||3855=1||3857=1||3859=1||3861=1||3863=1||3865=1||3867=1		4	Games necklace: Barbarian Outpost	T	20		
-2898 3553 0			3853=1||3855=1||3857=1||3859=1||3861=1||3863=1||3865=1||3867=1		4	Games necklace: Burthorpe	T	20		
+2899 3553 0			3853=1||3855=1||3857=1||3859=1||3861=1||3863=1||3865=1||3867=1		4	Games necklace: Burthorpe	T	20		
 2965 4254 2			3853=1||3855=1||3857=1||3859=1||3861=1||3863=1||3865=1||3867=1		4	Games necklace: Corporeal Beast	T	20		
 3245 9500 2			3853=1||3855=1||3857=1||3859=1||3861=1||3863=1||3865=1||3867=1		4	Games necklace: Tears of Guthix	T	20	451>1	
 1631 3940 0			3853=1||3855=1||3857=1||3859=1||3861=1||3863=1||3865=1||3867=1		4	Games necklace: Wintertodt	T	20	5619>0	
@@ -87,16 +87,16 @@
 2824 10168 0			11988=1||11986=1||11984=1||11982=1||11980=1||20790=1||20789=1||20788=1||20787=1||20786=1	Between a Rock...	4	Ring of wealth: Dondakan	T	30	299=10	
 										
 # Slayer ring (1-8)										
-2432 3423 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1		4	Slayer ring: Stronghold	T	30		
+2431 3422 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1		4	Slayer ring: Stronghold	T	30		
 3421 3537 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1	Priest in Peril	4	Slayer ring: Slayer Tower	T	30		
-2802 10000 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1		4	Slayer ring: Fremennik	T	30		
+2802 9999 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1		4	Slayer ring: Fremennik	T	30		
 3185 4601 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1	Haunted Mine	4	Slayer ring: Tarn's Lair	T	30		
 2028 4636 0			11866=1||11867=1||11868=1||11869=1||11870=1||11871=1||11872=1||11873=1	Mourning's End Part II	4	Slayer ring: Dark Beasts	T	30		
 										
 # Slayer ring (eternal)										
-2432 3423 0			21268=1		4	Slayer ring: Stronghold	F	30		
+2431 3422 0			21268=1		4	Slayer ring: Stronghold	F	30		
 3421 3537 0			21268=1	Priest in Peril	4	Slayer ring: Slayer Tower	F	30		
-2802 10000 0			21268=1		4	Slayer ring: Fremennik	F	30		
+2802 9999 0			21268=1		4	Slayer ring: Fremennik	F	30		
 3185 4601 0			21268=1	Haunted Mine	4	Slayer ring: Tarn's Lair	F	30		
 2028 4636 0			21268=1	Mourning's End Part II	4	Slayer ring: Dark Beasts	F	30		
 										
@@ -107,7 +107,7 @@
 										
 # Necklace of passage (1-5)										
 3114 3179 0			21146=1||21149=1||21151=1||21153=1||21155=1		4	Necklace of passage: Wizards' Tower	T	20		
-2428 3350 0			21146=1||21149=1||21151=1||21153=1||21155=1		4	Necklace of passage: The Outpost	T	20		
+2430 3349 0			21146=1||21149=1||21151=1||21153=1||21155=1		4	Necklace of passage: The Outpost	T	20		
 3405 3158 0			21146=1||21149=1||21151=1||21153=1||21155=1		4	Necklace of passage: Eagle's Eyrie	T	20		
 										
 # Burning amulet										
@@ -139,12 +139,12 @@
 #  Teleport tablets										
 3213 3424 0			8007=1		4	Varrock tablet	T	20		
 # Varbit 4480 is DIARY_VARROCK_MEDIUM										
-3164 3478 0			8007=1		4	Varrock tablet: GE	T	20	4480=1	
-2965 3378 0			8009=1		4	Falador tablet	T	20		
+3165 3479 0			8007=1		4	Varrock tablet: GE	T	20	4480=1	
+2964 3378 0			8009=1		4	Falador tablet	T	20		
 3221 3218 0			8008=1		4	Lumbridge tablet	T	20		
-2757 3478 0			8010=1		4	Camelot tablet	T	20		
-2661 3302 0			8011=1	Plague City	4	Ardougne tablet	T	20		
-2549 3112 0			8012=1	Watchtower	4	Watchtower tablet	T	20		
+2757 3479 0			8010=1		4	Camelot tablet	T	20		
+2662 3305 0			8011=1	Plague City	4	Ardougne tablet	T	20		
+2546 3112 0			8012=1	Watchtower	4	Watchtower tablet	T	20		
 # Varbit 4460 is DIARY_ARDOUGNE_HARD										
 2584 3097 0			8012=1	Watchtower	4	Watchtower tablet: Yanille	T	20	4460=1	
 2953 3224 0			11741=1		4	Rimmington tablet	T	20		
@@ -156,32 +156,32 @@
 2890 3679 0			11747=1		4	Trollheim tablet	T	20		
 1743 3517 0			19651=1		4	Hosidius tablet	T	20		
 3239 6077 0			23771=1		4	Prifddinas tablet	T	20		
-3100 9883 0			12781=1	Desert Treasure I	4	Paddewwa tablet	T	20		
+3097 9881 0			12781=1	Desert Treasure I	4	Paddewwa tablet	T	20		
 3320 3337 0			12782=1	Desert Treasure I	4	Senntisten tablet	T	20		
 3494 3473 0			12779=1	Desert Treasure I	4	Kharyrll tablet	T	20		
-3002 3470 0			12780=1	Desert Treasure I	4	Lassar tablet	T	20		
+3004 3470 0			12780=1	Desert Treasure I	4	Lassar tablet	T	20		
 2968 3696 0			12777=1	Desert Treasure I	4	Dareeyak tablet	T	20		
 3158 3666 0			12776=1	Desert Treasure I	4	Carrallanger tablet	T	20		
-3287 3888 0			12775=1	Desert Treasure I	4	Annakarl tablet	T	20		
-2974 3873 0			12778=1	Desert Treasure I	4	Ghorrock tablet	T	20		
+3288 3888 0			12775=1	Desert Treasure I	4	Annakarl tablet	T	20		
+2976 3875 0			12778=1	Desert Treasure I	4	Ghorrock tablet	T	20		
 2113 3915 0			24949=1	Lunar Diplomacy	4	Moonclan tablet	T	20		
 2468 3246 0			24951=1	Lunar Diplomacy	4	Ourania tablet	T	20		
-2546 3756 0			24953=1		4	Waterbirth tablet	T	20		
+2546 3755 0			24953=1		4	Waterbirth tablet	T	20		
 2543 3569 0			24955=1		4	Barbarian tablet	T	20		
 2636 3167 0			24957=1		4	Khazard tablet	T	20		
 2613 3391 0			24959=1		4	Fishing guild tablet	T	20		
 2801 3449 0			24961=1		4	Catherby tablet	T	20		
 2975 3938 0			24963=1		4	Ice plateau tablet	T	20		
-1633 3838 0			19613=1		4	Arceuus Library tablet	T	20		
-3110 3350 0			19615=1		4	Draynor Manor tablet	T	20		
+1632 3837 0			19613=1		4	Arceuus Library tablet	T	20		
+3109 3351 0			19615=1		4	Draynor Manor tablet	T	20		
 1347 3740 0			22949=1		4	Battlefront tablet	T	20		
-2980 3509 0			19617=1		4	Mind Altar tablet	T	20		
-3432 3461 0			19619=1	Priest in Peril	4	Salve Graveyard tablet	T	20		
+2979 3510 0			19617=1		4	Mind Altar tablet	T	20		
+3433 3461 0			19619=1	Priest in Peril	4	Salve Graveyard tablet	T	20		
 3548 3529 0			19621=1	Priest in Peril	4	Fenkenstrain's Castle tablet	T	20		
-2500 3291 0			19623=1	Biohazard	4	West Ardougne tablet	T	20		
-3797 2867 0			19625=1	The Great Brain Robbery	4	Harmony Island tablet	T	20		
-2980 3763 0			19627=1		4	Cemetery tablet	T	20		
-3565 3314 0			19629=1	Priest in Peril	4	Barrows tablet	T	20		
+2500 3290 0			19623=1	Biohazard	4	West Ardougne tablet	T	20		
+3797 2866 0			19625=1	The Great Brain Robbery	4	Harmony Island tablet	T	20		
+2981 3764 0			19627=1		4	Cemetery tablet	T	20		
+3564 3315 0			19629=1	Priest in Peril	4	Barrows tablet	T	20		
 2771 9102 0			19631=1	Monkey Madness I	4	Ape Atoll tablet	T	20		
 3811 3813 0			21541=1		4	Volcanic Mine tablet	T	20		
 3352 3782 0			24251=1		4	Wilderness Crabs tablet	T	20		
@@ -316,7 +316,7 @@
 										
 # Quest items										
 # Ectophial - includes the empty version										
-3659 3523 0			4251=1||4252=1		4	Ectophial	F	20		
+3660 3522 0			4251=1||4252=1		4	Ectophial	F	20		
 2330 3171 0			6099=1||6100=1||6101=1||6102=1||13102=1		4	Teleport crystal: Lletya	T	20		
 3264 6066 0			6099=1||6100=1||6101=1||6102=1||13102=1	Song of the Elves	4	Teleport crystal: Prifddinas	T	20		
 2330 3171 0			23946=1		4	Eternal teleport crystal: Lletya	F	20		

--- a/src/main/resources/transports/teleportation_portals_poh.tsv
+++ b/src/main/resources/transports/teleportation_portals_poh.tsv
@@ -11,9 +11,9 @@
 1928 5731 0	1632 3837 0	Enter Arceuus Library Portal 41416		1	Arceuus Library Portal
 1928 5731 0	1632 3837 0	Enter Arceuus Library Portal 41417		1	Arceuus Library Portal
 1928 5731 0	1632 3837 0	Enter Arceuus Library Portal 41418		1	Arceuus Library Portal
-1928 5731 0	2544 3570 0	Enter Barbarian Outpost Portal 60795		1	Barbarian Outpost Portal
-1928 5731 0	2544 3570 0	Enter Barbarian Outpost Portal 60805		1	Barbarian Outpost Portal
-1928 5731 0	2544 3570 0	Enter Barbarian Outpost Portal 60815		1	Barbarian Outpost Portal
+1928 5731 0	2543 3569 0	Enter Barbarian Outpost Portal 60795		1	Barbarian Outpost Portal
+1928 5731 0	2543 3569 0	Enter Barbarian Outpost Portal 60805		1	Barbarian Outpost Portal
+1928 5731 0	2543 3569 0	Enter Barbarian Outpost Portal 60815		1	Barbarian Outpost Portal
 1928 5731 0	3564 3315 0	Enter Barrows Portal 37591		1	Barrows Portal
 1928 5731 0	3564 3315 0	Enter Barrows Portal 37603		1	Barrows Portal
 1928 5731 0	3564 3315 0	Enter Barrows Portal 37615		1	Barrows Portal
@@ -26,9 +26,9 @@
 1928 5731 0	2757 3479 0	Camelot Camelot Portal 33094	4560=0	1	Camelot Portal
 1928 5731 0	2757 3479 0	Camelot Camelot Portal 33100	4560=0	1	Camelot Portal
 1928 5731 0	2757 3479 0	Camelot Camelot Portal 33106	4560=0	1	Camelot Portal
-1928 5731 0	2726 3485 0	Seers' Village Seers' Village Portal 33095	4560=1	1	Seers' Village Portal
-1928 5731 0	2726 3485 0	Seers' Village Seers' Village Portal 33101	4560=1	1	Seers' Village Portal
-1928 5731 0	2726 3485 0	Seers' Village Seers' Village Portal 33107	4560=1	1	Seers' Village Portal
+1928 5731 0	2726 3487 0	Seers' Village Seers' Village Portal 33095	4560=1	1	Seers' Village Portal
+1928 5731 0	2726 3487 0	Seers' Village Seers' Village Portal 33101	4560=1	1	Seers' Village Portal
+1928 5731 0	2726 3487 0	Seers' Village Seers' Village Portal 33107	4560=1	1	Seers' Village Portal
 1928 5731 0	3158 3666 0	Enter Carrallanger Portal 33434		1	Carrallanger Portal
 1928 5731 0	3158 3666 0	Enter Carrallanger Portal 33437		1	Carrallanger Portal
 1928 5731 0	3158 3666 0	Enter Carrallanger Portal 33440		1	Carrallanger Portal
@@ -41,9 +41,9 @@
 1928 5731 0	2981 3764 0	Enter Cemetery Portal 37590		1	Cemetery Portal
 1928 5731 0	2981 3764 0	Enter Cemetery Portal 37602		1	Cemetery Portal
 1928 5731 0	2981 3764 0	Enter Cemetery Portal 37614		1	Cemetery Portal
-1928 5731 0	2970 3698 0	Enter Dareeyak Portal 60793		1	Dareeyak Portal
-1928 5731 0	2970 3698 0	Enter Dareeyak Portal 60803		1	Dareeyak Portal
-1928 5731 0	2970 3698 0	Enter Dareeyak Portal 60813		1	Dareeyak Portal
+1928 5731 0	2968 3696 0	Enter Dareeyak Portal 60793		1	Dareeyak Portal
+1928 5731 0	2968 3696 0	Enter Dareeyak Portal 60803		1	Dareeyak Portal
+1928 5731 0	2968 3696 0	Enter Dareeyak Portal 60813		1	Dareeyak Portal
 1928 5731 0	3109 3351 0	Enter Draynor Manor Portal 37583		1	Draynor Manor Portal
 1928 5731 0	3109 3351 0	Enter Draynor Manor Portal 37595		1	Draynor Manor Portal
 1928 5731 0	3109 3351 0	Enter Draynor Manor Portal 37607		1	Draynor Manor Portal
@@ -65,9 +65,9 @@
 1928 5731 0	3797 2866 0	Enter Harmony Island Portal 37589		1	Harmony Island Portal
 1928 5731 0	3797 2866 0	Enter Harmony Island Portal 37601		1	Harmony Island Portal
 1928 5731 0	3797 2866 0	Enter Harmony Island Portal 37613		1	Harmony Island Portal
-1928 5731 0	2977 3940 0	Enter Ice Plateau Portal 60797		1	Ice Plateau Portal
-1928 5731 0	2977 3940 0	Enter Ice Plateau Portal 60807		1	Ice Plateau Portal
-1928 5731 0	2977 3940 0	Enter Ice Plateau Portal 60817		1	Ice Plateau Portal
+1928 5731 0	2975 3938 0	Enter Ice Plateau Portal 60797		1	Ice Plateau Portal
+1928 5731 0	2975 3938 0	Enter Ice Plateau Portal 60807		1	Ice Plateau Portal
+1928 5731 0	2975 3938 0	Enter Ice Plateau Portal 60817		1	Ice Plateau Portal
 1928 5731 0	3494 3473 0	Enter Kharyrll Portal 29338		1	Kharyrll Portal
 1928 5731 0	3494 3473 0	Enter Kharyrll Portal 29346		1	Kharyrll Portal
 1928 5731 0	3494 3473 0	Enter Kharyrll Portal 29354		1	Kharyrll Portal
@@ -89,15 +89,15 @@
 1928 5731 0	2979 3510 0	Enter Mind Altar Portal 37585		1	Mind Altar Portal
 1928 5731 0	2979 3510 0	Enter Mind Altar Portal 37597		1	Mind Altar Portal
 1928 5731 0	2979 3510 0	Enter Mind Altar Portal 37609		1	Mind Altar Portal
-1928 5731 0	2469 3247 0	Enter Ourania Portal 60794		1	Ourania Portal
-1928 5731 0	2469 3247 0	Enter Ourania Portal 60804		1	Ourania Portal
-1928 5731 0	2469 3247 0	Enter Ourania Portal 60814		1	Ourania Portal
-1928 5731 0	3098 9882 0	Enter Paddewwa Portal 60791		1	Paddewwa Portal
-1928 5731 0	3098 9882 0	Enter Paddewwa Portal 60801		1	Paddewwa Portal
-1928 5731 0	3098 9882 0	Enter Paddewwa Portal 60811		1	Paddewwa Portal
-1928 5731 0	2637 3168 0	Enter Port Khazard Portal 60796		1	Port Khazard Portal
-1928 5731 0	2637 3168 0	Enter Port Khazard Portal 60806		1	Port Khazard Portal
-1928 5731 0	2637 3168 0	Enter Port Khazard Portal 60816		1	Port Khazard Portal
+1928 5731 0	2468 3246 0	Enter Ourania Portal 60794		1	Ourania Portal
+1928 5731 0	2468 3246 0	Enter Ourania Portal 60804		1	Ourania Portal
+1928 5731 0	2468 3246 0	Enter Ourania Portal 60814		1	Ourania Portal
+1928 5731 0	3097 9881 0	Enter Paddewwa Portal 60791		1	Paddewwa Portal
+1928 5731 0	3097 9881 0	Enter Paddewwa Portal 60801		1	Paddewwa Portal
+1928 5731 0	3097 9881 0	Enter Paddewwa Portal 60811		1	Paddewwa Portal
+1928 5731 0	2636 3167 0	Enter Port Khazard Portal 60796		1	Port Khazard Portal
+1928 5731 0	2636 3167 0	Enter Port Khazard Portal 60806		1	Port Khazard Portal
+1928 5731 0	2636 3167 0	Enter Port Khazard Portal 60816		1	Port Khazard Portal
 1928 5731 0	3221 3218 0	Enter Respawn Portal 60798		1	Respawn Portal (Lumbridge)
 1928 5731 0	2964 3378 0	Enter Respawn Portal 60798	668=1	1	Respawn Portal (Falador)
 1928 5731 0	2757 3479 0	Enter Respawn Portal 60798	3910=1	1	Respawn Portal (Camelot)
@@ -112,9 +112,9 @@
 1928 5731 0	3320 3337 0	Enter Senntisten Portal 29340		1	Senntisten Portal
 1928 5731 0	3320 3337 0	Enter Senntisten Portal 29348		1	Senntisten Portal
 1928 5731 0	3320 3337 0	Enter Senntisten Portal 29356		1	Senntisten Portal
-1928 5731 0	2891 3680 0	Enter Trollheim Portal 60790		1	Trollheim Portal
-1928 5731 0	2891 3680 0	Enter Trollheim Portal 60800		1	Trollheim Portal
-1928 5731 0	2891 3680 0	Enter Trollheim Portal 60810		1	Trollheim Portal
+1928 5731 0	2890 3679 0	Enter Trollheim Portal 60790		1	Trollheim Portal
+1928 5731 0	2890 3679 0	Enter Trollheim Portal 60800		1	Trollheim Portal
+1928 5731 0	2890 3679 0	Enter Trollheim Portal 60810		1	Trollheim Portal
 1928 5731 0	2845 3694 0	Enter Troll Stronghold Portal 33179	4493=0	1	Troll Stronghold Portal
 1928 5731 0	2845 3694 0	Enter Troll Stronghold Portal 33180	4493=0	1	Troll Stronghold Portal
 1928 5731 0	2845 3694 0	Enter Troll Stronghold Portal 33181	4493=0	1	Troll Stronghold Portal
@@ -135,7 +135,7 @@
 1928 5731 0	2500 3290 0	Enter West Ardougne Portal 37612		1	West Ardougne Portal
 1864 5732 0	2546 3114 0	Watchtower Yanille Watchtower Portal 33096	4548=0	1	Watchtower Portal
 1864 5732 0	2546 3114 0	Watchtower Yanille Watchtower Portal 33108	4548=0	1	Watchtower Portal
-1864 5732 0	2546 3114 0	Watchtower Yanille Portal 33102	4548=0	1	Yanille Portal
+1864 5732 0	2546 3114 0	Watchtower Yanille Portal 33102	4548=0	1	Watchtower Portal
 1864 5732 0	2584 3097 0	Yanille Yanille Portal 33097	4548=1	1	Yanille Portal
 1864 5732 0	2584 3097 0	Yanille Yanille Portal 33103	4548=1	1	Yanille Portal
 1864 5732 0	2584 3097 0	Yanille Yanille Portal 33109	4548=1	1	Yanille Portal

--- a/src/main/resources/transports/teleportation_spells.tsv
+++ b/src/main/resources/transports/teleportation_spells.tsv
@@ -9,13 +9,13 @@
 # Varrock Teleport								
 3213 3424 0	AIR_RUNE=3&&FIRE_RUNE=1&&LAW_RUNE=1	25 Magic		4	Varrock Teleport	20	4070=0	
 # Varbit 4480 is DIARY_VARROCK_MEDIUM								
-3164 3478 0	AIR_RUNE=3&&FIRE_RUNE=1&&LAW_RUNE=1	25 Magic		4	Varrock Teleport: GE	20	4070=0;4480=1	
+3165 3479 0	AIR_RUNE=3&&FIRE_RUNE=1&&LAW_RUNE=1	25 Magic		4	Varrock Teleport: GE	20	4070=0;4480=1	
 								
 # Lumbridge Teleport								
 3221 3218 0	AIR_RUNE=3&&EARTH_RUNE=1&&LAW_RUNE=1	31 Magic		4	Lumbridge Teleport	20	4070=0	
 								
 # Falador Teleport								
-2965 3378 0	AIR_RUNE=3&&WATER_RUNE=1&&LAW_RUNE=1	37 Magic		4	Falador Teleport	20	4070=0	
+2964 3378 0	AIR_RUNE=3&&WATER_RUNE=1&&LAW_RUNE=1	37 Magic		4	Falador Teleport	20	4070=0	
 								
 # Teleport to House - These depend on the current player's home location  determined by varbit 2187								
 1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;4744=0	
@@ -39,21 +39,21 @@
 1422 2963 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=9;4744=1	
 								
 # Camelot Teleport								
-2757 3478 0	AIR_RUNE=5&&LAW_RUNE=1	45 Magic		4	Camelot Teleport	20	4070=0	
+2757 3479 0	AIR_RUNE=5&&LAW_RUNE=1	45 Magic		4	Camelot Teleport	20	4070=0	
 # Varbit 4477 is DIARY_KANDARIN_HARD								
-2726 3485 0	AIR_RUNE=5&&LAW_RUNE=1	45 Magic		4	Camelot Teleport: Seers'	20	4070=0;4477=1	
+2726 3487 0	AIR_RUNE=5&&LAW_RUNE=1	45 Magic		4	Camelot Teleport: Seers'	20	4070=0;4477=1	
 								
 # Kourend Castle Teleport								
 1641 3673 0	FIRE_RUNE=1&&WATER_RUNE=1&&LAW_RUNE=2	48 Magic	Client of Kourend	4	Kourend Castle Teleport	20	4070=0	
 								
 # Ardougne Teleport								
-2661 3302 0	WATER_RUNE=2&&LAW_RUNE=2	51 Magic	Plague City	4	Ardougne Teleport	20	4070=0	165=30
+2662 3305 0	WATER_RUNE=2&&LAW_RUNE=2	51 Magic	Plague City	4	Ardougne Teleport	20	4070=0	165=30
 								
 # Civitas illa Fortis Teleport								
-1680 3134 0	EARTH_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=2	54 Magic	Twilight's Promise	4	Civitas illa Fortis Teleport	20	4070=0	
+1681 3136 0	EARTH_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=2	54 Magic	Twilight's Promise	4	Civitas illa Fortis Teleport	20	4070=0	
 								
 # Watchtower Teleport								
-2549 3112 0	EARTH_RUNE=2&&LAW_RUNE=2	58 Magic	Watchtower	4	Watchtower Teleport	20	4070=0	212=14
+2546 3112 0	EARTH_RUNE=2&&LAW_RUNE=2	58 Magic	Watchtower	4	Watchtower Teleport	20	4070=0	212=14
 # Varbit 4460 is DIARY_ARDOUGNE_HARD								
 2584 3097 0	EARTH_RUNE=2&&LAW_RUNE=2	58 Magic	Watchtower	4	Watchtower Teleport: Yanille	20	4070=0;4460=1	212=14
 								
@@ -71,7 +71,7 @@
 3087 3504 0			Desert Treasure I	23	Edgeville Home Teleport	20	4070=1	4560&249;892@30
 								
 # Paddewwa Teleport								
-3100 9883 0	AIR_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=2	54 Magic	Desert Treasure I	5	Paddewwa Teleport	20	4070=1	
+3097 9881 0	AIR_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=2	54 Magic	Desert Treasure I	5	Paddewwa Teleport	20	4070=1	
 								
 # Senntisten Teleport								
 3320 3337 0	LAW_RUNE=2&&SOUL_RUNE=1	60 Magic	Desert Treasure I	5	Senntisten Teleport	20	4070=1	
@@ -80,7 +80,7 @@
 3494 3473 0	LAW_RUNE=2&&BLOOD_RUNE=1	66 Magic	Desert Treasure I	5	Kharyrll Teleport	20	4070=1	
 								
 # Lassar Teleport								
-3002 3470 0	LAW_RUNE=2&&WATER_RUNE=4	72 Magic	Desert Treasure I	5	Lassar Teleport	20	4070=1	
+3004 3470 0	LAW_RUNE=2&&WATER_RUNE=4	72 Magic	Desert Treasure I	5	Lassar Teleport	20	4070=1	
 								
 # Dareeyak Teleport								
 2968 3696 0	AIR_RUNE=2&&FIRE_RUNE=3&&LAW_RUNE=2	78 Magic	Desert Treasure I	5	Dareeyak Teleport	20	4070=1	
@@ -92,10 +92,10 @@
 #		85 Magic	Desert Treasure I	5	Teleport to Target	20	4070=1	
 								
 # Annakarl Teleport								
-3287 3888 0	LAW_RUNE=2&&BLOOD_RUNE=2	90 Magic	Desert Treasure I	5	Annakarl Teleport	20	4070=1	
+3288 3888 0	LAW_RUNE=2&&BLOOD_RUNE=2	90 Magic	Desert Treasure I	5	Annakarl Teleport	20	4070=1	
 								
 # Ghorrock Teleport								
-2974 3873 0	LAW_RUNE=2&&WATER_RUNE=8	96 Magic	Desert Treasure I	5	Ghorrock Teleport	20	4070=1	
+2976 3875 0	LAW_RUNE=2&&WATER_RUNE=8	96 Magic	Desert Treasure I	5	Ghorrock Teleport	20	4070=1	
 								
 # Lunar Spellbook - Varbit 4070=2								
 # Lunar Home Teleport								
@@ -111,7 +111,7 @@
 2468 3246 0	EARTH_RUNE=6&&ASTRAL_RUNE=2&&LAW_RUNE=1	71 Magic	Lunar Diplomacy	4	Ourania Teleport	20	4070=2	
 								
 # Waterbirth Teleport								
-2546 3756 0	WATER_RUNE=1&&ASTRAL_RUNE=2&&LAW_RUNE=1	72 Magic	Lunar Diplomacy	4	Waterbirth Teleport	20	4070=2	
+2546 3755 0	WATER_RUNE=1&&ASTRAL_RUNE=2&&LAW_RUNE=1	72 Magic	Lunar Diplomacy	4	Waterbirth Teleport	20	4070=2	
 								
 # Barbarian Teleport								
 2543 3569 0	FIRE_RUNE=3&&ASTRAL_RUNE=2&&LAW_RUNE=2	75 Magic	Lunar Diplomacy	4	Barbarian Teleport	20	4070=2	
@@ -136,23 +136,23 @@
 1700 3882 0				23	Arceuus Home Teleport	20	4070=3	4560&249;892@30
 								
 # Arceuus Library Teleport								
-1632 3834 0	EARTH_RUNE=2&&LAW_RUNE=1	6 Magic		4	Arceuus Library Teleport	20	4070=3	
+1632 3837 0	EARTH_RUNE=2&&LAW_RUNE=1	6 Magic		4	Arceuus Library Teleport	20	4070=3	
 								
 # Draynor Manor Teleport								
-3108 3351 0	EARTH_RUNE=1&&WATER_RUNE=1&&LAW_RUNE=1	17 Magic		4	Draynor Manor Teleport	20	4070=3	
+3109 3351 0	EARTH_RUNE=1&&WATER_RUNE=1&&LAW_RUNE=1	17 Magic		4	Draynor Manor Teleport	20	4070=3	
 								
 # Battlefront Teleport								
-1347 3741 0	EARTH_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=1	23 Magic		4	Battlefront Teleport	20	4070=3	
+1347 3740 0	EARTH_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=1	23 Magic		4	Battlefront Teleport	20	4070=3	
 								
 # Mind Altar Teleport								
-2976 3509 0	LAW_RUNE=1&&MIND_RUNE=2	28 Magic		4	Mind Altar Teleport	20	4070=3	
+2979 3510 0	LAW_RUNE=1&&MIND_RUNE=2	28 Magic		4	Mind Altar Teleport	20	4070=3	
 								
 # Respawn Teleport								
 # TODO: Figure out values of Varbit 668								
 #	LAW_RUNE=1&&SOUL_RUNE=1	34 Magic		4	Respawn Teleport	20	4070=3	
 								
 # Salve Graveyard Teleport								
-3432 3459 0	LAW_RUNE=1&&SOUL_RUNE=2	40 Magic	Priest in Peril	4	Salve Graveyard Teleport	20	4070=3	
+3433 3459 0	LAW_RUNE=1&&SOUL_RUNE=2	40 Magic	Priest in Peril	4	Salve Graveyard Teleport	20	4070=3	
 								
 # Fenkenstrain's Castle Teleport								
 3548 3529 0	EARTH_RUNE=1&&LAW_RUNE=1&&SOUL_RUNE=1	48 Magic	Priest in Peril	4	Fenkenstrain's Castle Teleport	20	4070=3	
@@ -161,13 +161,13 @@
 2500 3290 0	LAW_RUNE=2&&SOUL_RUNE=2	61 Magic	Biohazard	4	West Ardougne Teleport	20	4070=3	
 								
 # Harmony Island Teleport								
-3796 2866 0	LAW_RUNE=1&&NATURE_RUNE=1&&SOUL_RUNE=1	65 Magic	The Great Brain Robbery	4	Harmony Island Teleport	20	4070=3	
+3797 2866 0	LAW_RUNE=1&&NATURE_RUNE=1&&SOUL_RUNE=1	65 Magic	The Great Brain Robbery	4	Harmony Island Teleport	20	4070=3	
 								
 # Cemetery Teleport								
-2980 3762 0	BLOOD_RUNE=1&&LAW_RUNE=1&&SOUL_RUNE=1	71 Magic		4	Cemetery Teleport	20	4070=3	
+2981 3762 0	BLOOD_RUNE=1&&LAW_RUNE=1&&SOUL_RUNE=1	71 Magic		4	Cemetery Teleport	20	4070=3	
 								
 # Barrows Teleport								
-3563 3314 0	BLOOD_RUNE=1&&LAW_RUNE=2&&SOUL_RUNE=2	83 Magic		4	Barrows Teleport	20	4070=3	
+3564 3315 0	BLOOD_RUNE=1&&LAW_RUNE=2&&SOUL_RUNE=2	83 Magic		4	Barrows Teleport	20	4070=3	
 								
 # Ape Atoll Teleport								
 2771 9102 0	BLOOD_RUNE=2&&LAW_RUNE=2&&SOUL_RUNE=2	90 Magic	Monkey Madness I	4	Ape Atoll Teleport	20	4070=3	

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -1107,7 +1107,7 @@ public class PathfinderTest {
         setupConfig(QuestState.FINISHED, 99, TeleportationItem.NONE, varbits);
         Pathfinder withVarrockTeleport = runScenario("Deep wilderness -> Grand Exchange with GE Varrock Teleport", deepWilderness, grandExchange);
 
-        assertEquals(182, withVarrockTeleport.getPath().size());
+        assertEquals(181, withVarrockTeleport.getPath().size());
         assertTrue("GE Varrock Teleport should be used on the route to Grand Exchange",
             usedTransportWithDisplayInfo(withVarrockTeleport, TransportType.TELEPORTATION_SPELL, "Varrock Teleport: GE"));
     }
@@ -1132,7 +1132,7 @@ public class PathfinderTest {
 
         Pathfinder pathfinder = runScenario("Deep wilderness -> Grand Exchange with glory and GE runes", deepWilderness, grandExchange);
 
-        assertEquals(103, pathfinder.getPath().size());
+        assertEquals(102, pathfinder.getPath().size());
         assertTrue("Glory should be used when both glory and GE runes are available but the spell is still wilderness-locked",
             usedTransportWithDisplayInfo(pathfinder, TransportType.TELEPORTATION_ITEM, "Amulet of glory"));
     }


### PR DESCRIPTION
## Summary

Systematic review of teleport destination coordinates across all four teleportation data files, cross-referenced against OSRS wiki kartographer.

**Note:** The wiki's `data-lat` attribute has a consistent +2 Y offset relative to actual in-game tile coordinates. Changes that only appeared to differ by Y+2 were not applied.

### `teleportation_spells.tsv`
- Varrock Teleport (GE), Falador, Camelot (standard + Seers' variant), Ardougne, Civitas illa Fortis, Watchtower, Salve Graveyard (Standard spellbook), Paddewwa, Lassar, Annakarl, Ghorrock, Waterbirth, Arceuus Library, Battlefront, Draynor Manor, Mind Altar, Salve Graveyard (Arceuus), Harmony Island, Cemetery, Barrows

### `teleportation_items.tsv`
- **Tablets:** Varrock (GE), Falador, Camelot, Ardougne, Watchtower, Paddewwa, Lassar, Annakarl, Ghorrock, Waterbirth, Arceuus Library, Draynor Manor, Mind Altar, Salve Graveyard, West Ardougne, Harmony Island, Cemetery, Barrows
- **Jewellery:** Slayer ring (Stronghold, Fremennik cave), Games necklace (Burthorpe), Necklace of passage (The Outpost), Ectophial, Kandarin headgear, Ardougne cloak (Monastery + Farm), Rada's blessing (Kourend Woodland + Mount Karuulm)
- **Western banner:** corrected to land inside Piscatoris Colony

### `teleportation_portals_poh.tsv`
- Barbarian Outpost, Seers' Village, Dareeyak, Ice Plateau, Ourania, Paddewwa, Port Khazard, Trollheim portals
- Relabelled pre-Hard-Diary Yanille Portal → Watchtower Portal (it teleports to Watchtower coordinates when the diary condition is not met)

### `teleportation_boxes.tsv`
- Amulet of Glory destinations (Edgeville, Karamja, Draynor Village, Al Kharid) in both jewellery box and ornate jewellery box
- Games necklace: Burthorpe

## Tests
Two `PathfinderTest` expected path lengths adjusted due to the corrected Varrock Teleport (GE) destination landing one tile closer to the Grand Exchange target.