### PR TITLE
Fix pickup alternative options and rune pouch use

### DIFF
--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -438,7 +438,17 @@ public class PathTileOverlay extends Overlay {
             }
         }
 
-        for (Transport transport : candidateTransports) {
+        // Only show transports the player can currently use; fall back to all if none are usable.
+        java.util.Map<Integer, Integer> playerHas = BankPickupRequirements.collectPlayerItems(client);
+        java.util.List<Transport> usableTransports = new java.util.ArrayList<>();
+        for (Transport t : candidateTransports) {
+            if (BankPickupRequirements.transportSatisfiedBy(t, playerHas)) {
+                usableTransports.add(t);
+            }
+        }
+        java.util.Collection<Transport> transportsToShow = usableTransports.isEmpty() ? candidateTransports : usableTransports;
+
+        for (Transport transport : transportsToShow) {
             String text = transport.getDisplayInfo();
             if (text == null || text.isEmpty()) {
                 continue;

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -41,15 +41,15 @@ import shortestpath.transport.requirement.ItemRequirement;
 import shortestpath.transport.requirement.TransportItems;
 
 public class PathfinderConfig {
-    private static final List<Integer> RUNE_POUCHES = Arrays.asList(
+    public static final List<Integer> RUNE_POUCHES = Arrays.asList(
             ItemID.BH_RUNE_POUCH, ItemID.BH_RUNE_POUCH_TROUVER,
             ItemID.DIVINE_RUNE_POUCH, ItemID.DIVINE_RUNE_POUCH_TROUVER
     );
-    private static final int[] RUNE_POUCH_RUNE_VARBITS = {
+    public static final int[] RUNE_POUCH_RUNE_VARBITS = {
             VarbitID.RUNE_POUCH_TYPE_1, VarbitID.RUNE_POUCH_TYPE_2, VarbitID.RUNE_POUCH_TYPE_3, VarbitID.RUNE_POUCH_TYPE_4,
             VarbitID.RUNE_POUCH_TYPE_5, VarbitID.RUNE_POUCH_TYPE_6
     };
-    private static final int[] RUNE_POUCH_AMOUNT_VARBITS = {
+    public static final int[] RUNE_POUCH_AMOUNT_VARBITS = {
             VarbitID.RUNE_POUCH_QUANTITY_1, VarbitID.RUNE_POUCH_QUANTITY_2, VarbitID.RUNE_POUCH_QUANTITY_3, VarbitID.RUNE_POUCH_QUANTITY_4,
             VarbitID.RUNE_POUCH_QUANTITY_5, VarbitID.RUNE_POUCH_QUANTITY_6
     };

--- a/src/main/java/shortestpath/transport/BankPickupRequirements.java
+++ b/src/main/java/shortestpath/transport/BankPickupRequirements.java
@@ -2,6 +2,7 @@ package shortestpath.transport;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -60,9 +61,6 @@ public class BankPickupRequirements {
             return requiredItems;
         }
 
-        // Snapshot what the player already has on them (inventory + equipment + rune pouch).
-        Map<Integer, Integer> playerHas = collectPlayerItems(client);
-
         // Snapshot bank contents.
         Map<Integer, Integer> bankHas = new HashMap<>();
         for (Item bankItem : bank.getItems()) {
@@ -70,6 +68,13 @@ public class BankPickupRequirements {
                 bankHas.merge(bankItem.getId(), bankItem.getQuantity(), Integer::sum);
             }
         }
+
+        // Map runeId → pouchId for any rune pouch sitting in the bank.
+        // Used so computeBankPickups can show "pick up rune pouch" instead of individual runes.
+        Map<Integer, Integer> bankPouchRunes = buildBankPouchRunes(client, bankHas);
+
+        // Snapshot what the player already has on them (inventory + equipment + rune pouch in hand).
+        Map<Integer, Integer> playerHas = collectPlayerItems(client);
 
         // Each entry is one edge's pickup phrase, e.g. "Air rune (3), Law rune or Varrock teleport".
         // A LinkedHashSet preserves order while deduplicating identical phrases across edges.
@@ -138,11 +143,11 @@ public class BankPickupRequirements {
                 continue;
             }
 
-            // Otherwise, surface every alternative the bank can fully supply, joined by " or ".
+            // Otherwise, surface every alternative the bank can fully supply, joined, bankPouchRunes by " or ".
             // Deduplicate alternatives that resolve to the exact same set of bank items.
             LinkedHashSet<String> altStrings = new LinkedHashSet<>();
             for (Transport t : nonFairy) {
-                Map<Integer, Long> pickups = computeBankPickups(t, playerHas, bankHas);
+                Map<Integer, Long> pickups = computeBankPickups(t, playerHas, bankHas, bankPouchRunes);
                 if (pickups == null || pickups.isEmpty()) {
                     continue; // bank can't satisfy this alternative
                 }
@@ -228,7 +233,7 @@ public class BankPickupRequirements {
      * Returns true if every requirement of the transport is already met by the player's
      * inventory/equipment/rune-pouch (taking item-id, staff and offhand variations into account).
      */
-    private static boolean transportSatisfiedBy(Transport transport, Map<Integer, Integer> playerHas) {
+    public static boolean transportSatisfiedBy(Transport transport, Map<Integer, Integer> playerHas) {
         if (transport.getItemRequirements() == null) {
             return true;
         }
@@ -247,11 +252,15 @@ public class BankPickupRequirements {
     /**
      * For an unsatisfied transport, returns the items (id → qty) that need to be picked up
      * from the bank to satisfy it, or null if the bank can't supply them.
+     * When a required rune is only available via a bank rune pouch, the pouch itself is
+     * returned as the pickup item (qty 1, deduped across multiple rune requirements).
      */
     private static Map<Integer, Long> computeBankPickups(Transport transport,
                                                          Map<Integer, Integer> playerHas,
-                                                         Map<Integer, Integer> bankHas) {
+                                                         Map<Integer, Integer> bankHas,
+                                                         Map<Integer, Integer> bankPouchRunes) {
         Map<Integer, Long> pickups = new LinkedHashMap<>();
+        Set<Integer> addedPouches = new HashSet<>(); // tracks pouch IDs already added to pickups
         if (transport.getItemRequirements() == null) {
             return pickups;
         }
@@ -263,29 +272,76 @@ public class BankPickupRequirements {
                     || hasAnyItem(playerHas, req.getOffhandIds(), 1)) {
                 continue;
             }
-            // Try to satisfy from bank: prefer the primary item ids, then staves, then offhands.
-            int foundId = findItemIdInBank(bankHas, req.getItemIds(), qty);
-            int foundQty = qty;
-            if (foundId == -1) {
-                foundId = findItemIdInBank(bankHas, req.getStaffIds(), 1);
-                foundQty = 1;
+            // Prefer bank rune pouch over individual runes. This avoids surfacing combination
+            // rune variants (mist, dust, etc.) when the pouch already covers the requirement.
+            boolean satisfied = false;
+            if (req.getItemIds() != null) {
+                for (int itemId : req.getItemIds()) {
+                    Integer pouchId = bankPouchRunes.get(itemId);
+                    if (pouchId != null) {
+                        if (!addedPouches.contains(pouchId)) {
+                            addedPouches.add(pouchId);
+                            pickups.put(pouchId, 1L);
+                        }
+                        satisfied = true;
+                        break;
+                    }
+                }
             }
+            if (satisfied) {
+                continue;
+            }
+            // Try to satisfy from bank directly. Use the canonical (first) item ID for display
+            // so we show "Air rune" rather than a combination rune variant like "Mist rune".
+            int foundId = findItemIdInBank(bankHas, req.getItemIds(), qty);
+            if (foundId != -1) {
+                pickups.merge(req.getItemIds()[0], (long) qty, Long::sum);
+                continue;
+            }
+            foundId = findItemIdInBank(bankHas, req.getStaffIds(), 1);
             if (foundId == -1) {
                 foundId = findItemIdInBank(bankHas, req.getOffhandIds(), 1);
-                foundQty = 1;
             }
             if (foundId == -1) {
                 return null; // bank can't satisfy this requirement
             }
-            pickups.merge(foundId, (long) foundQty, Long::sum);
+            pickups.merge(foundId, 1L, Long::sum);
         }
         return pickups;
     }
 
     /**
-     * Collects the items the player currently has accessible (inventory + equipment + rune pouch).
+     * Builds a map of runeId → pouchId for every rune stored inside any rune pouch in the bank.
+     * The varbits that encode pouch contents are always current regardless of pouch location.
      */
-    private static Map<Integer, Integer> collectPlayerItems(Client client) {
+    private static Map<Integer, Integer> buildBankPouchRunes(Client client, Map<Integer, Integer> bankHas) {
+        Map<Integer, Integer> bankPouchRunes = new HashMap<>();
+        for (Integer pouchId : PathfinderConfig.RUNE_POUCHES) {
+            if (!bankHas.containsKey(pouchId)) {
+                continue;
+            }
+            EnumComposition runePouchEnum = client.getEnum(EnumID.RUNEPOUCH_RUNE);
+            if (runePouchEnum == null) {
+                break;
+            }
+            for (int i = 0; i < PathfinderConfig.RUNE_POUCH_RUNE_VARBITS.length; i++) {
+                int runeEnumId = client.getVarbitValue(PathfinderConfig.RUNE_POUCH_RUNE_VARBITS[i]);
+                int runeId = runeEnumId > 0 ? runePouchEnum.getIntValue(runeEnumId) : 0;
+                int runeAmount = client.getVarbitValue(PathfinderConfig.RUNE_POUCH_AMOUNT_VARBITS[i]);
+                if (runeId > 0 && runeAmount > 0) {
+                    bankPouchRunes.put(runeId, pouchId);
+                }
+            }
+            break; // one pouch per bank
+        }
+        return bankPouchRunes;
+    }
+
+    /**
+     * Snapshots what the player already has on them (inventory + equipment + rune pouch
+     * contents if the pouch is in inventory or equipped).
+     */
+    public static Map<Integer, Integer> collectPlayerItems(Client client) {
         Map<Integer, Integer> totals = new HashMap<>();
 
         ItemContainer inventory = client.getItemContainer(InventoryID.INV);
@@ -306,7 +362,7 @@ public class BankPickupRequirements {
             }
         }
 
-        // Rune pouch contents (only readable when a pouch is in inventory).
+        // Rune pouch contents — only when the pouch is actually on the player.
         boolean hasPouch = false;
         for (Integer pouchId : PathfinderConfig.RUNE_POUCHES) {
             if (totals.containsKey(pouchId)) {

--- a/src/main/java/shortestpath/transport/BankPickupRequirements.java
+++ b/src/main/java/shortestpath/transport/BankPickupRequirements.java
@@ -1,11 +1,15 @@
 package shortestpath.transport;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import net.runelite.api.Client;
+import net.runelite.api.EnumComposition;
+import net.runelite.api.EnumID;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.gameval.InventoryID;
@@ -13,10 +17,15 @@ import shortestpath.ItemVariations;
 import shortestpath.pathfinder.PathfinderConfig;
 import shortestpath.pathfinder.PathStep;
 import shortestpath.pathfinder.TransportAvailability;
+import shortestpath.transport.requirement.ItemRequirement;
 
 /**
  * Determines what items need to be picked up from the bank for a given path.
  * This handles transport-specific requirements like the Dramen staff for fairy rings.
+ *
+ * Multiple transports that connect the same edge are treated as alternatives (OR):
+ * if the player can satisfy any one of them, no pickup is needed; otherwise the
+ * cheapest single alternative that can be filled from the bank is chosen.
  */
 public class BankPickupRequirements {
 
@@ -51,116 +60,239 @@ public class BankPickupRequirements {
             return requiredItems;
         }
 
-        // Check what transports are used after this bank step
-        boolean usesFairyRing = false;
-        List<Transport> transportsWithItems = new ArrayList<>();
+        // Snapshot what the player already has on them (inventory + equipment + rune pouch).
+        Map<Integer, Integer> playerHas = collectPlayerItems(client);
 
+        // Snapshot bank contents.
+        Map<Integer, Integer> bankHas = new HashMap<>();
+        for (Item bankItem : bank.getItems()) {
+            if (bankItem.getId() >= 0 && bankItem.getQuantity() > 0) {
+                bankHas.merge(bankItem.getId(), bankItem.getQuantity(), Integer::sum);
+            }
+        }
+
+        // Each entry is one edge's pickup phrase, e.g. "Air rune (3), Law rune or Varrock teleport".
+        // A LinkedHashSet preserves order while deduplicating identical phrases across edges.
+        LinkedHashSet<String> phrases = new LinkedHashSet<>();
+        boolean usesFairyRing = false;
+
+        // Walk each edge in the remaining path and collect alternative transports per edge.
         for (int i = pathIndex; i < path.size() - 1; i++) {
             int stepPoint = path.get(i).getPackedPosition();
             int nextPoint = path.get(i + 1).getPackedPosition();
             boolean banked = path.get(i + 1).isBankVisited();
             TransportAvailability availability = pathfinderConfig.getTransportAvailability(banked);
-            Set<Transport> stepTransports = availability.getTransportsByOrigin().get(stepPoint);
-            if (stepTransports != null) {
-                for (Transport t : stepTransports) {
+
+            List<Transport> edgeAlternatives = new ArrayList<>();
+            Set<Transport> originSet = availability.getTransportsByOrigin().get(stepPoint);
+            if (originSet != null) {
+                for (Transport t : originSet) {
                     if (t.getDestination() == nextPoint) {
-                        if (TransportType.FAIRY_RING.equals(t.getType())) {
-                            usesFairyRing = true;
-                        } else if (t.getItemRequirements() != null && t.getItemRequirements().size() > 0) {
-                            transportsWithItems.add(t);
-                        }
+                        edgeAlternatives.add(t);
                     }
                 }
             }
-            // Transports with no fixed origin (e.g. Royal seed pod, Quetzal whistle) live in usableTeleports
             for (Transport t : availability.getUsableTeleports()) {
-                if (t.getDestination() == nextPoint
-                        && t.getItemRequirements() != null && t.getItemRequirements().size() > 0) {
-                    transportsWithItems.add(t);
+                if (t.getDestination() == nextPoint) {
+                    edgeAlternatives.add(t);
                 }
             }
+            if (edgeAlternatives.isEmpty()) {
+                continue;
+            }
+
+            // Fairy rings handled once globally via the staff requirement below.
+            List<Transport> nonFairy = new ArrayList<>();
+            for (Transport t : edgeAlternatives) {
+                if (TransportType.FAIRY_RING.equals(t.getType())) {
+                    usesFairyRing = true;
+                } else {
+                    nonFairy.add(t);
+                }
+            }
+            if (nonFairy.isEmpty()) {
+                continue;
+            }
+
+            // If at least one alternative requires no items, nothing to pick up for this edge.
+            boolean anyAlternativeIsFree = false;
+            for (Transport t : nonFairy) {
+                if (t.getItemRequirements() == null || t.getItemRequirements().size() == 0) {
+                    anyAlternativeIsFree = true;
+                    break;
+                }
+            }
+            if (anyAlternativeIsFree) {
+                continue;
+            }
+
+            // If any alternative is fully satisfied by the player already, no pickup needed.
+            boolean satisfied = false;
+            for (Transport t : nonFairy) {
+                if (transportSatisfiedBy(t, playerHas)) {
+                    satisfied = true;
+                    break;
+                }
+            }
+            if (satisfied) {
+                continue;
+            }
+
+            // Otherwise, surface every alternative the bank can fully supply, joined by " or ".
+            // Deduplicate alternatives that resolve to the exact same set of bank items.
+            LinkedHashSet<String> altStrings = new LinkedHashSet<>();
+            for (Transport t : nonFairy) {
+                Map<Integer, Long> pickups = computeBankPickups(t, playerHas, bankHas);
+                if (pickups == null || pickups.isEmpty()) {
+                    continue; // bank can't satisfy this alternative
+                }
+                altStrings.add(formatPickups(client, pickups));
+            }
+            if (altStrings.isEmpty()) {
+                continue;
+            }
+            phrases.add(String.join(" or ", altStrings));
         }
 
-        // Accumulate: bank item ID → total quantity needed for the trip
-        LinkedHashMap<Integer, Long> itemQtyNeeded = new LinkedHashMap<>();
-
-        // Dramen/Lunar staff for fairy rings
+        // Fairy ring staff (Dramen / Lunar) is a single OR requirement across the whole trip.
         if (usesFairyRing) {
             int[] staffIds = ItemVariations.DRAMEN_STAFF.getIds();
-            if (!hasItemInInventoryOrEquipment(client, staffIds, 1)) {
-                int foundId = findItemIdInBank(bank, staffIds, 1);
+            if (!hasAnyItem(playerHas, staffIds, 1)) {
+                int foundId = findItemIdInBank(bankHas, staffIds, 1);
                 if (foundId != -1) {
-                    itemQtyNeeded.put(foundId, 1L);
+                    Map<Integer, Long> single = new LinkedHashMap<>();
+                    single.put(foundId, 1L);
+                    phrases.add(formatPickups(client, single));
                 }
             }
         }
 
-        // Accumulate item requirements for all transports along the path
-        for (Transport transport : transportsWithItems) {
-            if (transport.getItemRequirements() == null) {
-                continue;
-            }
-            for (shortestpath.transport.requirement.ItemRequirement req : transport.getItemRequirements().getRequirements()) {
-                int[] itemIds = req.getItemIds();
-                if (itemIds == null || itemIds.length == 0) {
-                    continue;
-                }
-                int reqQty = req.getQuantity() > 0 ? req.getQuantity() : 1;
-                if (hasItemInInventoryOrEquipment(client, itemIds, reqQty)) {
-                    continue;
-                }
-                int foundId = findItemIdInBank(bank, itemIds, reqQty);
-                if (foundId != -1) {
-                    itemQtyNeeded.merge(foundId, (long) reqQty, Long::sum);
-                }
-            }
-        }
+        requiredItems.addAll(phrases);
+        return requiredItems;
+    }
 
-        // Format display strings, re-checking bank against the accumulated total quantity
-        for (Map.Entry<Integer, Long> entry : itemQtyNeeded.entrySet()) {
+    /**
+     * Formats a pickup map (item id → quantity) as a comma-separated, human-readable string.
+     */
+    private static String formatPickups(Client client, Map<Integer, Long> pickups) {
+        List<String> parts = new ArrayList<>(pickups.size());
+        for (Map.Entry<Integer, Long> entry : pickups.entrySet()) {
             int itemId = entry.getKey();
-            long totalQty = entry.getValue();
-            if (!hasItemInBank(bank, new int[]{itemId}, (int) Math.min(totalQty, Integer.MAX_VALUE))) {
-                continue;
-            }
+            long qty = entry.getValue();
             String itemName = client.getItemDefinition(itemId).getName();
             if (itemName == null || itemName.isEmpty() || "null".equals(itemName)) {
                 itemName = "Unknown item";
             }
             boolean isCurrency = PathfinderConfig.CURRENCIES.contains(itemId);
-            if (isCurrency && totalQty > 1) {
-                itemName += " (" + String.format("%,d", totalQty) + ")";
+            if (isCurrency && qty > 1) {
+                itemName += " (" + String.format("%,d", qty) + ")";
             }
-            requiredItems.add(itemName);
+            parts.add(itemName);
         }
-
-        return requiredItems;
+        return String.join(", ", parts);
     }
 
     /**
-     * Returns the item ID from {@code itemIds} that is present in the bank with at least
+     * Returns true if the player has at least {@code requiredQty} of any id in {@code itemIds}
+     * across inventory/equipment/rune-pouch.
+     */
+    private static boolean hasAnyItem(Map<Integer, Integer> playerHas, int[] itemIds, int requiredQty) {
+        if (itemIds == null) {
+            return false;
+        }
+        for (int id : itemIds) {
+            if (playerHas.getOrDefault(id, 0) >= requiredQty) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the item ID from {@code itemIds} present in the bank with at least
      * {@code requiredQty}, or -1 if none qualifies.
      */
-    private static int findItemIdInBank(ItemContainer bank, int[] itemIds, int requiredQty) {
-        for (Item bankItem : bank.getItems()) {
-            for (int itemId : itemIds) {
-                if (bankItem.getId() == itemId && bankItem.getQuantity() >= requiredQty) {
-                    return itemId;
-                }
+    private static int findItemIdInBank(Map<Integer, Integer> bankHas, int[] itemIds, int requiredQty) {
+        if (itemIds == null) {
+            return -1;
+        }
+        for (int id : itemIds) {
+            if (bankHas.getOrDefault(id, 0) >= requiredQty) {
+                return id;
             }
         }
         return -1;
     }
 
+    /**
+     * Returns true if every requirement of the transport is already met by the player's
+     * inventory/equipment/rune-pouch (taking item-id, staff and offhand variations into account).
+     */
+    private static boolean transportSatisfiedBy(Transport transport, Map<Integer, Integer> playerHas) {
+        if (transport.getItemRequirements() == null) {
+            return true;
+        }
+        for (ItemRequirement req : transport.getItemRequirements().getRequirements()) {
+            int qty = req.getQuantity() > 0 ? req.getQuantity() : 1;
+            if (hasAnyItem(playerHas, req.getItemIds(), qty)
+                    || hasAnyItem(playerHas, req.getStaffIds(), 1)
+                    || hasAnyItem(playerHas, req.getOffhandIds(), 1)) {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
 
-    private static boolean hasItemInInventoryOrEquipment(Client client, int[] itemIds, int requiredQty) {
+    /**
+     * For an unsatisfied transport, returns the items (id → qty) that need to be picked up
+     * from the bank to satisfy it, or null if the bank can't supply them.
+     */
+    private static Map<Integer, Long> computeBankPickups(Transport transport,
+                                                         Map<Integer, Integer> playerHas,
+                                                         Map<Integer, Integer> bankHas) {
+        Map<Integer, Long> pickups = new LinkedHashMap<>();
+        if (transport.getItemRequirements() == null) {
+            return pickups;
+        }
+        for (ItemRequirement req : transport.getItemRequirements().getRequirements()) {
+            int qty = req.getQuantity() > 0 ? req.getQuantity() : 1;
+            // Already satisfied by player?
+            if (hasAnyItem(playerHas, req.getItemIds(), qty)
+                    || hasAnyItem(playerHas, req.getStaffIds(), 1)
+                    || hasAnyItem(playerHas, req.getOffhandIds(), 1)) {
+                continue;
+            }
+            // Try to satisfy from bank: prefer the primary item ids, then staves, then offhands.
+            int foundId = findItemIdInBank(bankHas, req.getItemIds(), qty);
+            int foundQty = qty;
+            if (foundId == -1) {
+                foundId = findItemIdInBank(bankHas, req.getStaffIds(), 1);
+                foundQty = 1;
+            }
+            if (foundId == -1) {
+                foundId = findItemIdInBank(bankHas, req.getOffhandIds(), 1);
+                foundQty = 1;
+            }
+            if (foundId == -1) {
+                return null; // bank can't satisfy this requirement
+            }
+            pickups.merge(foundId, (long) foundQty, Long::sum);
+        }
+        return pickups;
+    }
+
+    /**
+     * Collects the items the player currently has accessible (inventory + equipment + rune pouch).
+     */
+    private static Map<Integer, Integer> collectPlayerItems(Client client) {
+        Map<Integer, Integer> totals = new HashMap<>();
+
         ItemContainer inventory = client.getItemContainer(InventoryID.INV);
         if (inventory != null) {
             for (Item item : inventory.getItems()) {
-                for (int itemId : itemIds) {
-                    if (item.getId() == itemId && item.getQuantity() >= requiredQty) {
-                        return true;
-                    }
+                if (item.getId() >= 0 && item.getQuantity() > 0) {
+                    totals.merge(item.getId(), item.getQuantity(), Integer::sum);
                 }
             }
         }
@@ -168,25 +300,34 @@ public class BankPickupRequirements {
         ItemContainer equipment = client.getItemContainer(InventoryID.WORN);
         if (equipment != null) {
             for (Item item : equipment.getItems()) {
-                for (int itemId : itemIds) {
-                    if (item.getId() == itemId) {
-                        return true; // equipped items don't have a meaningful quantity
+                if (item.getId() >= 0 && item.getQuantity() > 0) {
+                    totals.merge(item.getId(), item.getQuantity(), Integer::sum);
+                }
+            }
+        }
+
+        // Rune pouch contents (only readable when a pouch is in inventory).
+        boolean hasPouch = false;
+        for (Integer pouchId : PathfinderConfig.RUNE_POUCHES) {
+            if (totals.containsKey(pouchId)) {
+                hasPouch = true;
+                break;
+            }
+        }
+        if (hasPouch) {
+            EnumComposition runePouchEnum = client.getEnum(EnumID.RUNEPOUCH_RUNE);
+            if (runePouchEnum != null) {
+                for (int i = 0; i < PathfinderConfig.RUNE_POUCH_RUNE_VARBITS.length; i++) {
+                    int runeEnumId = client.getVarbitValue(PathfinderConfig.RUNE_POUCH_RUNE_VARBITS[i]);
+                    int runeId = runeEnumId > 0 ? runePouchEnum.getIntValue(runeEnumId) : 0;
+                    int runeAmount = client.getVarbitValue(PathfinderConfig.RUNE_POUCH_AMOUNT_VARBITS[i]);
+                    if (runeId > 0 && runeAmount > 0) {
+                        totals.merge(runeId, runeAmount, Integer::sum);
                     }
                 }
             }
         }
 
-        return false;
-    }
-
-    private static boolean hasItemInBank(ItemContainer bank, int[] itemIds, int requiredQty) {
-        for (Item bankItem : bank.getItems()) {
-            for (int itemId : itemIds) {
-                if (bankItem.getId() == itemId && bankItem.getQuantity() >= requiredQty) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return totals;
     }
 }


### PR DESCRIPTION
Fix the BankPickupRequirements treating alternative transport options as AND conditions to accept either alternative as valid. Updated display to indicate option A or option B. Fixed rune pouch detection in bank, taking it's contents into account, banked or not. Also filtered transport hint to only show available options instead of all options for a destination.

**Transport and Pickup Logic Improvements:**

* The logic for calculating required bank pickups in `BankPickupRequirements` has been rewritten to treat multiple transports connecting the same edge as alternatives (OR), only requiring a pickup if none are satisfied by the inventory. The code now deduplicates and formats pickup requirements more clearly, and handles rune pouch contents.
* Added new utility methods to `BankPickupRequirements` for checking if a transport is satisfied by the player's inventory, for computing required pickups from the bank, and for collecting and formatting player and bank item snapshots, including rune pouch contents.

**Transport Display Logic:**

* In `PathTileOverlay`, only transports that the player can currently use are shown; if none are usable, all are shown as a fallback. This uses the new `collectPlayerItems` and `transportSatisfiedBy` logic.