### PR TITLE
Create separate enable and cost settings for Home Teleports

### DIFF
--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -10,6 +10,9 @@ import net.runelite.client.config.Keybind;
 import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
 
+
+
+
 @SuppressWarnings("SameReturnValue")
 @ConfigGroup(ShortestPathPlugin.CONFIG_GROUP)
 public interface ShortestPathConfig extends Config
@@ -262,11 +265,23 @@ public interface ShortestPathConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "useTeleportationSpellsHome",
+		name = "Use Home Teleport spells",
+		description = "Whether to include Home Teleport spells in the path",
+		position = 20,
+		section = sectionSettings
+	)
+	default boolean useTeleportationSpellsHome()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "useTeleportationMinigames",
 		name = "Use teleportation to minigames",
 		description = "Whether to include teleportation to minigames/activities/grouping in the path<br>" +
 			"(e.g. the Nightmare Zone minigame teleport). These teleports share a 20 minute cooldown.",
-		position = 20,
+		position = 21,
 		section = sectionSettings
 	)
 	default boolean useTeleportationMinigames()
@@ -278,7 +293,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "useWildernessObelisks",
 		name = "Use wilderness obelisks",
 		description = "Whether to include wilderness obelisks in the path",
-		position = 21,
+		position = 22,
 		section = sectionSettings
 	)
 	default boolean useWildernessObelisks()
@@ -290,7 +305,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "useSeasonalTransports",
 		name = "Use seasonal transports",
 		description = "Whether to include seasonal transports like League teleports in the path",
-		position = 22,
+		position = 23,
 		section = sectionSettings
 	)
 	default boolean useSeasonalTransports()
@@ -303,7 +318,7 @@ public interface ShortestPathConfig extends Config
 		name = "Include path to bank",
 		description = "Whether to include the path to the closest bank<br>" +
 			"when suggesting teleports from the bank",
-		position = 23,
+		position = 24,
 		section = sectionSettings
 	)
 	default boolean includeBankPath()
@@ -316,7 +331,7 @@ public interface ShortestPathConfig extends Config
 		name = "Currency threshold",
 		description = "The maximum amount of currency to use on a single transportation method." +
 			"<br>The currencies affected by the threshold are coins, trading sticks, ecto-tokens and warrior guild tokens.",
-		position = 24,
+		position = 25,
 		section = sectionSettings
 	)
 	default int currencyThreshold()
@@ -329,7 +344,7 @@ public interface ShortestPathConfig extends Config
 		name = "Cancel instead of recalculating",
 		description = "Whether the path should be cancelled rather than recalculated " +
 			"when the recalculate distance limit is exceeded",
-		position = 25,
+		position = 26,
 		section = sectionSettings
 	)
 	default boolean cancelInstead()
@@ -345,7 +360,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "recalculateDistance",
 		name = "Recalculate distance",
 		description = "Distance from the path the player should be for it to be recalculated (-1 for never)",
-		position = 26,
+		position = 27,
 		section = sectionSettings
 	)
 	default int recalculateDistance()
@@ -361,7 +376,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "finishDistance",
 		name = "Finish distance",
 		description = "Distance from the target tile at which the path should be ended (-1 for never)",
-		position = 27,
+		position = 28,
 		section = sectionSettings
 	)
 	default int reachedDistance()
@@ -377,7 +392,7 @@ public interface ShortestPathConfig extends Config
 		name = "Unreachable target distance",
 		description = "Distance from the target at which a finished path is considered not to reach the target." +
 			"<br>Useful for determining if a path is potentially invalid.",
-		position = 28,
+		position = 29,
 		section = sectionSettings
 	)
 	default int unreachableTargetDistance()
@@ -389,7 +404,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "showTileCounter",
 		name = "Show tile counter",
 		description = "Whether to display the number of tiles travelled, number of tiles remaining or disable counting",
-		position = 29,
+		position = 30,
 		section = sectionSettings
 	)
 	default TileCounter showTileCounter()
@@ -401,7 +416,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "tileCounterStep",
 		name = "Tile counter step",
 		description = "The number of tiles between the displayed tile counter numbers",
-		position = 30,
+		position = 31,
 		section = sectionSettings
 	)
 	default int tileCounterStep()
