### PR TITLE
Use Easy Teleports labels for transport display

### DIFF
--- a/src/main/java/shortestpath/PathMapTooltipOverlay.java
+++ b/src/main/java/shortestpath/PathMapTooltipOverlay.java
@@ -109,9 +109,9 @@ public class PathMapTooltipOverlay extends Overlay
 			PathStep nextStep = plugin.nextPathStep(path, pathIndex);
 			for (Transport transport : plugin.transportsForEdge(currentStep, nextStep))
 			{
-				if (transport.getDisplayInfo() != null && !transport.getDisplayInfo().isEmpty())
+				String displayInfo = plugin.formatTransportDisplayInfo(transport);
+				if (displayInfo != null && !displayInfo.isEmpty())
 				{
-					String displayInfo = transport.getDisplayInfo();
 					// Check if this transport goes to POH - if so, look ahead to find the exit
 					// transport
 					String pohExitInfo = plugin.getPohExitInfo(nextPoint, path, pathIndex);

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -470,7 +470,7 @@ public class PathTileOverlay extends Overlay
 			String text = null;
 			for (Transport transport : candidateTransports)
 			{
-				text = transport.getDisplayInfo();
+				text = plugin.formatTransportDisplayInfo(transport);
 				if (text != null && !text.isEmpty())
 				{
 					break;
@@ -532,7 +532,7 @@ public class PathTileOverlay extends Overlay
 
 		for (Transport transport : transportsToShow)
 		{
-			String text = transport.getDisplayInfo();
+			String text = plugin.formatTransportDisplayInfo(transport);
 			if (text == null || text.isEmpty())
 			{
 				continue;

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -442,10 +442,22 @@ public interface ShortestPathConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "easyTeleportNames",
+		name = "Easy teleport names",
+		description = "Use Easy Teleports custom names in transport hints when available",
+		position = 33,
+		section = sectionSettings
+	)
+	default boolean easyTeleportNames()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "showBankPickupInfo",
 		name = "Show transport hint at pickup",
 		description = "When standing at a bank on the path, also show the transport hint for the next step requiring an item pickup",
-		position = 33,
+		position = 34,
 		section = sectionSettings
 	)
 	default boolean showBankPickupInfo()

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -55,12 +55,14 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.PluginChanged;
 import net.runelite.client.events.PluginMessage;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.JagexColors;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
@@ -72,6 +74,7 @@ import shortestpath.pathfinder.CollisionMap;
 import shortestpath.pathfinder.PathStep;
 import shortestpath.pathfinder.Pathfinder;
 import shortestpath.pathfinder.PathfinderConfig;
+import shortestpath.teleports.EasyTeleportLabelFormatter;
 import shortestpath.transport.Transport;
 import shortestpath.transport.TransportType;
 
@@ -83,6 +86,7 @@ import shortestpath.transport.TransportType;
 public class ShortestPathPlugin extends Plugin
 {
 	protected static final String CONFIG_GROUP = "shortestpath";
+	private static final String EASY_TELEPORTS_PLUGIN_NAME = "Easy Teleports";
 
 	// POH (Player Owned House) bounds for detecting when path goes through POH
 	// Note: POH_MIN_X is 1856 to exclude the Daddy's Home miniquest area
@@ -109,6 +113,7 @@ public class ShortestPathPlugin extends Plugin
 	private static final Pattern SPIRIT_TREE_LABEL_PATTERN_MENU = Pattern.compile("<col=735a28>(.+)</col>: (<col=5f5f5f>)?(.+)");
 	private static final Pattern SPIRIT_TREE_LABEL_PATTERN_MENU_NEW = Pattern.compile("<col=ffffff>(.+)</col>: (<col=5f5f5f>)?(.+)");
 	private final List<PendingTask> pendingTasks = new ArrayList<>(3);
+	private final Map<String, String> transportDisplayInfoCache = new HashMap<>();
 	private final Object pathfinderMutex = new Object();
 	boolean drawCollisionMap;
 	boolean drawMap;
@@ -117,6 +122,8 @@ public class ShortestPathPlugin extends Plugin
 	boolean drawTransports;
 	boolean showTransportInfo;
 	boolean showBankPickupInfo;
+	boolean easyTeleportNames;
+	boolean easyTeleportsPluginActive;
 	Color colourCollisionMap;
 	Color colourPath;
 	Color colourPathCalculating;
@@ -135,6 +142,10 @@ public class ShortestPathPlugin extends Plugin
 	private ClientThread clientThread;
 	@Inject
 	private ShortestPathConfig config;
+	@Inject
+	ConfigManager configManager;
+	@Inject
+	PluginManager pluginManager;
 	@Inject
 	private EventBus eventBus;
 	@Inject
@@ -296,6 +307,7 @@ public class ShortestPathPlugin extends Plugin
 	protected void startUp()
 	{
 		cacheConfigValues();
+		cacheEasyTeleportsPluginActive();
 
 		pathfinderConfig = new PathfinderConfig(client, config);
 		if (GameState.LOGGED_IN.equals(client.getGameState()))
@@ -442,9 +454,19 @@ public class ShortestPathPlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
+		if (EasyTeleportLabelFormatter.CONFIG_GROUP.equals(event.getGroup()))
+		{
+			transportDisplayInfoCache.clear();
+			return;
+		}
+
 		if (!CONFIG_GROUP.equals(event.getGroup()))
 		{
 			return;
+		}
+		if ("easyTeleportNames".equals(event.getKey()))
+		{
+			transportDisplayInfoCache.clear();
 		}
 
 		cacheConfigValues();
@@ -469,6 +491,16 @@ public class ShortestPathPlugin extends Plugin
 			{
 				restartPathfinding(pathfinder.getStart(), pathfinder.getTargets());
 			}
+		}
+	}
+
+	@Subscribe
+	public void onPluginChanged(PluginChanged event)
+	{
+		if (isEasyTeleportsPlugin(event.getPlugin()))
+		{
+			cacheEasyTeleportsPluginActive();
+			transportDisplayInfoCache.clear();
 		}
 	}
 
@@ -624,7 +656,7 @@ public class ShortestPathPlugin extends Plugin
 					transportOrigins.add(WorldPointUtil.unpackWorldPoint(currentStep.getPackedPosition()));
 					transportDestinations.add(WorldPointUtil.unpackWorldPoint(nextStep.getPackedPosition()));
 					transportObjectInfos.add(transport.getObjectInfo());
-					transportDisplayInfos.add(transport.getDisplayInfo());
+					transportDisplayInfos.add(formatTransportDisplayInfo(transport));
 				}
 			}
 			data.put("origin", transportOrigins);
@@ -633,6 +665,47 @@ public class ShortestPathPlugin extends Plugin
 			data.put("displayInfo", transportDisplayInfos);
 			eventBus.post(new PluginMessage(CONFIG_GROUP, PLUGIN_MESSAGE_TRANSPORTS, data));
 		}
+	}
+
+	/**
+	 * Display label for overlays and plugin messages. Applies Easy Teleports replacements
+	 * when {@link #easyTeleportNames} is enabled and the Easy Teleports plugin is active.
+	 */
+	String formatTransportDisplayInfo(Transport transport)
+	{
+		if (transport == null)
+		{
+			return null;
+		}
+
+		String displayInfo = transport.getDisplayInfo();
+		if (displayInfo == null || displayInfo.isEmpty())
+		{
+			return displayInfo;
+		}
+		if (!easyTeleportNames || !easyTeleportsPluginActive)
+		{
+			return displayInfo;
+		}
+
+		return transportDisplayInfoCache.computeIfAbsent(displayInfo,
+			label -> EasyTeleportLabelFormatter.format(label, configManager::getConfiguration));
+	}
+
+	/** Refreshes whether the Easy Teleports plugin is installed and enabled. */
+	private void cacheEasyTeleportsPluginActive()
+	{
+		easyTeleportsPluginActive = pluginManager != null && pluginManager.getPlugins().stream()
+			.anyMatch(plugin -> isEasyTeleportsPlugin(plugin) && pluginManager.isPluginActive(plugin));
+	}
+
+	/**
+	 * Detects Easy Teleports by RuneLite's plugin display name to avoid a compile-time
+	 * dependency on Easy Teleports classes.
+	 */
+	private static boolean isEasyTeleportsPlugin(Plugin plugin)
+	{
+		return plugin != null && EASY_TELEPORTS_PLUGIN_NAME.equals(plugin.getName());
 	}
 
 	@Subscribe
