### PR TITLE
Disable Castle Wars F2P doors to Ferox

### DIFF
--- a/src/main/resources/transports/teleportation_portals.tsv
+++ b/src/main/resources/transports/teleportation_portals.tsv
@@ -3,8 +3,9 @@
 3147 3638 0	2440 3089 0	Enter Castle Wars portal 30386					1	
 3147 3639 0	2440 3089 0	Enter Castle Wars portal 30386					1	
 3147 3640 0	2440 3089 0	Enter Castle Wars portal 30386					1	
-2444 3089 0	3151 3635 0	Enter Large door 30388					1	
-2444 3090 0	3151 3635 0	Enter Large door 30388					1	
+# Disable the big doors for now as we can't distinguish between f2p and members' worlds atm.								
+#2444 3089 0	3151 3635 0	Enter Large door 30388					1	
+#2444 3090 0	3151 3635 0	Enter Large door 30388					1	
 2438 3097 0	2376 9489 0	Enter Saradomin Portal 4387	HEADSLOT=0&CAPESLOT=0				1	
 2438 3096 0	2376 9489 0	Enter Saradomin Portal 4387	HEADSLOT=0&CAPESLOT=0				1	
 2436 3095 0	2376 9489 0	Enter Saradomin Portal 4387	HEADSLOT=0&CAPESLOT=0				1	

--- a/src/main/resources/transports/teleportation_portals.tsv
+++ b/src/main/resources/transports/teleportation_portals.tsv
@@ -4,8 +4,6 @@
 3147 3639 0	2440 3089 0	Enter Castle Wars portal 30386					1	
 3147 3640 0	2440 3089 0	Enter Castle Wars portal 30386					1	
 # Disable the big doors for now as we can't distinguish between f2p and members' worlds atm.								
-#2444 3089 0	3151 3635 0	Enter Large door 30388					1	
-#2444 3090 0	3151 3635 0	Enter Large door 30388					1	
 2438 3097 0	2376 9489 0	Enter Saradomin Portal 4387	HEADSLOT=0&CAPESLOT=0				1	
 2438 3096 0	2376 9489 0	Enter Saradomin Portal 4387	HEADSLOT=0&CAPESLOT=0				1	
 2436 3095 0	2376 9489 0	Enter Saradomin Portal 4387	HEADSLOT=0&CAPESLOT=0				1	


### PR DESCRIPTION
We don't distinguish between F2P and members' worlds at this time, so these doors can cause some weird issues.