@@ -421,7 +436,7 @@ public interface ShortestPathConfig extends Config
 		name = "Calculation cutoff",
 		description = "The cutoff threshold in number of ticks (0.6 seconds) of no progress being<br>" +
 			"made towards the path target before the calculation will be stopped",
-		position = 31,
+		position = 32,
 		section = sectionSettings
 	)
 	default int calculationCutoff()
@@ -433,7 +448,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "showTransportInfo",
 		name = "Show transport info",
 		description = "Whether to display transport destination hint info, e.g. which chat option and text to click",
-		position = 32,
+		position = 33,
 		section = sectionSettings
 	)
 	default boolean showTransportInfo()
@@ -445,7 +460,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "showBankPickupInfo",
 		name = "Show transport hint at pickup",
 		description = "When standing at a bank on the path, also show the transport hint for the next step requiring an item pickup",
-		position = 33,
+		position = 34,
 		section = sectionSettings
 	)
 	default boolean showBankPickupInfo()
@@ -456,7 +471,7 @@ public interface ShortestPathConfig extends Config
 	@ConfigSection(
 		name = "Player-Owned House",
 		description = "Options for POH (Player-Owned House) teleports",
-		position = 34,
+		position = 35,
 		closedByDefault = true
 	)
 	String sectionPoh = "sectionPoh";
@@ -466,7 +481,7 @@ public interface ShortestPathConfig extends Config
 		name = "Enable POH teleports",
 		description = "Master toggle for all Player-Owned House (POH) teleports.<br>" +
 			"When disabled, all POH transports are excluded regardless of individual settings below.",
-		position = 35,
+		position = 36,
 		section = sectionPoh
 	)
 	default boolean usePoh()
@@ -479,7 +494,7 @@ public interface ShortestPathConfig extends Config
 		name = "POH fairy ring",
 		description = "Whether to include the POH fairy ring in the path.<br>" +
 			"Enable this if you have built a fairy ring in your house (85 Construction or boosted)",
-		position = 36,
+		position = 37,
 		section = sectionPoh
 	)
 	default boolean usePohFairyRing()
@@ -492,7 +507,7 @@ public interface ShortestPathConfig extends Config
 		name = "POH spirit tree",
 		description = "Whether to include the POH spirit tree in the path.<br>" +
 			"Enable this if you have built a spirit tree in your house (75 Construction, 83 Farming or boosted)",
-		position = 37,
+		position = 38,
 		section = sectionPoh
 	)
 	default boolean usePohSpiritTree()
@@ -504,7 +519,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "useTeleportationPortalsPoh",
 		name = "POH portal nexus",
 		description = "Whether to include POH teleportation portals/nexus in the path",
-		position = 38,
+		position = 39,
 		section = sectionPoh
 	)
 	default boolean useTeleportationPortalsPoh()
@@ -517,7 +532,7 @@ public interface ShortestPathConfig extends Config
 		name = "POH jewellery box tier",
 		description = "The tier of jewellery box built in your POH<br>" +
 			"(Basic: 1-9, Fancy: A-J, Ornate: K-R). Set to None to disable jewellery box.",
-		position = 39,
+		position = 40,
 		section = sectionPoh
 	)
 	default JewelleryBoxTier pohJewelleryBoxTier()
@@ -530,7 +545,7 @@ public interface ShortestPathConfig extends Config
 		name = "POH mounted items",
 		description = "Whether to include POH mounted items in the path<br>" +
 			"(e.g. mounted glory, Xeric's talisman, digsite pendant, mythical cape)",
-		position = 40,
+		position = 41,
 		section = sectionPoh
 	)
 	default boolean usePohMountedItems()
@@ -543,7 +558,7 @@ public interface ShortestPathConfig extends Config
 		name = "POH wilderness obelisk",
 		description = "Whether to include the POH wilderness obelisk in the path.<br>" +
 			"Enable this if you have built an obelisk in your house (80 Construction or boosted)",
-		position = 41,
+		position = 42,
 		section = sectionPoh
 	)
 	default boolean usePohObelisk()
@@ -555,7 +570,7 @@ public interface ShortestPathConfig extends Config
 		name = "Transport Thresholds",
 		description = "Set customizable thresholds for how much faster a transportation<br>" +
 			"method must be to be preferred over other methods",
