### PR TITLE
PoH Teleport Fixes

### DIFF
--- a/src/main/resources/transports/teleportation_items.tsv
+++ b/src/main/resources/transports/teleportation_items.tsv
@@ -116,25 +116,36 @@
 3028 3842 0			21166=1||21169=1||21171=1||21173=1||21175=1		4	Burning amulet: Lava Maze	T	20		
 										
 # Teleport to house (tablet) - These depend on the current player's home location, determined by varbit 2187, and teleport inside or outside determined by varbit 4744										
+# Shows (Inside) or (Outside) only if that is not the current default for the player.										
 1923 5709 0			8013=1		4	Teleport to House tablet	T	20	4744=0	
+1923 5709 0			8013=1		4	Teleport to House tablet (Inside)	T	20	4744=1	
 # 1 - Rimmington										
-2953 3224 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=1;4744=1	
+2953 3224 0			8013=1		4	Teleport to House tablet	T	20	2187=1;4744=1	
+2953 3224 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=1;4744=0	
 # 2 - Taverly										
-2893 3465 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=2;4744=1	
+2893 3465 0			8013=1		4	Teleport to House tablet	T	20	2187=2;4744=1	
+2893 3465 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=2;4744=0	
 # 3 - Pollnivneach										
-3340 3003 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=3;4744=1	
+3340 3003 0			8013=1		4	Teleport to House tablet	T	20	2187=3;4744=1	
+3340 3003 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=3;4744=0	
 # 4 - Rellekka										
-2670 3631 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=4;4744=1	
+2670 3631 0			8013=1		4	Teleport to House tablet	T	20	2187=4;4744=1	
+2670 3631 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=4;4744=0	
 # 5 - Brimhaven										
-2757 3178 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=5;4744=1	
+2757 3178 0			8013=1		4	Teleport to House tablet	T	20	2187=5;4744=1	
+2757 3178 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=5;4744=0	
 # 6 - Yanille										
-2544 3096 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=6;4744=1	
+2544 3096 0			8013=1		4	Teleport to House tablet	T	20	2187=6;4744=1	
+2544 3096 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=6;4744=0	
 # 7 - Prifddinas										
-3239 6076 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=7;4744=1	
+3239 6076 0			8013=1		4	Teleport to House tablet	T	20	2187=7;4744=1	
+3239 6076 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=7;4744=0	
 # 8 - Hosidius										
-1743 3517 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=8;4744=1	
+1743 3517 0			8013=1		4	Teleport to House tablet	T	20	2187=8;4744=1	
+1743 3517 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=8;4744=0	
 # 9 - Aldarin										
-1422 2963 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=9;4744=1	
+1422 2963 0			8013=1		4	Teleport to House tablet	T	20	2187=9;4744=1	
+1422 2963 0			8013=1		4	Teleport to House tablet (Outside)	T	20	2187=9;4744=0	
 										
 #  Teleport tablets										
 3213 3424 0			8007=1		4	Varrock tablet	T	20		

--- a/src/main/resources/transports/teleportation_portals.tsv
+++ b/src/main/resources/transports/teleportation_portals.tsv
@@ -125,22 +125,31 @@
 # Player-owned house								
 # Rimmington								
 2953 3224 0	1923 5709 0	Home Portal 15478			2187=1		4	Home Portal
+1923 5709 0	2953 3224 0	Home Portal 15478			2187=1		4	Home Portal
 # Taverly								
 2893 3465 0	1923 5709 0	Home Portal 15477			2187=2		4	Home Portal
+1923 5709 0	2893 3465 0	Home Portal 15477			2187=2		4	Home Portal
 # Pollnivneach								
 3340 3003 0	1923 5709 0	Home Portal 15479			2187=3		4	Home Portal
+1923 5709 0	3340 3003 0	Home Portal 15479			2187=3		4	Home Portal
 # Rellekka								
 2670 3631 0	1923 5709 0	Home Portal 15480			2187=4		4	Home Portal
+1923 5709 0	2670 3631 0	Home Portal 15480			2187=4		4	Home Portal
 # Brimhaven								
 2757 3178 0	1923 5709 0	Home Portal 15481			2187=5		4	Home Portal
+1923 5709 0	2757 3178 0	Home Portal 15481			2187=5		4	Home Portal
 # Yanille								
 2544 3096 0	1923 5709 0	Home Portal 15482			2187=6		4	Home Portal
+1923 5709 0	2544 3096 0	Home Portal 15482			2187=6		4	Home Portal
 # Prifddinas								
 3239 6076 0	1923 5709 0	Home Portal 34947			2187=7		4	Home Portal
+1923 5709 0	3239 6076 0	Home Portal 34947			2187=7		4	Home Portal
 # Hosidius								
 1743 3517 0	1923 5709 0	Home Portal 28822			2187=8		4	Home Portal
+1923 5709 0	1743 3517 0	Home Portal 28822			2187=8		4	Home Portal
 # Aldarin								
 1422 2963 0	1923 5709 0	Home Portal 55353			2187=9		4	Home Portal
+1923 5709 0	1422 2963 0	Home Portal 55353			2187=9		4	Home Portal
 								
 # Myths' Guild Portals								
 2456 2855 2	2904 3512 0	Enter Portal of Heroes 31621		Dragon Slayer II			1	Heroes' Guild

