### PR TITLE
League max cape Fix

### DIFF
--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -873,9 +873,17 @@ public class PathfinderConfig
 	 */
 	private boolean hasRequiredLevels(Transport transport)
 	{
+		// In leagues some skills are disabled so the max total level is lower than
+		// the standard 2376. Holding the item (e.g. Max cape) already proves the
+		// player is maxed for the available skills, so skip the total-level check.
+		final int totalLevelIndex = Skill.values().length;
 		int[] requiredLevels = transport.getSkillLevels();
 		for (int i = 0; i < boostedSkillLevelsAndMore.length; i++)
 		{
+			if (leagueModeState.isSeasonal() && i == totalLevelIndex)
+			{
+				continue;
+			}
 			int boostedLevel = boostedSkillLevelsAndMore[i];
 			int requiredLevel = requiredLevels[i];
 			if (boostedLevel < requiredLevel)


### PR DESCRIPTION
The max cape was always conditional on the total level of the player. This is fine for the current game mode, and properly disables the cape when new skills are introduced. As leagues come with set-skills, we don't need this check as there might be skills disabled too. Removed the total skill level conditional for leagues only.