-		position = 42,
+		position = 43,
 		closedByDefault = true
 	)
 	String sectionThresholds = "sectionThresholds";
@@ -568,7 +583,7 @@ public interface ShortestPathConfig extends Config
 		name = "Agility shortcut threshold",
 		description = "How many extra tiles an agility shortcut must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 43,
+		position = 44,
 		section = sectionThresholds
 	)
 	default int costAgilityShortcuts()
@@ -584,7 +599,7 @@ public interface ShortestPathConfig extends Config
 		name = "Grapple shortcut threshold",
 		description = "How many extra tiles a grapple shortcut must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 44,
+		position = 45,
 		section = sectionThresholds
 	)
 	default int costGrappleShortcuts()
@@ -600,7 +615,7 @@ public interface ShortestPathConfig extends Config
 		name = "Boat threshold",
 		description = "How many extra tiles a small boat must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 45,
+		position = 46,
 		section = sectionThresholds
 	)
 	default int costBoats()
@@ -616,7 +631,7 @@ public interface ShortestPathConfig extends Config
 		name = "Canoe threshold",
 		description = "How many extra tiles a canoe must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 46,
+		position = 47,
 		section = sectionThresholds
 	)
 	default int costCanoes()
@@ -632,7 +647,7 @@ public interface ShortestPathConfig extends Config
 		name = "Charter ship threshold",
 		description = "How many extra tiles a charter ship must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 47,
+		position = 48,
 		section = sectionThresholds
 	)
 	default int costCharterShips()
@@ -648,7 +663,7 @@ public interface ShortestPathConfig extends Config
 		name = "Ship threshold",
 		description = "How many extra tiles a passenger ship must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 48,
+		position = 49,
 		section = sectionThresholds
 	)
 	default int costShips()
@@ -664,7 +679,7 @@ public interface ShortestPathConfig extends Config
 		name = "Fairy ring threshold",
 		description = "How many extra tiles a fairy ring must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 49,
+		position = 50,
 		section = sectionThresholds
 	)
 	default int costFairyRings()
@@ -680,7 +695,7 @@ public interface ShortestPathConfig extends Config
 		name = "Gnome glider threshold",
 		description = "How many extra tiles a gnome glider must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 50,
+		position = 51,
 		section = sectionThresholds
 	)
 	default int costGnomeGliders()
@@ -696,7 +711,7 @@ public interface ShortestPathConfig extends Config
 		name = "Hot air balloon threshold",
 		description = "How many extra tiles a hot air balloon must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 51,
+		position = 52,
 		section = sectionThresholds
 	)
 	default int costHotAirBalloons()
@@ -712,7 +727,7 @@ public interface ShortestPathConfig extends Config
 		name = "Magic carpets threshold",
 		description = "How many extra tiles a magic carpet must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 52,
+		position = 53,
 		section = sectionThresholds
 	)
 	default int costMagicCarpets()
@@ -728,7 +743,7 @@ public interface ShortestPathConfig extends Config
 		name = "Magic mushtrees threshold",
 		description = "How many extra tiles a magic mushtree must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 53,
+		position = 54,
 		section = sectionThresholds
 	)
 	default int costMagicMushtrees()
@@ -744,7 +759,7 @@ public interface ShortestPathConfig extends Config
 		name = "Minecart threshold",
 		description = "How many extra tiles a minecart must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 54,
+		position = 55,
 		section = sectionThresholds
 	)
 	default int costMinecarts()
@@ -760,7 +775,7 @@ public interface ShortestPathConfig extends Config
 		name = "Quetzal threshold",
 		description = "How many extra tiles a quetzal must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 55,
+		position = 56,
 		section = sectionThresholds
 	)
 	default int costQuetzals()
@@ -776,7 +791,7 @@ public interface ShortestPathConfig extends Config
 		name = "Quetzal whistle threshold",
 		description = "How many extra tiles a quetzal whistle teleport must save<br>" +
 			"to be preferred over using a landing site",
-		position = 56,
+		position = 57,
 		section = sectionThresholds
 	)
 	default int costQuetzalWhistle()
