### PR TITLE
POH spirit tree sugessted with option disabled

### DIFF
--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -461,7 +461,9 @@ public class PathfinderConfig {
         if (!usePoh) {
             int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
             int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
-            if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
+            int destX = WorldPointUtil.unpackWorldX(transport.getDestination());
+            int destY = WorldPointUtil.unpackWorldY(transport.getDestination());
+            if (ShortestPathPlugin.isInsidePoh(originX, originY) || ShortestPathPlugin.isInsidePoh(destX, destY)) {
                 return false;
             }
         }
@@ -543,8 +545,10 @@ public class PathfinderConfig {
     private boolean checkPohVariant(Transport transport, TransportType type) {
         int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
         int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
+        int destX = WorldPointUtil.unpackWorldX(transport.getDestination());
+        int destY = WorldPointUtil.unpackWorldY(transport.getDestination());
 
-        if (!ShortestPathPlugin.isInsidePoh(originX, originY)) {
+        if (!ShortestPathPlugin.isInsidePoh(originX, originY) && !ShortestPathPlugin.isInsidePoh(destX, destY)) {
             return true; // Not a POH transport
         }
 

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -171,6 +171,8 @@ public class PathfinderTest {
     @Test
     public void testFairyRings() {
         when(config.useFairyRings()).thenReturn(true);
+        when(config.usePoh()).thenReturn(true);
+        when(config.usePohFairyRing()).thenReturn(true);
         setupInventory(new Item(ItemID.DRAMEN_STAFF, 1));
         when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
 
@@ -181,6 +183,8 @@ public class PathfinderTest {
     @Test
     public void testLunarStaffFairyRings() {
         when(config.useFairyRings()).thenReturn(true);
+        when(config.usePoh()).thenReturn(true);
+        when(config.usePohFairyRing()).thenReturn(true);
         setupInventory(new Item(ItemID.LUNAR_MOONCLAN_LIMINAL_STAFF, 1));
         when(client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST)).thenReturn(100);
 
@@ -1451,11 +1455,6 @@ public class PathfinderTest {
         for (int origin : transports.keySet()) {
             for (Transport transport : transports.get(origin)) {
                 if (transportType.equals(transport.getType())) {
-                    int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
-                    int originY = WorldPointUtil.unpackWorldY(transport.getOrigin());
-                    if (ShortestPathPlugin.isInsidePoh(originX, originY)) {
-                        continue;
-                    }
                     expectedCount++;
                     if (sampleTransport == null) {
                         sampleTransport = transport;


### PR DESCRIPTION
I got a random suggestion to use a spirit tree to go to the POH even though I did not have it enabled in the config. The POH teleports with a destination inside the POH were not filtered properly on availability, fixed that.