### PR TITLE
Add Ancient Cavern Whirlpool transport

### DIFF
--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -5023,8 +5023,10 @@
 2522 3493 1	2522 3493 0	Climb-down Ladder 16679						2	
 									
 # Ancient Cavern (Baxtorian Falls Whirlpool)									
-2511 3511 0	1768 5366 0	Jump-into Whirlpool 25274	35 Firemaking					2	
-2512 3511 0	1768 5366 0	Jump-into Whirlpool 25274	35 Firemaking					2	
+2511 3511 0	1768 5366 0	Jump-into Whirlpool 25274				3759>1		2	
+2512 3511 0	1768 5366 0	Jump-into Whirlpool 25274				3759>1		2	
+1742 5352 0	2531 3446 0	Ride Aged log 25216						2	
+1761 5362 0	2531 3446 0	Ride Aged log 25216						2	
 									
 # Hunter Guild									
 1559 3046 0	1556 3046 2	Climb-up Rope 51647						2	

--- a/src/main/resources/transports/transports.tsv
+++ b/src/main/resources/transports/transports.tsv
@@ -5022,6 +5022,10 @@
 2521 3494 1	2521 3494 0	Climb-down Ladder 16679						2	
 2522 3493 1	2522 3493 0	Climb-down Ladder 16679						2	
 									
+# Ancient Cavern (Baxtorian Falls Whirlpool)									
+2511 3511 0	1768 5366 0	Jump-into Whirlpool 25274	35 Firemaking					2	
+2512 3511 0	1768 5366 0	Jump-into Whirlpool 25274	35 Firemaking					2	
+									
 # Hunter Guild									
 1559 3046 0	1556 3046 2	Climb-up Rope 51647						2	
 1556 3046 2	1559 3046 0	Climb-down Rope 51644						2	


### PR DESCRIPTION
Adds transport entries for the Ancient Cavern whirlpool and aged log exits.

**Whirlpool (surface → cavern)**
- Origins: `2511 3511 0` and `2512 3511 0` (Baxtorian Falls pier)
- Destination: `1768 5366 0` (Ancient Cavern)
- Object: `Jump-into Whirlpool 25274`
- Requirement: `BRUT_FIRE (3759) > 1` — guards entry behind the barbarian firemaking prerequisite. Value 2 is set when a player has lit their first pyre ship and spoken to Otto about pyre ships, which is the exact gate the game enforces.

**Aged log (cavern → surface)**
- Origins: `1742 5352 0` and `1761 5362 0` (aged logs inside Ancient Cavern)
- Destination: `2531 3446 0` (south-east of Baxtorian Falls, near Hadley)
- Object: `Ride Aged log 25216`
- No requirements — anyone inside can exit freely.

Closes: #374