@@ -792,7 +807,7 @@ public interface ShortestPathConfig extends Config
 		name = "Spirit tree threshold",
 		description = "How many extra tiles a spirit tree must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 57,
+		position = 58,
 		section = sectionThresholds
 	)
 	default int costSpiritTrees()
@@ -808,7 +823,7 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation item (non-consumable) threshold",
 		description = "How many extra tiles a non-consumable (permanent) teleportation item<br>" +
 			"must save to be preferred over walking or other transports",
-		position = 58,
+		position = 59,
 		section = sectionThresholds
 	)
 	default int costNonConsumableTeleportationItems()
@@ -824,7 +839,7 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation item (consumable) threshold",
 		description = "How many extra tiles a consumable (non-permanent) teleportation item<br>" +
 			"must save to be preferred over walking or other transports",
-		position = 59,
+		position = 60,
 		section = sectionThresholds
 	)
 	default int costConsumableTeleportationItems()
@@ -840,7 +855,7 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation box threshold",
 		description = "How many extra tiles a teleportation box must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 60,
+		position = 61,
 		section = sectionThresholds
 	)
 	default int costTeleportationBoxes()
@@ -856,7 +871,7 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation lever threshold",
 		description = "How many extra tiles a teleportation lever must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 61,
+		position = 62,
 		section = sectionThresholds
 	)
 	default int costTeleportationLevers()
@@ -872,7 +887,7 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation portal threshold",
 		description = "How many extra tiles a teleportation portal must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 62,
+		position = 63,
 		section = sectionThresholds
 	)
 	default int costTeleportationPortals()
@@ -888,10 +903,26 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation spell threshold",
 		description = "How many extra tiles a teleportation spell must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 63,
+		position = 64,
 		section = sectionThresholds
 	)
 	default int costTeleportationSpells()
+	{
+		return 0;
+	}
+
+	@Range(
+		max = 10000
+	)
+	@ConfigItem(
+		keyName = "costTeleportationSpellsHome",
+		name = "Home Teleport spell threshold",
+		description = "How many extra tiles a Home Teleport spell must save<br>" +
+			"to be preferred over walking or other transports",
+		position = 65,
+		section = sectionThresholds
+	)
+	default int costTeleportationSpellsHome()
 	{
 		return 0;
 	}
@@ -904,7 +935,7 @@ public interface ShortestPathConfig extends Config
 		name = "Teleportation to minigame threshold",
 		description = "How many extra tiles a minigame teleport must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 64,
+		position = 66,
 		section = sectionThresholds
 	)
 	default int costTeleportationMinigames()
@@ -920,7 +951,7 @@ public interface ShortestPathConfig extends Config
 		name = "Wilderness obelisk threshold",
 		description = "How many extra tiles a wilderness obelisk must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 65,
+		position = 67,
 		section = sectionThresholds
 	)
 	default int costWildernessObelisks()
@@ -936,7 +967,7 @@ public interface ShortestPathConfig extends Config
 		name = "Seasonal transport threshold",
 		description = "How many extra tiles a seasonal transport must save<br>" +
 			"to be preferred over walking or other transports",
-		position = 66,
+		position = 68,
 		section = sectionThresholds
 	)
 	default int costSeasonalTransports()
@@ -947,7 +978,7 @@ public interface ShortestPathConfig extends Config
 	@ConfigSection(
 		name = "Display",
 		description = "Options for displaying the path on the world map, minimap and scene tiles",
-		position = 67
+		position = 69
 	)
 	String sectionDisplay = "sectionDisplay";
 
@@ -955,7 +986,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "drawMap",
 		name = "Draw path on world map",
 		description = "Whether the path should be drawn on the world map",
-		position = 68,
+		position = 70,
 		section = sectionDisplay
 	)
 	default boolean drawMap()
@@ -967,7 +998,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "drawMinimap",
 		name = "Draw path on minimap",
 		description = "Whether the path should be drawn on the minimap",
-		position = 69,
+		position = 71,
 		section = sectionDisplay
 	)
 	default boolean drawMinimap()
@@ -979,7 +1010,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "drawTiles",
 		name = "Draw path on tiles",
 		description = "Whether the path should be drawn on the game tiles",
