### PR TITLE
Added pharos staff Jaltevas unlock condition.

### DIFF
--- a/src/main/resources/transports/teleportation_items.tsv
+++ b/src/main/resources/transports/teleportation_items.tsv
@@ -358,7 +358,7 @@
 1934 4428 0			26948=1		4	Pharaoh's sceptre: Jalsavrah	T	20		
 3341 2827 0			26948=1		4	Pharaoh's sceptre: Jaleustrophos	T	20		
 3232 2897 0			26948=1		4	Pharaoh's sceptre: Jaldraocht	T	20		
-3313 2718 0			26948=1		4	Pharaoh's sceptre: Jaltevas	T	20		
+3313 2718 0			26948=1		4	Pharaoh's sceptre: Jaltevas	T	20	13839=1	
 3081 3421 0			9013=1||21276=1		4	Skull sceptre	T	20		
 1579 3530 0			13393=1		4	Xeric's talisman: 1. Xeric's Lookout	T	20		
 1752 3566 0			13393=1		4	Xeric's talisman: 2. Xeric's Glade	T	20		


### PR DESCRIPTION
Unlock was not gated. RuneLite's API lists PHARAOHS_SCEPTRE_NECROPOLIS=13839 for the unlock.