### PR TITLE
Item requirement fixes

### DIFF
--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -507,7 +507,7 @@ public class PathTileOverlay extends Overlay
 			if (!bankPickupItems.isEmpty())
 			{
 				String pickupText = "Pick up: " + String.join(", ", bankPickupItems);
-				drawLabelAtPackedLocation(graphics, location, pickupText, 0);
+				playerTileLabelOffset = drawLabelAtPackedLocation(graphics, location, pickupText, playerTileLabelOffset);
 
 				// By default, bank pickup info replaces the default transport hint text;
 				// enable the option to show both

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -410,6 +410,10 @@ public class PathfinderConfig
 		{
 			return costConsumableTeleportationItems;
 		}
+		if (transport.isConsumable() && TransportType.QUETZAL_WHISTLE.equals(transport.getType()))
+		{
+			return transportTypeConfig.getCost(transport.getType()) + costConsumableTeleportationItems;
+		}
 		return transportTypeConfig.getCost(transport.getType());
 	}
 

--- a/src/main/java/shortestpath/transport/BankPickupRequirements.java
+++ b/src/main/java/shortestpath/transport/BankPickupRequirements.java
@@ -222,9 +222,16 @@ public final class BankPickupRequirements
 				itemName = "Unknown item";
 			}
 			boolean isCurrency = PathfinderConfig.CURRENCIES.contains(itemId);
-			if (isCurrency && qty > 1)
+			if (isCurrency)
 			{
-				itemName += " (" + String.format("%,d", qty) + ")";
+				if (qty > 1)
+				{
+					itemName += " (" + String.format("%,d", qty) + ")";
+				}
+			}
+			else
+			{
+				itemName = qty + " " + itemName;
 			}
 			parts.add(itemName);
 		}

--- a/src/test/java/shortestpath/pathfinder/PathfinderTest.java
+++ b/src/test/java/shortestpath/pathfinder/PathfinderTest.java
@@ -995,6 +995,35 @@ public class PathfinderTest
 		assertEquals("Whistle should be used when far from any platform", 2, pathLength);
 	}
 
+	/**
+	 * Issue #468: costConsumableTeleportationItems should penalise the Quetzal
+	 * whistle as well as teleportation tabs, since both are consumable items.
+	 * Without this fix the whistle bypassed the consumable-item threshold and could
+	 * make a bank-detour route appear cheaper than a direct teleportation tab.
+	 *
+	 * Verified via the Aldarin platform cost boundary: from 1 tile away the platform
+	 * compareCost is 7 (1 walk + 6 flight). With costConsumableTeleportationItems=5
+	 * the whistle's actual cost becomes 4+5=9, so the platform wins (path length 3).
+	 * Before the fix the whistle paid no consumable penalty (cost 4) and won (path 2).
+	 */
+	@Test
+	public void testConsumableCostPenaltyAppliedToQuetzalWhistle()
+	{
+		when(config.useQuetzals()).thenReturn(true);
+		when(config.costConsumableTeleportationItems()).thenReturn(5);
+		when(config.costQuetzalWhistle()).thenReturn(0);
+		setupInventory(new Item(29271, 1)); // Quetzal whistle
+		setupConfig(QuestState.FINISHED, 99, TeleportationItem.INVENTORY);
+
+		int nearAldarin = WorldPointUtil.packWorldPoint(1390, 2901, 0);
+		int hunterGuild = WorldPointUtil.packWorldPoint(1585, 3053, 0);
+
+		int pathLength = calculatePathLength(nearAldarin, hunterGuild);
+		assertEquals(
+			"Platform should win when costConsumableTeleportationItems tips the whistle past the platform cost",
+			3, pathLength);
+	}
+
 	@Test
 	public void testSpiritTrees()
 	{


### PR DESCRIPTION
Three fixes:

- Fixed custom costs for consumable teleports in combination with quetzals
- Fixed display hints being drawn on top of each other
- Displaying quantities for item pickup