-		position = 70,
+		position = 72,
 		section = sectionDisplay
 	)
 	default boolean drawTiles()
@@ -991,7 +1022,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "pathStyle",
 		name = "Path style",
 		description = "Whether to display the path as tiles or a segmented line",
-		position = 71,
+		position = 73,
 		section = sectionDisplay
 	)
 	default TileStyle pathStyle()
@@ -1002,7 +1033,7 @@ public interface ShortestPathConfig extends Config
 	@ConfigSection(
 		name = "Colours",
 		description = "Colours for the path map, minimap and scene tiles",
-		position = 72
+		position = 74
 	)
 	String sectionColours = "sectionColours";
 
@@ -1011,7 +1042,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "colourPath",
 		name = "Path",
 		description = "Colour of the path tiles on the world map, minimap and in the game scene",
-		position = 73,
+		position = 75,
 		section = sectionColours
 	)
 	default Color colourPath()
@@ -1025,7 +1056,7 @@ public interface ShortestPathConfig extends Config
 		name = "Calculating",
 		description = "Colour of the path tiles while the pathfinding calculation is in progress," +
 			"<br>and the colour of unused targets if there are more than a single target",
-		position = 74,
+		position = 76,
 		section = sectionColours
 	)
 	default Color colourPathCalculating()
@@ -1038,7 +1069,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "colourPathUnreachable",
 		name = "Unreachable",
 		description = "Colour of the path tiles when pathfinding has finished but the target is still too far away",
-		position = 75,
+		position = 77,
 		section = sectionColours
 	)
 	default Color colourPathUnreachable()
@@ -1051,7 +1082,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "colourTransports",
 		name = "Transports",
 		description = "Colour of the transport tiles",
-		position = 76,
+		position = 78,
 		section = sectionColours
 	)
 	default Color colourTransports()
@@ -1064,7 +1095,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "colourCollisionMap",
 		name = "Collision map",
 		description = "Colour of the collision map tiles",
-		position = 77,
+		position = 79,
 		section = sectionColours
 	)
 	default Color colourCollisionMap()
@@ -1077,7 +1108,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "colourText",
 		name = "Text",
 		description = "Colour of the text of the tile counter and fairy ring codes",
-		position = 78,
+		position = 80,
 		section = sectionColours
 	)
 	default Color colourText()
@@ -1088,7 +1119,7 @@ public interface ShortestPathConfig extends Config
 	@ConfigSection(
 		name = "Hotkeys",
 		description = "Options for keyboard shortcuts",
-		position = 80
+		position = 81
 	)
 	String sectionHotkeys = "sectionHotkeys";
 
@@ -1096,7 +1127,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "clearPathHotkey",
 		name = "Clear current path",
 		description = "Hotkey to clear the current path",
-		position = 81,
+		position = 82,
 		section = sectionHotkeys
 	)
 	default Keybind clearPathHotkey()
@@ -1107,7 +1138,7 @@ public interface ShortestPathConfig extends Config
 	@ConfigSection(
 		name = "Debug Options",
 		description = "Various options for debugging",
-		position = 82,
+		position = 83,
 		closedByDefault = true
 	)
 	String sectionDebug = "sectionDebug";
@@ -1116,7 +1147,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "drawTransports",
 		name = "Draw transports",
 		description = "Whether transports should be drawn",
-		position = 83,
+		position = 84,
 		section = sectionDebug
 	)
 	default boolean drawTransports()
@@ -1128,7 +1159,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "drawCollisionMap",
 		name = "Draw collision map",
 		description = "Whether the collision map should be drawn",
-		position = 84,
+		position = 85,
 		section = sectionDebug
 	)
 	default boolean drawCollisionMap()
@@ -1140,7 +1171,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "drawDebugPanel",
 		name = "Show debug panel",
 		description = "Toggles displaying the pathfinding debug stats panel",
-		position = 85,
+		position = 86,
 		section = sectionDebug
 	)
 	default boolean drawDebugPanel()
@@ -1152,7 +1183,7 @@ public interface ShortestPathConfig extends Config
 		keyName = "postTransports",
 		name = "Post transports",
 		description = "Whether to post the transports used in the current path as a PluginMessage event",