--- a/src/main/resources/transports/teleportation_spells.tsv
+++ b/src/main/resources/transports/teleportation_spells.tsv
@@ -17,26 +17,38 @@
 # Falador Teleport								
 2964 3378 0	AIR_RUNE=3&&WATER_RUNE=1&&LAW_RUNE=1	37 Magic		4	Falador Teleport	20	4070=0	
 								
-# Teleport to House - These depend on the current player's home location  determined by varbit 2187								
+# Teleport to House - These depend on the current player's home location  determined by varbit 2187
+# Varbit 4744 is the Teleport to House mode, 0 = Inside, 1 = Outside. As both options are always available, we list
+# each option twice, only specifying (Inside) or (Outside) if that is not the default mode selected by the player.								
 1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;4744=0	
+1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Inside)	20	4070=0;4744=0;4744=1	
 # 1 - Rimmington								
-2953 3224 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=1;4744=1	
+2953 3224 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=1;4744=1	
+2953 3224 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=1;4744=0	
 # 2 - Taverly								
-2893 3465 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=2;4744=1	
+2893 3465 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=2;4744=1	
+2893 3465 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=2;4744=0	
 # 3 - Pollnivneach								
-3340 3003 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=3;4744=1	
+3340 3003 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=3;4744=1	
+3340 3003 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=3;4744=0	
 # 4 - Rellekka								
-2670 3631 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=4;4744=1	
+2670 3631 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=4;4744=1	
+2670 3631 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=4;4744=0	
 # 5 - Brimhaven								
-2757 3178 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=5;4744=1	
+2757 3178 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=5;4744=1	
+2757 3178 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=5;4744=0	
 # 6 - Yanille								
-2544 3096 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=6;4744=1	
+2544 3096 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=6;4744=1	
+2544 3096 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=6;4744=0	
 # 7 - Prifddinas								
-3239 6076 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=7;4744=1	
+3239 6076 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=7;4744=1	
+3239 6076 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=7;4744=0	
 # 8 - Hosidius								
-1743 3517 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=8;4744=1	
+1743 3517 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=8;4744=1	
+1743 3517 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=8;4744=0	
 # 9 - Aldarin								
-1422 2963 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=9;4744=1	
+1422 2963 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;2187=9;4744=1	
+1422 2963 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Outside)	20	4070=0;2187=9;4744=0	
 								
 # Camelot Teleport								
 2757 3479 0	AIR_RUNE=5&&LAW_RUNE=1	45 Magic		4	Camelot Teleport	20	4070=0	

--- a/src/main/resources/transports/teleportation_spells.tsv
+++ b/src/main/resources/transports/teleportation_spells.tsv
@@ -17,8 +17,8 @@
 # Falador Teleport								
 2964 3378 0	AIR_RUNE=3&&WATER_RUNE=1&&LAW_RUNE=1	37 Magic		4	Falador Teleport	20	4070=0	
 								
-# Teleport to House - These depend on the current player's home location  determined by varbit 2187
-# Varbit 4744 is the Teleport to House mode, 0 = Inside, 1 = Outside. As both options are always available, we list
+# Teleport to House - These depend on the current player's home location  determined by varbit 2187								
+# Varbit 4744 is the Teleport to House mode, 0 = Inside, 1 = Outside. As both options are always available, we list								
 # each option twice, only specifying (Inside) or (Outside) if that is not the default mode selected by the player.								
 1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House	20	4070=0;4744=0	
 1923 5709 0	AIR_RUNE=1&&EARTH_RUNE=1&&LAW_RUNE=1	40 Magic		4	Teleport to House (Inside)	20	4070=0;4744=0;4744=1	
@@ -182,4 +182,4 @@
 3564 3315 0	BLOOD_RUNE=1&&LAW_RUNE=2&&SOUL_RUNE=2	83 Magic		4	Barrows Teleport	20	4070=3	
 								
 # Ape Atoll Teleport								
-2771 9102 0	BLOOD_RUNE=2&&LAW_RUNE=2&&SOUL_RUNE=2	90 Magic	Monkey Madness I	4	Ape Atoll Teleport	20	4070=3	
+2771 9102 0	BLOOD_RUNE=2&&LAW_RUNE=2&&SOUL_RUNE=2	90 Magic	Monkey Madness I	4	Ape Atoll Teleport	20	4070=3		

--- a/src/main/resources/transports/teleportation_spells.tsv
+++ b/src/main/resources/transports/teleportation_spells.tsv
@@ -182,4 +182,4 @@
 3564 3315 0	BLOOD_RUNE=1&&LAW_RUNE=2&&SOUL_RUNE=2	83 Magic		4	Barrows Teleport	20	4070=3	
 								
 # Ape Atoll Teleport								
-2771 9102 0	BLOOD_RUNE=2&&LAW_RUNE=2&&SOUL_RUNE=2	90 Magic	Monkey Madness I	4	Ape Atoll Teleport	20	4070=3		
+2771 9102 0	BLOOD_RUNE=2&&LAW_RUNE=2&&SOUL_RUNE=2	90 Magic	Monkey Madness I	4	Ape Atoll Teleport	20	4070=3	


### PR DESCRIPTION
Add portals for "Inside PoH -> Outside" to allow routing out of PoH through the default portal.

Add teleport spells + tablets for non-default options for PoH Teleport. If the player has the default mode set to `Inside`, outside options are displayed as `Teleport to House (Outside)`. If the player has the default mode set to `Outside`, then the inside option will be displayed as `Teleport to House (Inside)`. If the destination matches the players default mode setting, then it will simply display `Teleport to House`.

#500