@@ -1136,7 +1209,7 @@ public class ShortestPathPlugin extends Plugin
 				PathStep nextStep = path.get(i + 1);
 				for (Transport transport : transportsForEdge(currentStep, nextStep))
 				{
-					String exitInfo = transport.getDisplayInfo();
+					String exitInfo = formatTransportDisplayInfo(transport);
 					if (exitInfo != null && !exitInfo.isEmpty())
 					{
 						TransportType exitType = transport.getType();
@@ -1256,6 +1329,7 @@ public class ShortestPathPlugin extends Plugin
 		drawTransports = override("drawTransports", config.drawTransports());
 		showTransportInfo = override("showTransportInfo", config.showTransportInfo());
 		showBankPickupInfo = override("showBankPickupInfo", config.showBankPickupInfo());
+		easyTeleportNames = override("easyTeleportNames", config.easyTeleportNames());
 
 		colourCollisionMap = override("colourCollisionMap", config.colourCollisionMap());
 		colourPath = override("colourPath", config.colourPath());

--- a/src/main/java/shortestpath/teleports/EasyTeleportLabelFormatter.java
+++ b/src/main/java/shortestpath/teleports/EasyTeleportLabelFormatter.java
@@ -1,0 +1,127 @@
+package shortestpath.teleports;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import net.runelite.client.util.Text;
+
+/**
+ * Rewrites Shortest Path transport hint labels using Easy Teleports user-defined
+ * destination names when the separate Easy Teleports plugin is installed.
+ * <p>
+ * Mappings are loaded from {@code /easy_teleport_labels.txt}. Config is read from
+ * RuneLite's {@link net.runelite.client.config.ConfigManager} using {@link #CONFIG_GROUP},
+ * matching upstream Easy Teleports.
+ *
+ * @see <a href="https://github.com/LlemonDuck/easy-teleports">LlemonDuck/easy-teleports</a>
+ */
+public final class EasyTeleportLabelFormatter
+{
+	/**
+	 * Easy Teleports config group ({@code easypharaohsceptre}), from
+	 * <a href="https://github.com/LlemonDuck/easy-teleports/blob/31e38dbedb512292b0370dc9be0f72df6cd25e1b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java">
+	 * EasyTeleportsConfig.CONFIG_GROUP</a>.
+	 */
+	public static final String CONFIG_GROUP = "easypharaohsceptre";
+	private static final String LABEL_SEPARATOR = ": ";
+	private static final Map<String, ReplacementConfig> REPLACEMENTS = loadReplacements();
+
+	private EasyTeleportLabelFormatter()
+	{
+	}
+
+	/**
+	 * Returns {@code displayInfo} with the destination suffix replaced when Easy Teleports
+	 * has an enabled mapping and non-blank replacement for that label; otherwise returns
+	 * {@code displayInfo} unchanged.
+	 *
+	 * @param displayInfo full Shortest Path label ({@code "Item: Destination"})
+	 * @param configLookup reads Easy Teleports config keys from {@link #CONFIG_GROUP}
+	 * @return formatted display label, or the original label when no replacement applies
+	 */
+	public static String format(String displayInfo, BiFunction<String, String, String> configLookup)
+	{
+		ReplacementConfig replacementConfig = REPLACEMENTS.get(displayInfo);
+		if (replacementConfig == null || configLookup == null
+			|| !Boolean.parseBoolean(configLookup.apply(CONFIG_GROUP, replacementConfig.enabledKey)))
+		{
+			return displayInfo;
+		}
+
+		String replacement = stripTags(configLookup.apply(CONFIG_GROUP, replacementConfig.replacementKey));
+		if (replacement == null || replacement.isEmpty())
+		{
+			return displayInfo;
+		}
+
+		int separatorIndex = displayInfo.indexOf(LABEL_SEPARATOR);
+		if (separatorIndex < 0)
+		{
+			return displayInfo;
+		}
+
+		return displayInfo.substring(0, separatorIndex + LABEL_SEPARATOR.length()) + replacement;
+	}
+
+	private static String stripTags(String value)
+	{
+		if (value == null)
+		{
+			return null;
+		}
+
+		return Text.removeTags(value).replace('\u00A0', ' ').trim();
+	}
+
+	private static Map<String, ReplacementConfig> loadReplacements()
+	{
+		Map<String, ReplacementConfig> replacements = new HashMap<>();
+		InputStream input = EasyTeleportLabelFormatter.class.getResourceAsStream("/easy_teleport_labels.txt");
+		if (input == null)
+		{
+			throw new IllegalStateException("Missing easy_teleport_labels.txt");
+		}
+
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8)))
+		{
+			String line;
+			while ((line = reader.readLine()) != null)
+			{
+				if (line.isBlank() || line.startsWith("#"))
+				{
+					continue;
+				}
+
+				String[] fields = line.split("\t", -1);
+				if (fields.length != 4)
+				{
+					throw new IllegalStateException("Invalid easy teleport label row: " + line);
+				}
+
+				replacements.put(fields[0] + LABEL_SEPARATOR + fields[1], new ReplacementConfig(fields[2], fields[3]));
+			}
+		}
+		catch (IOException e)
+		{
+			throw new IllegalStateException("Unable to load easy teleport labels", e);
+		}
+		return Map.copyOf(replacements);
+	}
+
+	private static final class ReplacementConfig
+	{
+		private final String enabledKey;
+		private final String replacementKey;
+
+		private ReplacementConfig(String enabledKey, String replacementKey)
+		{
+			this.enabledKey = enabledKey;
+			this.replacementKey = replacementKey;
+		}
+	}
+}