-		position = 86,
+		position = 87,
 		section = sectionDebug
 	)
 	default boolean postTransports()

--- a/src/main/java/shortestpath/transport/TransportType.java
+++ b/src/main/java/shortestpath/transport/TransportType.java
@@ -91,6 +91,14 @@ public enum TransportType
 				return true;
 			}
 		},
+	TELEPORTATION_SPELL_HOME("/transports/teleportation_spells_home.tsv", "useTeleportationSpellsHome", ShortestPathConfig::useTeleportationSpellsHome, "costTeleportationSpellsHome", ShortestPathConfig::costTeleportationSpellsHome)
+		{
+			@Override
+			public boolean isTeleport()
+			{
+				return true;
+			}
+		},
 	WILDERNESS_OBELISK("/transports/wilderness_obelisks.tsv", "useWildernessObelisks", ShortestPathConfig::useWildernessObelisks, "costWildernessObelisks", ShortestPathConfig::costWildernessObelisks),
 	;
 

--- a/src/main/resources/transports/teleportation_spells.tsv
+++ b/src/main/resources/transports/teleportation_spells.tsv
@@ -1,11 +1,5 @@
 # Destination	Items	Skills	Quests	Duration	Display info	Wilderness level	Varbits	VarPlayers
 # Standard Spellbook - Varbit 4070=0								
-# Lumbridge Home Teleport (enabled animation:4560=3 is both 1 and 2 randomly. &249 is either 1, 8, 16, 32, 64 or 128)								
-3221 3218 0				23	Lumbridge Home Teleport	20	4070=0	4560=0;892@30
-3221 3218 0				21	Lumbridge Home Teleport	20	4070=0	4560&2;892@30
-3221 3218 0				18	Lumbridge Home Teleport	20	4070=0	4560&4;892@30
-3221 3218 0				23	Lumbridge Home Teleport	20	4070=0	4560&249;892@30
-								
 # Varrock Teleport								
 3213 3424 0	AIR_RUNE=3&&FIRE_RUNE=1&&LAW_RUNE=1	25 Magic		4	Varrock Teleport	20	4070=0	
 # Varbit 4480 is DIARY_VARROCK_MEDIUM								
@@ -64,12 +58,6 @@
 2797 2798 1	FIRE_RUNE=2&&WATER_RUNE=2&&LAW_RUNE=2&&BANANA=1	64 Magic	Freeing King Awowogei	4	Ape Atoll Teleport	20	4070=0	
 								
 # Ancient Spellbook - Varbit 4070=1								
-# Edgeville Home Teleport								
-3087 3504 0			Desert Treasure I	23	Edgeville Home Teleport	20	4070=1	4560=0;892@30
-3087 3504 0			Desert Treasure I	21	Edgeville Home Teleport	20	4070=1	4560&2;892@30
-3087 3504 0			Desert Treasure I	18	Edgeville Home Teleport	20	4070=1	4560&4;892@30
-3087 3504 0			Desert Treasure I	23	Edgeville Home Teleport	20	4070=1	4560&249;892@30
-								
 # Paddewwa Teleport								
 3097 9881 0	AIR_RUNE=1&&FIRE_RUNE=1&&LAW_RUNE=2	54 Magic	Desert Treasure I	5	Paddewwa Teleport	20	4070=1	
 								
@@ -98,12 +86,6 @@
 2976 3875 0	LAW_RUNE=2&&WATER_RUNE=8	96 Magic	Desert Treasure I	5	Ghorrock Teleport	20	4070=1	
 								
 # Lunar Spellbook - Varbit 4070=2								
-# Lunar Home Teleport								
-2113 3915 0			Lunar Diplomacy	23	Lunar Home Teleport	20	4070=2	4560=0;892@30
-2113 3915 0			Lunar Diplomacy	21	Lunar Home Teleport	20	4070=2	4560&2;892@30
-2113 3915 0			Lunar Diplomacy	18	Lunar Home Teleport	20	4070=2	4560&4;892@30
-2113 3915 0			Lunar Diplomacy	23	Lunar Home Teleport	20	4070=2	4560&249;892@30
-								
 # Moonclan Teleport								
 2113 3915 0	EARTH_RUNE=2&&ASTRAL_RUNE=2&&LAW_RUNE=1	69 Magic	Lunar Diplomacy	4	Moonclan Teleport	20	4070=2	
 								
