### PR TITLE
Sailing teleport inhibitor

### DIFF
--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -436,9 +436,23 @@ public class PathTileOverlay extends Overlay
 	private void drawTransportInfo(Graphics2D graphics, PathStep currentStep, PathStep nextStep, List<PathStep> path, int pathIndex)
 	{
 		int location = currentStep.getPackedPosition();
-		if (nextStep == null || !plugin.showTransportInfo || plugin.isPathUnreachable() ||
-			!plugin.getPathfinder().isDone() ||
+		if (nextStep == null || !plugin.showTransportInfo ||
 			WorldPointUtil.unpackWorldPlane(location) != client.getTopLevelWorldView().getPlane())
+		{
+			return;
+		}
+
+		// Sailing: teleports are suppressed while aboard a boat. When the path is
+		// unreachable as a result, show a one-time hint on the player tile.
+		if (pathIndex == 0 && plugin.getPathfinderConfig().isOnSailingBoat()
+			&& plugin.getPathfinder().isDone() && plugin.isPathUnreachable())
+		{
+			playerTileLabelOffset = drawLabelOnPlayerTile(graphics,
+				"Disembark the boat to resume pathfinding", playerTileLabelOffset);
+			return;
+		}
+
+		if (plugin.isPathUnreachable() || !plugin.getPathfinder().isDone())
 		{
 			return;
 		}

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -125,6 +125,8 @@ public class PathfinderConfig
 	private JewelleryBoxTier pohJewelleryBoxTier;
 	private int costConsumableTeleportationItems;
 	private int currencyThreshold;
+	@Getter
+	private boolean isOnSailingBoat;
 
 	public PathfinderConfig(Client client, ShortestPathConfig config)
 	{
@@ -283,6 +285,8 @@ public class PathfinderConfig
 
 		if (GameState.LOGGED_IN.equals(client.getGameState()))
 		{
+			isOnSailingBoat = client.getVarbitValue(VarbitID.SAILING_BOARDED_BOAT) != 0;
+
 			int i = 0;
 			for (; i < Skill.values().length; i++)
 			{
@@ -647,6 +651,14 @@ public class PathfinderConfig
 
 	private boolean useTransport(Transport transport)
 	{
+		// Sailing: suppress teleports while the player is aboard a boat.
+		// We don't model sailing navigation, so teleporting away mid-ocean would produce
+		// confusing suggestions. Pathfinding resumes normally after disembarking.
+		if (isOnSailingBoat && transport.getType().isTeleport())
+		{
+			return false;
+		}
+
 		// Master POH gate - if POH is disabled, reject all POH transports
 		if (!usePoh)
 		{


### PR DESCRIPTION
Disables teleports when sailing to prevent teleport hints suggesting to leave the boat in the middle of the ocean. Displays a hint to disembark before pathfinding resumes. Sailing routes themselves still work.