--- a/src/main/resources/easy_teleport_labels.txt
+++ b/src/main/resources/easy_teleport_labels.txt
@@ -1,0 +1,121 @@
+# Maps Shortest Path transport display labels to Easy Teleports config keys.
+# Columns 1-2 come from Shortest Path Display info values in transports/teleportation_items.tsv.
+# Columns 3-4 come from Easy Teleports' EasyTeleportsConfig @ConfigItem key names and
+# its replacer classes' TeleportReplacement(original, config.replacement...) entries.
+# Upstream Easy Teleports source:
+# https://github.com/LlemonDuck/easy-teleports/blob/31e38dbedb512292b0370dc9be0f72df6cd25e1b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
+# https://github.com/LlemonDuck/easy-teleports/tree/31e38dbedb512292b0370dc9be0f72df6cd25e1b/src/main/java/com/duckblade/osrs/easyteleports/replacers
+# Easy Teleports stores these values under config group "easypharaohsceptre";
+# that legacy group name comes from EasyTeleportsConfig.CONFIG_GROUP.
+# Only add rows where the Shortest Path label identifies one unambiguous Easy Teleports replacement.
+# Shortest Path item label	Shortest Path destination label	Easy Teleports enabled key	Easy Teleports replacement key
+Achievement diary cape	1. Two-pints	enableDiaryCape	replacementArdougne
+Achievement diary cape	2. Jarr	enableDiaryCape	replacementDesert
+Achievement diary cape	3. Sir Rebral	enableDiaryCape	replacementFalador
+Achievement diary cape	4. Thorodin	enableDiaryCape	replacementFremennik
+Achievement diary cape	5. Flax keeper	enableDiaryCape	replacementKandarin
+Achievement diary cape	6. Pirate Jackie the Fruit	enableDiaryCape	replacementKaramjaJackie
+Achievement diary cape	7. Kaleb Paramaya	enableDiaryCape	replacementKaramjaKaleb
+Achievement diary cape	8. Jungle forester	enableDiaryCape	replacementKaramjaForester
+Achievement diary cape	9. TzHaar-Mej	enableDiaryCape	replacementKaramjaTzhaar
+Achievement diary cape	A. Elise	enableDiaryCape	replacementKourend
+Achievement diary cape	B. Hatius Cosaintus	enableDiaryCape	replacementLumbridge
+Achievement diary cape	C. Le-sabrè	enableDiaryCape	replacementMorytania
+Achievement diary cape	D. Toby	enableDiaryCape	replacementVarrock
+Achievement diary cape	E. Lesser Fanatic	enableDiaryCape	replacementWilderness
+Achievement diary cape	F. Elder Gnome child	enableDiaryCape	replacementWestern
+Achievement diary cape	G. Twiggy O'Korn	enableDiaryCape	replacementTwiggy
+Kharedst's memoirs	Lunch by the Lancalliums	enableKharedstsMemoirs	replacementLancalliums
+Kharedst's memoirs	The Fisher's Flute	enableKharedstsMemoirs	replacementFishers
+Kharedst's memoirs	History and Hearsay	enableKharedstsMemoirs	replacementHistory
+Kharedst's memoirs	Jewelry of Jubilation	enableKharedstsMemoirs	replacementJubilation
+Kharedst's memoirs	A Dark Disposition	enableKharedstsMemoirs	replacementDisposition
+Book of the dead	Lunch by the Lancalliums	enableKharedstsMemoirs	replacementLancalliums
+Book of the dead	The Fisher's Flute	enableKharedstsMemoirs	replacementFishers
+Book of the dead	History and Hearsay	enableKharedstsMemoirs	replacementHistory
+Book of the dead	Jewelry of Jubilation	enableKharedstsMemoirs	replacementJubilation
+Book of the dead	A Dark Disposition	enableKharedstsMemoirs	replacementDisposition
+Pharaoh's sceptre	Jalsavrah	enablePharaohSceptre	replacementJalsavrah
+Pharaoh's sceptre	Jaleustrophos	enablePharaohSceptre	replacementJaleustrophos
+Pharaoh's sceptre	Jaldraocht	enablePharaohSceptre	replacementJaldraocht
+Pharaoh's sceptre	Jaltevas	enablePharaohSceptre	replacementJaltevas
+Necklace of passage	Wizards' Tower	enableNecklaceOfPassage	replacementWizardsTower
+Necklace of passage	The Outpost	enableNecklaceOfPassage	replacementOutpost
+Necklace of passage	Eagle's Eyrie	enableNecklaceOfPassage	replacementEagleEyrie
+Karamja gloves	Gem Mine	enableKaramjaGloves	replacementKaramjaGemMine
+Karamja gloves 4	Slayer Master	enableKaramjaGloves	replacementKaramjaSlayerMaster
+Desert amulet 4	Nardah	enableDesertAmulet	replacementDesertNardah
+Desert amulet 4	Kalphite cave	enableDesertAmulet	replacementDesertKalphiteCave
+Morytania legs	Slime Pit	enableMorytaniaLegs	replacementMorytaniaEctofuntus
+Morytania legs	Burgh de Rott	enableMorytaniaLegs	replacementMorytaniaBurgh
+Rada's blessing	Kourend Woodland	enableRadasBlessing	replacementRadasKourendWoodland
+Rada's blessing	Mount Karuulm	enableRadasBlessing	replacementRadasMountKaruulm
+Ring of dueling	Emir's Arena	enableRingOfDueling	replacementEmirsArena
+Ring of dueling	Castle Wars	enableRingOfDueling	replacementCastleWars
+Ring of dueling	Ferox Enclave	enableRingOfDueling	replacementFeroxEnclave
+Ring of dueling	Fortis Colosseum	enableRingOfDueling	replacementFortisColosseum
+Slayer ring	Stronghold	enableSlayerRing	replacementSlayerStronghold
+Slayer ring	Slayer Tower	enableSlayerRing	replacementSlayerTower
+Slayer ring	Fremennik	enableSlayerRing	replacementSlayerRellekka
+Slayer ring	Tarn's Lair	enableSlayerRing	replacementTarns
+Slayer ring	Dark Beasts	enableSlayerRing	replacementDarkBeasts
+Digsite pendant	Digsite	enableDigsitePendant	replacementDigsite
+Digsite pendant	Fossil Island	enableDigsitePendant	replacementFossilIsland
+Digsite pendant	Lithkren	enableDigsitePendant	replacementLithkren
+Burning amulet	Chaos Temple	enableBurningAmulet	replacementBurningChaosTemple
+Burning amulet	Bandit Camp	enableBurningAmulet	replacementBurningBanditCamp
+Burning amulet	Lava Maze	enableBurningAmulet	replacementBurningLavaMaze
+Enchanted lyre	Rellekka	enableEnchantedLyre	replacementLyreRellekka
+Enchanted lyre	Waterbirth Island	enableEnchantedLyre	replacementLyreWaterbirthIsland
+Enchanted lyre	Jatizso	enableEnchantedLyre	replacementLyreJatizso
+Enchanted lyre	Neitiznot	enableEnchantedLyre	replacementLyreNeitiznot
+Enchanted lyre (i)	Rellekka	enableEnchantedLyre	replacementLyreRellekka
+Enchanted lyre (i)	Waterbirth Island	enableEnchantedLyre	replacementLyreWaterbirthIsland
+Enchanted lyre (i)	Jatizso	enableEnchantedLyre	replacementLyreJatizso
+Enchanted lyre (i)	Neitiznot	enableEnchantedLyre	replacementLyreNeitiznot
+Camulet	Enakhra's Temple	enableCamulet	replacementCamuletEnakhrasTemple
+Camulet	Bandit Camp Quarry	enableCamulet	replacementCamuletEnakhrasTempleEntrance
+Eternal teleport crystal	Lletya	enableEternalTeleportCrystal	replacementEternalLletya
+Eternal teleport crystal	Prifddinas	enableEternalTeleportCrystal	replacementEternalPrifddinas
+Drakan's medallion	Ver Sinhaza	enableDrakans	replacementVerSinhaza
+Drakan's medallion	Darkmeyer	enableDrakans	replacementDarkmeyer
+Drakan's medallion	Slepe	enableDrakans	replacementSlepe
+Xeric's talisman	1. Xeric's Lookout	enableXericsTalisman	replacementLookout
+Xeric's talisman	2. Xeric's Glade	enableXericsTalisman	replacementGlade
+Xeric's talisman	3. Xeric's Inferno	enableXericsTalisman	replacementInferno
+Xeric's talisman	4. Xeric's Heart	enableXericsTalisman	replacementHeart
+Xeric's talisman	5. Xeric's Honour	enableXericsTalisman	replacementHonour
+Ring of the elements	Air	enableRingOfTheElements	replacementAirAltar
+Ring of the elements	Water	enableRingOfTheElements	replacementWaterAltar
+Ring of the elements	Earth	enableRingOfTheElements	replacementEarthAltar
+Ring of the elements	Fire	enableRingOfTheElements	replacementFireAltar
+Ring of shadows	Ancient Vault	enableRingOfShadows	replacementAncientVault
+Ring of shadows	Ghorrock Dungeon	enableRingOfShadows	replacementGhorrockDungeon
+Ring of shadows	The Scar	enableRingOfShadows	replacementScar
+Ring of shadows	Lassar Undercity	enableRingOfShadows	replacementLassarUndercity
+Ring of shadows	The Stranglewood	enableRingOfShadows	replacementStranglewood
+Pendant of ates	1. The Darkfrost	enablePendantOfAtes	replacementDarkfrost
+Pendant of ates	2. Twilight Temple	enablePendantOfAtes	replacementTwilightTemple
+Pendant of ates	3. Ralos' Rise	enablePendantOfAtes	replacementRalosRise
+Pendant of ates	4. North Aldarin	enablePendantOfAtes	replacementNorthAldarin
+Pendant of ates	5. Kastori	enablePendantOfAtes	replacementKastori
+Pendant of ates	6. Nemus Retreat	enablePendantOfAtes	replacementNemusRetreat
+Giantsoul amulet	1. Bryophyta	enableGiantsoulAmulet	replacementBryophyta
+Giantsoul amulet	2. Obor	enableGiantsoulAmulet	replacementObor
+Giantsoul amulet	3. Branda and Eldric	enableGiantsoulAmulet	replacementBrandaAndEldric
+Max cape	POH Portals: Rimmington	enableMaxCape	replacementMaxCapeRimmington
+Max cape	POH Portals: Taverley	enableMaxCape	replacementMaxCapeTaverley
+Max cape	POH Portals: Pollnivneach	enableMaxCape	replacementMaxCapePollnivneach
+Max cape	POH Portals: Hosidius	enableMaxCape	replacementMaxCapeHosidius
+Max cape	POH Portals: Rellekka	enableMaxCape	replacementMaxCapeRellekka
+Max cape	POH Portals: Brimhaven	enableMaxCape	replacementMaxCapeBrimhaven
+Max cape	POH Portals: Yanille	enableMaxCape	replacementMaxCapeYanille
+Max cape	POH Portals: Prifddinas	enableMaxCape	replacementMaxCapePrifddinas
+Max cape	Warriors' Guild	enableMaxCape	replacementMaxCapeWarriorsGuild
+Max cape	Fishing Teleports: Fishing Guild	enableMaxCape	replacementMaxCapeFishingGuild
+Max cape	Fishing Teleports: Otto's Grotto	enableMaxCape	replacementMaxCapeOttosGrotto
+Max cape	Crafting Guild	enableMaxCape	replacementMaxCapeCraftingGuild
+Max cape	Other Teleports: Feldip Hills	enableMaxCape	replacementMaxCapeFeldipHills
+Max cape	Other Teleports: Black chinchompa	enableMaxCape	replacementMaxCapeBlackChincompas
+Max cape	Other Teleports: Hunter Guild	enableMaxCape	replacementMaxCapeHunterGuild
+Max cape	Other Teleports: Farming Guild	enableMaxCape	replacementMaxCapeFarmingGuild