@@ -129,12 +111,6 @@
 2975 3938 0	WATER_RUNE=8&&ASTRAL_RUNE=3&&LAW_RUNE=3	89 Magic	Lunar Diplomacy	4	Ice Plateau Teleport	20	4070=2	
 								
 # Arceuus Spellbook - Varbit 4070=3								
-# Arceuus Home Teleport								
-1700 3882 0				23	Arceuus Home Teleport	20	4070=3	4560=0;892@30
-1700 3882 0				21	Arceuus Home Teleport	20	4070=3	4560&2;892@30
-1700 3882 0				18	Arceuus Home Teleport	20	4070=3	4560&4;892@30
-1700 3882 0				23	Arceuus Home Teleport	20	4070=3	4560&249;892@30
-								
 # Arceuus Library Teleport								
 1632 3837 0	EARTH_RUNE=2&&LAW_RUNE=1	6 Magic		4	Arceuus Library Teleport	20	4070=3	
 								

--- a/src/main/resources/transports/teleportation_spells_home.tsv
+++ b/src/main/resources/transports/teleportation_spells_home.tsv
@@ -1,0 +1,28 @@
+# Destination	Items	Skills	Quests	Duration	Display info	Wilderness level	Varbits	VarPlayers
+# Standard Spellbook - Varbit 4070=0								
+# Lumbridge Home Teleport (enabled animation:4560=3 is both 1 and 2 randomly. &249 is either 1, 8, 16, 32, 64 or 128)								
+3221 3218 0				23	Lumbridge Home Teleport	20	4070=0	4560=0;892@30
+3221 3218 0				21	Lumbridge Home Teleport	20	4070=0	4560&2;892@30
+3221 3218 0				18	Lumbridge Home Teleport	20	4070=0	4560&4;892@30
+3221 3218 0				23	Lumbridge Home Teleport	20	4070=0	4560&249;892@30
+								
+# Ancient Spellbook - Varbit 4070=1								
+# Edgeville Home Teleport								
+3087 3504 0			Desert Treasure I	23	Edgeville Home Teleport	20	4070=1	4560=0;892@30
+3087 3504 0			Desert Treasure I	21	Edgeville Home Teleport	20	4070=1	4560&2;892@30
+3087 3504 0			Desert Treasure I	18	Edgeville Home Teleport	20	4070=1	4560&4;892@30
+3087 3504 0			Desert Treasure I	23	Edgeville Home Teleport	20	4070=1	4560&249;892@30
+								
+# Lunar Spellbook - Varbit 4070=2								
+# Lunar Home Teleport								
+2113 3915 0			Lunar Diplomacy	23	Lunar Home Teleport	20	4070=2	4560=0;892@30
+2113 3915 0			Lunar Diplomacy	21	Lunar Home Teleport	20	4070=2	4560&2;892@30
+2113 3915 0			Lunar Diplomacy	18	Lunar Home Teleport	20	4070=2	4560&4;892@30
+2113 3915 0			Lunar Diplomacy	23	Lunar Home Teleport	20	4070=2	4560&249;892@30
+								
+# Arceuus Spellbook - Varbit 4070=3								
+# Arceuus Home Teleport								
+1700 3882 0				23	Arceuus Home Teleport	20	4070=3	4560=0;892@30
+1700 3882 0				21	Arceuus Home Teleport	20	4070=3	4560&2;892@30
+1700 3882 0				18	Arceuus Home Teleport	20	4070=3	4560&4;892@30
+1700 3882 0				23	Arceuus Home Teleport	20	4070=3	4560&249;892@30


### PR DESCRIPTION
Adds settings for enabling/disabling the `Home Teleport` spells for teleporting to Lumbridge, etc.

Breaks out Home Teleport spells to a separate transport type, `TransportType.TELEPORTATION_SPELL_HOME`. Moves the associated transport data from `teleportation_spells.tsv` to `teleportation_spells_home.tsv`.

Tested locally by enabling/disabling home teleports and incrementing/decrementing the cost to see the effect.

Partially addresses #503 by giving the user the option to penalize home teleports.