--- a/src/test/java/shortestpath/ShortestPathPluginEasyTeleportsTest.java
+++ b/src/test/java/shortestpath/ShortestPathPluginEasyTeleportsTest.java
@@ -1,0 +1,80 @@
+package shortestpath;
+
+import java.util.Collections;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.events.PluginChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginManager;
+import org.junit.Assert;
+import org.junit.Test;
+import shortestpath.teleports.EasyTeleportLabelFormatter;
+import shortestpath.transport.Transport;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ShortestPathPluginEasyTeleportsTest
+{
+	@Test
+	public void fallsBackWhenEasyTeleportsPluginIsDisabled() throws Exception
+	{
+		ShortestPathPlugin plugin = createPlugin(false, true);
+		Transport transport = createTransport();
+
+		Assert.assertEquals("Pharaoh's sceptre: Jalsavrah", plugin.formatTransportDisplayInfo(transport));
+	}
+
+	@Test
+	public void formatsWhenEasyTeleportsPluginIsActive() throws Exception
+	{
+		ShortestPathPlugin plugin = createPlugin(true, true);
+		Transport transport = createTransport();
+
+		Assert.assertEquals("Pharaoh's sceptre: Pyramid Plunder", plugin.formatTransportDisplayInfo(transport));
+	}
+
+	@Test
+	public void fallsBackWhenEasyTeleportNamesOptionIsDisabled() throws Exception
+	{
+		ShortestPathPlugin plugin = createPlugin(true, false);
+		Transport transport = createTransport();
+
+		Assert.assertEquals("Pharaoh's sceptre: Jalsavrah", plugin.formatTransportDisplayInfo(transport));
+	}
+
+	private static ShortestPathPlugin createPlugin(boolean easyTeleportsActive, boolean easyTeleportNames) throws Exception
+	{
+		ShortestPathPlugin plugin = new ShortestPathPlugin();
+		Plugin easyTeleportsPlugin = new TestEasyTeleportsPlugin();
+		plugin.easyTeleportNames = easyTeleportNames;
+
+		ConfigManager configManager = mock(ConfigManager.class);
+		when(configManager.getConfiguration(EasyTeleportLabelFormatter.CONFIG_GROUP, "enablePharaohSceptre")).thenReturn("true");
+		when(configManager.getConfiguration(EasyTeleportLabelFormatter.CONFIG_GROUP, "replacementJalsavrah")).thenReturn("Pyramid Plunder");
+		plugin.configManager = configManager;
+
+		PluginManager pluginManager = mock(PluginManager.class);
+		when(pluginManager.getPlugins()).thenReturn(Collections.singleton(easyTeleportsPlugin));
+		when(pluginManager.isPluginActive(easyTeleportsPlugin)).thenReturn(easyTeleportsActive);
+		plugin.pluginManager = pluginManager;
+
+		plugin.onPluginChanged(new PluginChanged(easyTeleportsPlugin, easyTeleportsActive));
+		return plugin;
+	}
+
+	private static Transport createTransport()
+	{
+		Transport transport = mock(Transport.class);
+		when(transport.getDisplayInfo()).thenReturn("Pharaoh's sceptre: Jalsavrah");
+		return transport;
+	}
+
+	private static final class TestEasyTeleportsPlugin extends Plugin
+	{
+		@Override
+		public String getName()
+		{
+			return "Easy Teleports";
+		}
+	}
+}

--- a/src/test/java/shortestpath/teleports/EasyTeleportLabelFormatterTest.java
+++ b/src/test/java/shortestpath/teleports/EasyTeleportLabelFormatterTest.java
@@ -1,0 +1,119 @@
+package shortestpath.teleports;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EasyTeleportLabelFormatterTest
+{
+	private final Map<String, String> config = new HashMap<>();
+	private final BiFunction<String, String, String> lookup = (group, key) -> config.get(group + "." + key);
+
+	@Test
+	public void formatsBookOfTheDeadWithEnabledEasyTeleportsReplacement()
+	{
+		config.put("easypharaohsceptre.enableKharedstsMemoirs", "true");
+		config.put("easypharaohsceptre.replacementLancalliums", "<col=2aae4f>Hosidius</col>");
+
+		String label = EasyTeleportLabelFormatter.format("Book of the dead: Lunch by the Lancalliums", lookup);
+
+		Assert.assertEquals("Book of the dead: Hosidius", label);
+	}
+
+	@Test
+	public void formatsPharaohsSceptreWithEnabledEasyTeleportsReplacement()
+	{
+		config.put("easypharaohsceptre.enablePharaohSceptre", "true");
+		config.put("easypharaohsceptre.replacementJalsavrah", "Pyramid Plunder");
+
+		String label = EasyTeleportLabelFormatter.format("Pharaoh's sceptre: Jalsavrah", lookup);
+
+		Assert.assertEquals("Pharaoh's sceptre: Pyramid Plunder", label);
+	}
+
+	@Test
+	public void formatsDiaryCapeNumberedDestinationWithEnabledEasyTeleportsReplacement()
+	{
+		config.put("easypharaohsceptre.enableDiaryCape", "true");
+		config.put("easypharaohsceptre.replacementArdougne", "Ardougne: Bar");
+
+		String label = EasyTeleportLabelFormatter.format("Achievement diary cape: 1. Two-pints", lookup);
+
+		Assert.assertEquals("Achievement diary cape: Ardougne: Bar", label);
+	}
+
+	@Test
+	public void fallsBackWhenEasyTeleportsToggleIsDisabled()
+	{
+		config.put("easypharaohsceptre.enableKharedstsMemoirs", "false");
+		config.put("easypharaohsceptre.replacementLancalliums", "Hosidius");
+
+		String label = EasyTeleportLabelFormatter.format("Book of the dead: Lunch by the Lancalliums", lookup);
+
+		Assert.assertEquals("Book of the dead: Lunch by the Lancalliums", label);
+	}
+
+	@Test
+	public void fallsBackWhenReplacementIsMissing()
+	{
+		config.put("easypharaohsceptre.enablePharaohSceptre", "true");
+
+		String label = EasyTeleportLabelFormatter.format("Pharaoh's sceptre: Jalsavrah", lookup);
+
+		Assert.assertEquals("Pharaoh's sceptre: Jalsavrah", label);
+	}
+
+	@Test
+	public void fallsBackForUnknownDisplayInfo()
+	{
+		String label = EasyTeleportLabelFormatter.format("Varrock Teleport: GE", lookup);
+
+		Assert.assertEquals("Varrock Teleport: GE", label);
+	}
+
+	@Test
+	public void formatsXericsTalismanNumberedDestination()
+	{
+		config.put("easypharaohsceptre.enableXericsTalisman", "true");
+		config.put("easypharaohsceptre.replacementHonour", "Raids");
+
+		String label = EasyTeleportLabelFormatter.format("Xeric's talisman: 5. Xeric's Honour", lookup);
+
+		Assert.assertEquals("Xeric's talisman: Raids", label);
+	}
+
+	@Test
+	public void formatsRingOfDuelingDestination()
+	{
+		config.put("easypharaohsceptre.enableRingOfDueling", "true");
+		config.put("easypharaohsceptre.replacementFeroxEnclave", "Ferox");
+
+		String label = EasyTeleportLabelFormatter.format("Ring of dueling: Ferox Enclave", lookup);
+
+		Assert.assertEquals("Ring of dueling: Ferox", label);
+	}
+
+	@Test
+	public void formatsPendantOfAtesNumberedDestination()
+	{
+		config.put("easypharaohsceptre.enablePendantOfAtes", "true");
+		config.put("easypharaohsceptre.replacementDarkfrost", "Darkfrost");
+
+		String label = EasyTeleportLabelFormatter.format("Pendant of ates: 1. The Darkfrost", lookup);
+
+		Assert.assertEquals("Pendant of ates: Darkfrost", label);
+	}
+
+	@Test
+	public void formatsMaxCapeNestedDestination()
+	{
+		config.put("easypharaohsceptre.enableMaxCape", "true");
+		config.put("easypharaohsceptre.replacementMaxCapeFishingGuild", "Fish Guild");
+
+		String label = EasyTeleportLabelFormatter.format("Max cape: Fishing Teleports: Fishing Guild", lookup);
+
+		Assert.assertEquals("Max cape: Fish Guild", label);
+	}
+}


### PR DESCRIPTION
## Summary

Adds optional Easy Teleports label integration for Shortest Path transport display text. When Easy Teleports is active, its matching item toggle is enabled, and Shortest Path's `Easy teleport names` option is enabled, Shortest Path overlays/tooltips/plugin messages display the user's Easy Teleports destination names instead of the raw teleport option names.

Pathfinding behavior is unchanged. This only changes user-facing transport labels.

## Implementation

- Adds `EasyTeleportLabelFormatter`, which maps Shortest Path display labels to Easy Teleports config keys and falls back to the original label when no valid replacement applies.
- Reads Easy Teleports values through RuneLite's `ConfigManager`; there is no compile-time dependency on Easy Teleports classes.
- Detects the active Easy Teleports plugin through RuneLite's `Plugin#getName()` API, avoiding reflective annotation access.
- Caches formatted display labels and clears the cache when Easy Teleports config changes, the Shortest Path option changes, or Easy Teleports starts/stops.
- Stores the mapping table in `src/main/resources/easy_teleport_labels.txt` so it is not treated as a pathfinding data TSV by the repository TSV validator.

## Mapping Source

The mapping file documents its sources:

- Shortest Path labels come from `src/main/resources/transports/teleportation_items.tsv` display info values.
- Easy Teleports config keys come from the separate [`LlemonDuck/easy-teleports`](https://github.com/LlemonDuck/easy-teleports) repo, specifically [`EasyTeleportsConfig`](https://github.com/LlemonDuck/easy-teleports/blob/31e38dbedb512292b0370dc9be0f72df6cd25e1b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java) and the [`replacers`](https://github.com/LlemonDuck/easy-teleports/tree/31e38dbedb512292b0370dc9be0f72df6cd25e1b/src/main/java/com/duckblade/osrs/easyteleports/replacers) classes.
- The Easy Teleports config group is intentionally `easypharaohsceptre`; that is the upstream value from `EasyTeleportsConfig.CONFIG_GROUP`.

## Fallbacks

Original Shortest Path labels are preserved when:

- Easy Teleports is not installed or not active.
- The Shortest Path `Easy teleport names` option is off.
- The matching Easy Teleports item toggle is off.
- The replacement value is missing or blank.
- The Shortest Path label is not specific enough to map to one destination.

## Coverage

Includes mappings for many Easy Teleports-supported multi-destination items, including achievement diary cape, Kharedst's memoirs / Book of the dead, Pharaoh's sceptre, jewellery, diary rewards, Xeric's talisman, ring of shadows, pendant of ates, giantsoul amulet, and unambiguous max cape entries.

## Testing

- `python3 scripts/check_tsv.py src/main/resources`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@11 ./gradlew test --tests shortestpath.teleports.EasyTeleportLabelFormatterTest --tests shortestpath.ShortestPathPluginEasyTeleportsTest`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@11 ./gradlew test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@11 ./gradlew check`

Fixes #480.
