### PR TITLE
Add alternative teleport routes side panel with available method list

### DIFF
--- a/src/main/java/shortestpath/AlternativeRoutesMode.java
+++ b/src/main/java/shortestpath/AlternativeRoutesMode.java
@@ -1,0 +1,48 @@
+package shortestpath;
+
+/**
+ * Which teleport/transport methods the alternative-routes feature considers when searching.
+ * Two families, each with two variants:
+ * <ul>
+ * <li><b>Owned</b> — only methods whose required items the player actually possesses:
+ * {@link #OWNED_INVENTORY} (inventory + equipment) or {@link #OWNED_WITH_BANK} (also items stored in
+ * the bank, routing through a bank to pick them up).</li>
+ * <li><b>All</b> — possession is ignored: {@link #ALL_UNLOCKED} still respects character unlocks
+ * (skill levels, quests, varbits/diaries), while {@link #ALL_EVERYTHING} shows every method in the
+ * game, including ones known to be unavailable to this character.</li>
+ * </ul>
+ */
+public enum AlternativeRoutesMode
+{
+	/**
+	 * Owned: items in inventory or equipment only (forces the INVENTORY teleport-item setting).
+	 */
+	OWNED_INVENTORY,
+	/**
+	 * Owned: inventory + equipment + bank, routing through a bank to withdraw banked items (mirrors
+	 * Shortest Path's {@code INVENTORY_AND_BANK} + {@code includeBankPath}).
+	 */
+	OWNED_WITH_BANK,
+	/**
+	 * All: possession ignored, but character unlocks (skills, quests, varbits) still apply — methods
+	 * the player could use if they obtained the item.
+	 */
+	ALL_UNLOCKED,
+	/**
+	 * All: every method in the game, including ones known to be unavailable (quest/skill-locked).
+	 */
+	ALL_EVERYTHING;
+
+	public boolean isOwned()
+	{
+		return this == OWNED_INVENTORY || this == OWNED_WITH_BANK;
+	}
+
+	/**
+	 * The second sub-option of each family (Inventory+bank under Owned, Everything under All).
+	 */
+	public boolean isSecondVariant()
+	{
+		return this == OWNED_WITH_BANK || this == ALL_EVERYTHING;
+	}
+}

--- a/src/main/java/shortestpath/AlternativeRoutesService.java
+++ b/src/main/java/shortestpath/AlternativeRoutesService.java
@@ -245,7 +245,8 @@ public class AlternativeRoutesService
 			{
 				break;
 			}
-			routes.add(new RouteOption(path, methods, result.getTotalCost(), reached, scan.bankGated));
+			routes.add(new RouteOption(path, methods, result.getTotalCost(), scan.rawCost, reached,
+				scan.bankGated, scan.walkBefore, scan.trailingWalk));
 			// Stream the route we just found so the panel shows it immediately.
 			emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, false);
 
@@ -392,7 +393,8 @@ public class AlternativeRoutesService
 					continue;
 				}
 				routes.add(new RouteOption(seedResult.path, seedResult.scan.methods,
-					seedResult.totalCost, seedResult.reached, seedResult.scan.bankGated));
+					seedResult.totalCost, seedResult.scan.rawCost, seedResult.reached,
+					seedResult.scan.bankGated, seedResult.scan.walkBefore, seedResult.scan.trailingWalk));
 				emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, false);
 			}
 		}
@@ -587,8 +589,13 @@ public class AlternativeRoutesService
 		Set<TeleportMethod> bankGated = new LinkedHashSet<>();
 		if (path == null)
 		{
-			return new MethodScan(methods, bankGated);
+			return new MethodScan(methods, bankGated, 0, new ArrayList<>(), 0);
 		}
+		int rawCost = 0;
+		// Walking-leg lengths: tiles walked before each method (parallel to `methods`), and after the
+		// last one. Plain connectors (doors, stairs, shortcuts) count into the leg they sit in.
+		List<Integer> walkBefore = new ArrayList<>();
+		int legSteps = 0;
 		for (int i = 1; i < path.size(); i++)
 		{
 			PathStep from = path.get(i - 1);
@@ -599,14 +606,30 @@ public class AlternativeRoutesService
 			{
 				TeleportMethod method = TeleportMethod.fromTransport(chosen);
 				methods.add(method);
+				walkBefore.add(legSteps);
+				legSteps = 0;
 				// Bank-gated: used in the post-bank state and not available without the bank.
 				if (bankVisited && !availableWithoutBank(config, from.getPackedPosition(), chosen))
 				{
 					bankGated.add(method);
 				}
 			}
+			// Raw cost: what the edge costs without any configured weights — a transport edge counts
+			// only its travel time, a walking edge its tile distance (mirrors the search's own cost
+			// accumulation minus the additional/weight terms).
+			Transport edgeTransport = chosen != null
+				? chosen
+				: matchAnyTransport(config, from.getPackedPosition(), to.getPackedPosition(), bankVisited);
+			int edgeCost = edgeTransport != null
+				? edgeTransport.getDuration()
+				: WorldPointUtil.distanceBetween(from.getPackedPosition(), to.getPackedPosition());
+			rawCost += edgeCost;
+			if (chosen == null)
+			{
+				legSteps += edgeCost;
+			}
 		}
-		return new MethodScan(methods, bankGated);
+		return new MethodScan(methods, bankGated, rawCost, walkBefore, legSteps);
 	}
 
 	private static boolean availableWithoutBank(PathfinderConfig config, int origin, Transport transport)
@@ -633,11 +656,20 @@ public class AlternativeRoutesService
 	{
 		private final List<TeleportMethod> methods;
 		private final Set<TeleportMethod> bankGated;
+		// Path cost without any configured weights: walk distance plus transport travel times only.
+		private final int rawCost;
+		// Tiles walked before each method (parallel to methods) and after the last one.
+		private final List<Integer> walkBefore;
+		private final int trailingWalk;
 
-		MethodScan(List<TeleportMethod> methods, Set<TeleportMethod> bankGated)
+		MethodScan(List<TeleportMethod> methods, Set<TeleportMethod> bankGated, int rawCost,
+			List<Integer> walkBefore, int trailingWalk)
 		{
 			this.methods = methods;
 			this.bankGated = bankGated;
+			this.rawCost = rawCost;
+			this.walkBefore = walkBefore;
+			this.trailingWalk = trailingWalk;
 		}
 	}
 
@@ -658,6 +690,32 @@ public class AlternativeRoutesService
 		for (Transport transport : config.getUsableTeleports(bankVisited))
 		{
 			if (transport.getDestination() == destination && TeleportMethod.isMethodType(transport.getType()))
+			{
+				return transport;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Like {@link #matchMethodTransport} but without the method-type filter: also matches plain
+	 * connectors (doors, stairs, agility shortcuts, ...) so the raw-cost scan can use the transport's
+	 * travel time for any edge the search traversed via a transport.
+	 */
+	private static Transport matchAnyTransport(PathfinderConfig config, int origin, int destination, boolean bankVisited)
+	{
+		Transport[] atOrigin = config.getTransportsPacked(bankVisited)
+			.getOrDefault(origin, TransportAvailability.EMPTY_TRANSPORTS);
+		for (Transport transport : atOrigin)
+		{
+			if (transport.getDestination() == destination)
+			{
+				return transport;
+			}
+		}
+		for (Transport transport : config.getUsableTeleports(bankVisited))
+		{
+			if (transport.getDestination() == destination)
 			{
 				return transport;
 			}

--- a/src/main/java/shortestpath/AlternativeRoutesService.java
+++ b/src/main/java/shortestpath/AlternativeRoutesService.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -244,7 +245,7 @@ public class AlternativeRoutesService
 			{
 				break;
 			}
-			routes.add(new RouteOption(path, methods, result.getTotalCost(), reached, scan.viaBank));
+			routes.add(new RouteOption(path, methods, result.getTotalCost(), reached, scan.bankGated));
 			// Stream the route we just found so the panel shows it immediately.
 			emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, false);
 
@@ -391,7 +392,7 @@ public class AlternativeRoutesService
 					continue;
 				}
 				routes.add(new RouteOption(seedResult.path, seedResult.scan.methods,
-					seedResult.totalCost, seedResult.reached, seedResult.scan.viaBank));
+					seedResult.totalCost, seedResult.reached, seedResult.scan.bankGated));
 				emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, false);
 			}
 		}
@@ -576,16 +577,17 @@ public class AlternativeRoutesService
 	/**
 	 * Derives the ordered list of teleport/transport methods a path uses, by inspecting each edge for
 	 * a method-type transport (anything beyond plain walking connectors) whose destination matches.
-	 * Also detects whether any used method is bank-gated (only available in the post-bank state), i.e.
-	 * the route walks to a bank to withdraw the required item first.
+	 * Also collects which of those methods are bank-gated (only available in the post-bank state), i.e.
+	 * the route walks to a bank to withdraw that method's required item first — so the panel can say
+	 * which method the bank detour is for.
 	 */
 	private MethodScan scanMethods(PathfinderConfig config, List<PathStep> path)
 	{
 		List<TeleportMethod> methods = new ArrayList<>();
-		boolean viaBank = false;
+		Set<TeleportMethod> bankGated = new LinkedHashSet<>();
 		if (path == null)
 		{
-			return new MethodScan(methods, false);
+			return new MethodScan(methods, bankGated);
 		}
 		for (int i = 1; i < path.size(); i++)
 		{
@@ -595,15 +597,16 @@ public class AlternativeRoutesService
 			Transport chosen = matchMethodTransport(config, from.getPackedPosition(), to.getPackedPosition(), bankVisited);
 			if (chosen != null)
 			{
-				methods.add(TeleportMethod.fromTransport(chosen));
+				TeleportMethod method = TeleportMethod.fromTransport(chosen);
+				methods.add(method);
 				// Bank-gated: used in the post-bank state and not available without the bank.
 				if (bankVisited && !availableWithoutBank(config, from.getPackedPosition(), chosen))
 				{
-					viaBank = true;
+					bankGated.add(method);
 				}
 			}
 		}
-		return new MethodScan(methods, viaBank);
+		return new MethodScan(methods, bankGated);
 	}
 
 	private static boolean availableWithoutBank(PathfinderConfig config, int origin, Transport transport)
@@ -629,12 +632,12 @@ public class AlternativeRoutesService
 	private static final class MethodScan
 	{
 		private final List<TeleportMethod> methods;
-		private final boolean viaBank;
+		private final Set<TeleportMethod> bankGated;
 
-		MethodScan(List<TeleportMethod> methods, boolean viaBank)
+		MethodScan(List<TeleportMethod> methods, Set<TeleportMethod> bankGated)
 		{
 			this.methods = methods;
-			this.viaBank = viaBank;
+			this.bankGated = bankGated;
 		}
 	}
 

--- a/src/main/java/shortestpath/AlternativeRoutesService.java
+++ b/src/main/java/shortestpath/AlternativeRoutesService.java
@@ -1,0 +1,678 @@
+package shortestpath;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Queue;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.callback.ClientThread;
+import shortestpath.pathfinder.PathStep;
+import shortestpath.pathfinder.Pathfinder;
+import shortestpath.pathfinder.PathfinderConfig;
+import shortestpath.pathfinder.PathfinderResult;
+import shortestpath.pathfinder.TransportAvailability;
+import shortestpath.transport.Transport;
+
+/**
+ * Generates up to {@link #MAX_ROUTES} alternative shortest paths to a target, each using a different
+ * set of teleport/transport methods.
+ * <p>
+ * Strategy: run the planning-mode pathfinder, record the methods the best path used, exclude that
+ * path's primary method, and search again. Repeating this yields successively-different routes in
+ * increasing cost order. The user's own exclusions (methods they switched off in the panel) are
+ * applied on top of every search.
+ * <p>
+ * Searches run on a dedicated background thread. Each search needs the planning config's transport
+ * availability rebuilt for the current exclusion set, and {@link PathfinderConfig#refresh()} must run
+ * on the client thread (it reads live game state), so the worker bounces each refresh onto the client
+ * thread and waits for it before running the search off-thread.
+ */
+@Slf4j
+public class AlternativeRoutesService
+{
+	public static final int MAX_ROUTES = 10;
+	private static final int MAX_ROUTES_CAP = 50;
+	private static final long CLIENT_THREAD_TIMEOUT_SECONDS = 10;
+	/**
+	 * When the exact target is unreachable, routes are accepted while their endpoint stays within this
+	 * many tiles of the best route's endpoint (they all converge on the closest reachable area).
+	 */
+	private static final int CLOSEST_DISTANCE_TOLERANCE = 10;
+
+	/**
+	 * Receives progressive updates for one generation: the catalog as soon as it's known, then the
+	 * routes-so-far after each one is found, and a final call with {@code done == true}. Invoked on
+	 * the worker thread; the caller marshals to the Swing EDT. Stale generations stop emitting.
+	 * {@code unavailable} maps each catalog method the player cannot use in the current mode to the
+	 * reason why (missing item, in the bank, missing level/quest, not unlocked), so the panel can mark
+	 * and explain them; it is populated in every mode.
+	 */
+	public interface ResultListener
+	{
+		void onUpdate(List<RouteOption> routes, List<TeleportMethod> catalog,
+			Map<TeleportMethod, MethodAvailability> unavailable, boolean done);
+	}
+
+	/**
+	 * Worker threads for the parallel seed searches (the exclusion loop itself is inherently
+	 * sequential). Small pool: searches are CPU-bound.
+	 */
+	private static final int SEED_POOL_SIZE = Math.max(1, Math.min(4, Runtime.getRuntime().availableProcessors() - 2));
+
+	private final ClientThread clientThread;
+	private final PathfinderConfig planningConfig;
+	private final ExecutorService executor;
+	private final ExecutorService seedExecutor;
+	// Bumped on every generate()/cancel() so a stale in-flight generation discards its result.
+	private final AtomicInteger generation = new AtomicInteger();
+
+	public AlternativeRoutesService(ClientThread clientThread, PathfinderConfig planningConfig)
+	{
+		this.clientThread = clientThread;
+		this.planningConfig = planningConfig;
+		this.executor = Executors.newSingleThreadExecutor(
+			new ThreadFactoryBuilder().setNameFormat("shortest-path-alts-%d").setDaemon(true).build());
+		this.seedExecutor = Executors.newFixedThreadPool(SEED_POOL_SIZE,
+			new ThreadFactoryBuilder().setNameFormat("shortest-path-alts-seed-%d").setDaemon(true).build());
+	}
+
+	/**
+	 * Asynchronously computes the alternative routes, streaming progressive updates to {@code listener}
+	 * (catalog first, then each route as it's found, then a final done update). Supersedes any in-flight
+	 * generation.
+	 */
+	public void generate(int start, Set<Integer> targets, Set<TeleportMethod> userExclusions,
+		AlternativeRoutesMode mode, int maxRoutes, ResultListener listener)
+	{
+		final int gen = generation.incrementAndGet();
+		final Set<Integer> targetsCopy = new HashSet<>(targets);
+		final Set<TeleportMethod> userExclusionsCopy = new HashSet<>(userExclusions);
+		executor.submit(() ->
+		{
+			try
+			{
+				computeRoutes(gen, start, targetsCopy, userExclusionsCopy, mode, maxRoutes, listener);
+			}
+			catch (Exception e)
+			{
+				log.warn("Alternative route generation failed", e);
+			}
+		});
+	}
+
+	public void cancel()
+	{
+		generation.incrementAndGet();
+	}
+
+	public void shutdown()
+	{
+		executor.shutdownNow();
+		seedExecutor.shutdownNow();
+	}
+
+	private void computeRoutes(int gen, int start, Set<Integer> targets,
+		Set<TeleportMethod> userExclusions, AlternativeRoutesMode mode, int maxRoutes, ResultListener listener)
+	{
+		final int limit = Math.max(1, Math.min(maxRoutes, MAX_ROUTES_CAP));
+		final Set<Integer> ends = new HashSet<>(targets);
+		final Set<TeleportMethod> excluded = new HashSet<>(userExclusions);
+		final GenTimer timer = new GenTimer();
+		final long wallStart = System.nanoTime();
+
+		// Single client-thread pass per generation, with NO exclusions: snapshots the game state and
+		// builds the full availability (the complete method catalog, and the base lists that per-search
+		// availability is rebuilt from off-thread), and drops targets the avoid-wilderness setting forbids.
+		long clientStart = System.nanoTime();
+		boolean refreshed = refreshOnClientThread(Collections.emptySet(), ends, mode);
+		timer.clientNanos += System.nanoTime() - clientStart;
+		if (!refreshed)
+		{
+			emit(gen, listener, List.of(), List.of(), Map.of(), true);
+			return;
+		}
+		final List<TeleportMethod> catalog = new ArrayList<>(planningConfig.getMethodCatalog());
+		// The catalog is the full method universe in every mode; flag the entries the player can't use
+		// in THIS mode, with the reason, so the panel can mark them. A banked item counts as usable only
+		// in the "Inventory + bank" mode (its route walks to a bank); every other mode marks it.
+		final Map<TeleportMethod, MethodAvailability> statuses = planningConfig.getMethodAvailability();
+		final Map<TeleportMethod, MethodAvailability> notUsable = new HashMap<>();
+		for (TeleportMethod method : catalog)
+		{
+			MethodAvailability status = statuses.getOrDefault(method, MethodAvailability.AVAILABLE);
+			if (status == MethodAvailability.AVAILABLE
+				|| (status == MethodAvailability.IN_BANK && mode == AlternativeRoutesMode.OWNED_WITH_BANK))
+			{
+				continue;
+			}
+			notUsable.put(method, status);
+		}
+		final Map<TeleportMethod, MethodAvailability> unavailable = Collections.unmodifiableMap(notUsable);
+		if (ends.isEmpty())
+		{
+			emit(gen, listener, List.of(), catalog, unavailable, true);
+			return;
+		}
+		// Show the catalog right away while the routes are still computing.
+		emit(gen, listener, List.of(), catalog, unavailable, false);
+
+		log.debug("[alt-routes] searching: start={}, target={}, mode={}, usableTeleports={}, catalog={}",
+			WorldPointUtil.unpackWorldPoint(start),
+			WorldPointUtil.unpackWorldPoint(ends.iterator().next()),
+			mode, planningConfig.getUsableTeleports(false).length, catalog.size());
+
+		// Snapshot the global-teleport candidates now, while availability reflects no exclusions; used
+		// to seed extra routes if the exclusion loop dries up before the limit.
+		final List<Transport> seedCandidates = new ArrayList<>(Arrays.asList(
+			planningConfig.getUsableTeleports(mode == AlternativeRoutesMode.OWNED_WITH_BANK)));
+
+		final List<RouteOption> routes = new ArrayList<>();
+		final Set<String> seenSignatures = new HashSet<>();
+		// Remaining distance to the target of the first route's endpoint; -1 until known. For an
+		// unreachable exact target (e.g. an NPC tile) every route ends at the closest reachable area,
+		// so later routes are only accepted while they get equally close (small tolerance).
+		int bestRemaining = -1;
+
+		for (int i = 0; i < limit; i++)
+		{
+			if (gen != generation.get())
+			{
+				return;
+			}
+			// Rebuild availability for the current exclusion set — pure computation over the base lists
+			// captured by the client-thread pass above, so no client-thread round-trip per search.
+			long rebuildStart = System.nanoTime();
+			planningConfig.rebuildAvailabilityWithExclusions(excluded);
+			timer.rebuildNanos += System.nanoTime() - rebuildStart;
+
+			long searchStart = System.nanoTime();
+			Pathfinder pathfinder = new Pathfinder(planningConfig, start, ends);
+			pathfinder.run();
+			timer.searchNanos += System.nanoTime() - searchStart;
+			timer.searches++;
+			PathfinderResult result = pathfinder.getResult();
+			List<PathStep> path = (result != null) ? result.getPathSteps() : List.of();
+			if (result == null || path.isEmpty())
+			{
+				log.debug("[alt-routes] search #{} produced no path: result={}, reason={}",
+					i, result == null ? "null" : "empty",
+					result == null ? "n/a" : result.getTerminationReason());
+				break;
+			}
+
+			boolean reached = result.isReached();
+			// Unreachable exact targets (e.g. NPC tiles) still have meaningful alternatives: different
+			// methods all ending at the closest reachable area. Keep enumerating while routes get
+			// equally close; stop once exclusions make the search end up meaningfully further away.
+			int remaining = reached ? 0 : remainingDistance(path, ends);
+			if (bestRemaining < 0)
+			{
+				bestRemaining = remaining;
+			}
+			else if (remaining > bestRemaining + CLOSEST_DISTANCE_TOLERANCE)
+			{
+				log.debug("[alt-routes] search #{} ends {} tiles from target (best {}); stopping with {} route(s)",
+					i, remaining, bestRemaining, routes.size());
+				break;
+			}
+
+			MethodScan scan = scanMethods(planningConfig, path);
+			List<TeleportMethod> methods = scan.methods;
+
+			// Distinct method-signature gate: if this route uses the same ordered methods as a previous
+			// one, excluding more would only reshuffle, so stop.
+			if (!seenSignatures.add(signature(methods)))
+			{
+				break;
+			}
+			routes.add(new RouteOption(path, methods, result.getTotalCost(), reached, scan.viaBank));
+			// Stream the route we just found so the panel shows it immediately.
+			emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, false);
+
+			TeleportMethod primary = methods.isEmpty() ? null : methods.get(0);
+			if (primary == null)
+			{
+				// Walk-only route: the exclusion strategy has nothing left to remove. Seeding below can
+				// still surface teleport routes that lost to walking on cost.
+				break;
+			}
+			excluded.add(primary);
+		}
+
+		// Stop at the pure-walk option: once walking there is on the list, anything more expensive than
+		// just walking isn't worth showing. Seeding only ever surfaces teleports that lost to walking on
+		// cost (i.e. routes MORE expensive than walk-only), so skip it entirely when a walk-only route was
+		// already found; only seed to fill slots when walking never came up (e.g. every route teleports).
+		boolean hasWalkOnly = routes.stream().anyMatch(RouteOption::isWalkOnly);
+		if (!hasWalkOnly && routes.size() < limit && !routes.isEmpty())
+		{
+			seedTeleportRoutes(gen, start, ends, userExclusions, mode, limit,
+				seedCandidates, routes, seenSignatures, catalog, unavailable, listener, bestRemaining, timer);
+		}
+
+		routes.sort(Comparator.comparingInt(RouteOption::getTotalCost));
+		// Drop anything after the pure-walk option (belt-and-braces alongside the skipped seeding above).
+		for (int i = 0; i < routes.size(); i++)
+		{
+			if (routes.get(i).isWalkOnly())
+			{
+				routes.subList(i + 1, routes.size()).clear();
+				break;
+			}
+		}
+		synchronized (timer)
+		{
+			log.debug("[alt-routes] generated {} route(s); timing: wall={}ms client={}ms rebuild={}ms searchCpu={}ms ({} searches)",
+				routes.size(),
+				(System.nanoTime() - wallStart) / 1_000_000,
+				timer.clientNanos / 1_000_000,
+				timer.rebuildNanos / 1_000_000,
+				timer.searchNanos / 1_000_000,
+				timer.searches);
+		}
+		emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, true);
+	}
+
+	/**
+	 * Per-generation timing breakdown: time blocked on the client thread, time rebuilding
+	 * availability off-thread, and time in the searches. Seed searches run in parallel, so their
+	 * rebuild/search nanos are CPU-summed across workers (can exceed wall time); accumulation from
+	 * worker threads synchronizes on this object.
+	 */
+	private static final class GenTimer
+	{
+		private long clientNanos;
+		private long rebuildNanos;
+		private long searchNanos;
+		private int searches;
+	}
+
+	/**
+	 * Seeds additional routes when the exclusion loop ended early: for each candidate global teleport
+	 * (closest landing to the target first), run one search with every OTHER global teleport excluded,
+	 * so the result is "the best route if you use this teleport". Routes with an already-seen method
+	 * signature, walk-only results, or endpoints meaningfully further than the best route are skipped.
+	 */
+	private void seedTeleportRoutes(int gen, int start, Set<Integer> ends, Set<TeleportMethod> userExclusions,
+		AlternativeRoutesMode mode, int limit, List<Transport> seedCandidates, List<RouteOption> routes,
+		Set<String> seenSignatures, List<TeleportMethod> catalog, Map<TeleportMethod, MethodAvailability> unavailable,
+		ResultListener listener, int bestRemaining, GenTimer timer)
+	{
+		final int target = closestTarget(start, ends);
+		final int startDistance = WorldPointUtil.distanceBetween(start, target);
+
+		// Rank candidates by how close they land to the target; drop ones that don't get closer than
+		// the start, user-excluded methods, and duplicate landings (e.g. tab vs spell to the same tile).
+		final Map<Integer, Transport> byDestination = new LinkedHashMap<>();
+		seedCandidates.sort(Comparator.comparingInt(t -> WorldPointUtil.distanceBetween(t.getDestination(), target)));
+		final Set<TeleportMethod> allSeedMethods = new HashSet<>();
+		for (Transport transport : seedCandidates)
+		{
+			allSeedMethods.add(TeleportMethod.fromTransport(transport));
+		}
+		for (Transport transport : seedCandidates)
+		{
+			if (WorldPointUtil.distanceBetween(transport.getDestination(), target) >= startDistance
+				|| userExclusions.contains(TeleportMethod.fromTransport(transport)))
+			{
+				continue;
+			}
+			byDestination.putIfAbsent(transport.getDestination(), transport);
+		}
+
+		final int maxAttempts = (limit - routes.size()) * 3;
+		final List<Transport> attempts = new ArrayList<>(Math.min(maxAttempts, byDestination.size()));
+		for (Transport seed : byDestination.values())
+		{
+			if (attempts.size() >= maxAttempts)
+			{
+				break;
+			}
+			attempts.add(seed);
+		}
+		if (attempts.isEmpty())
+		{
+			return;
+		}
+
+		// One config per concurrent worker (shares immutable data + the refreshed state); the seed
+		// searches are independent, so they run in parallel on the seed pool. Results are collected
+		// and accepted on this (generation) thread in completion order.
+		final int workers = Math.min(SEED_POOL_SIZE, attempts.size());
+		final Queue<PathfinderConfig> configPool = new ConcurrentLinkedQueue<>();
+		for (int i = 0; i < workers; i++)
+		{
+			configPool.add(planningConfig.copyForParallelSearch());
+		}
+		final AtomicBoolean stop = new AtomicBoolean(false);
+		final CompletionService<SeedResult> completion = new ExecutorCompletionService<>(seedExecutor);
+		final List<Future<SeedResult>> futures = new ArrayList<>(attempts.size());
+		for (Transport seed : attempts)
+		{
+			futures.add(completion.submit(() ->
+				runSeedSearch(gen, stop, start, ends, userExclusions, allSeedMethods, seed, bestRemaining, configPool, timer)));
+		}
+
+		try
+		{
+			for (int i = 0; i < futures.size() && routes.size() < limit && gen == generation.get(); i++)
+			{
+				SeedResult seedResult;
+				try
+				{
+					seedResult = completion.take().get();
+				}
+				catch (ExecutionException e)
+				{
+					log.warn("Seed search failed", e);
+					continue;
+				}
+				if (seedResult == null || !seenSignatures.add(signature(seedResult.scan.methods)))
+				{
+					continue;
+				}
+				routes.add(new RouteOption(seedResult.path, seedResult.scan.methods,
+					seedResult.totalCost, seedResult.reached, seedResult.scan.viaBank));
+				emit(gen, listener, new ArrayList<>(routes), catalog, unavailable, false);
+			}
+		}
+		catch (InterruptedException e)
+		{
+			Thread.currentThread().interrupt();
+		}
+		finally
+		{
+			stop.set(true);
+			for (Future<SeedResult> future : futures)
+			{
+				future.cancel(false);
+			}
+		}
+	}
+
+	/**
+	 * One parallel seed attempt: rebuild availability on a worker-owned config with every other
+	 * global teleport excluded, search, and pre-filter the result. Returns null when rejected.
+	 */
+	private SeedResult runSeedSearch(int gen, AtomicBoolean stop, int start, Set<Integer> ends,
+		Set<TeleportMethod> userExclusions, Set<TeleportMethod> allSeedMethods, Transport seed,
+		int bestRemaining, Queue<PathfinderConfig> configPool, GenTimer timer)
+	{
+		if (gen != generation.get() || stop.get())
+		{
+			return null;
+		}
+		PathfinderConfig config = configPool.poll();
+		if (config == null)
+		{
+			// Should not happen (pool size == max concurrency), but never block on it.
+			config = planningConfig.copyForParallelSearch();
+		}
+		try
+		{
+			// Exclude every other global teleport so the search is forced onto (at most) this one.
+			Set<TeleportMethod> seedExclusions = new HashSet<>(allSeedMethods);
+			seedExclusions.remove(TeleportMethod.fromTransport(seed));
+			seedExclusions.addAll(userExclusions);
+			long rebuildStart = System.nanoTime();
+			config.rebuildAvailabilityWithExclusions(seedExclusions);
+			long searchStart = System.nanoTime();
+			Pathfinder pathfinder = new Pathfinder(config, start, ends);
+			pathfinder.run();
+			long searchEnd = System.nanoTime();
+			synchronized (timer)
+			{
+				timer.rebuildNanos += searchStart - rebuildStart;
+				timer.searchNanos += searchEnd - searchStart;
+				timer.searches++;
+			}
+
+			PathfinderResult result = pathfinder.getResult();
+			List<PathStep> path = (result != null) ? result.getPathSteps() : List.of();
+			if (result == null || path.isEmpty())
+			{
+				return null;
+			}
+			boolean reached = result.isReached();
+			int remaining = reached ? 0 : remainingDistance(path, ends);
+			if (bestRemaining >= 0 && remaining > bestRemaining + CLOSEST_DISTANCE_TOLERANCE)
+			{
+				return null;
+			}
+			MethodScan scan = scanMethods(config, path);
+			if (scan.methods.isEmpty())
+			{
+				// Walk-only: the seed teleport didn't help.
+				return null;
+			}
+			return new SeedResult(path, scan, result.getTotalCost(), reached);
+		}
+		finally
+		{
+			configPool.offer(config);
+		}
+	}
+
+	/**
+	 * A candidate route produced by one parallel seed search, before signature dedup on the
+	 * generation thread.
+	 */
+	private static final class SeedResult
+	{
+		private final List<PathStep> path;
+		private final MethodScan scan;
+		private final int totalCost;
+		private final boolean reached;
+
+		SeedResult(List<PathStep> path, MethodScan scan, int totalCost, boolean reached)
+		{
+			this.path = path;
+			this.scan = scan;
+			this.totalCost = totalCost;
+			this.reached = reached;
+		}
+	}
+
+	private static int remainingDistance(List<PathStep> path, Set<Integer> targets)
+	{
+		int end = path.get(path.size() - 1).getPackedPosition();
+		int best = Integer.MAX_VALUE;
+		for (int target : targets)
+		{
+			best = Math.min(best, WorldPointUtil.distanceBetween(end, target));
+		}
+		return best;
+	}
+
+	private static int closestTarget(int start, Set<Integer> targets)
+	{
+		int best = WorldPointUtil.UNDEFINED;
+		int bestDistance = Integer.MAX_VALUE;
+		for (int target : targets)
+		{
+			int distance = WorldPointUtil.distanceBetween(start, target);
+			if (distance < bestDistance)
+			{
+				bestDistance = distance;
+				best = target;
+			}
+		}
+		return best;
+	}
+
+	private void emit(int gen, ResultListener listener, List<RouteOption> routes,
+		List<TeleportMethod> catalog, Map<TeleportMethod, MethodAvailability> unavailable, boolean done)
+	{
+		if (gen == generation.get())
+		{
+			listener.onUpdate(routes, catalog, unavailable, done);
+		}
+	}
+
+	/**
+	 * Runs {@code setExcludedMethods + refresh} (and, when {@code endsToFilter} is non-null, target
+	 * wilderness filtering) on the client thread and blocks the worker until it completes.
+	 *
+	 * @return false if the client thread did not run the task within the timeout.
+	 */
+	private boolean refreshOnClientThread(Set<TeleportMethod> excluded, Set<Integer> endsToFilter, AlternativeRoutesMode mode)
+	{
+		final Set<TeleportMethod> excludedSnapshot = new HashSet<>(excluded);
+		final CountDownLatch latch = new CountDownLatch(1);
+		clientThread.invokeLater(() ->
+		{
+			try
+			{
+				planningConfig.setPlanningMode(mode == AlternativeRoutesMode.ALL_EVERYTHING);
+				planningConfig.setBypassItemPossession(!mode.isOwned());
+				planningConfig.setConsiderBank(mode == AlternativeRoutesMode.OWNED_WITH_BANK);
+				planningConfig.setExcludedMethods(excludedSnapshot);
+				planningConfig.refresh();
+				if (endsToFilter != null)
+				{
+					planningConfig.filterLocations(endsToFilter, true);
+				}
+			}
+			finally
+			{
+				latch.countDown();
+			}
+		});
+		try
+		{
+			if (!latch.await(CLIENT_THREAD_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+			{
+				log.warn("Timed out waiting for planning config refresh on client thread");
+				return false;
+			}
+			return true;
+		}
+		catch (InterruptedException e)
+		{
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+	/**
+	 * Derives the ordered list of teleport/transport methods a path uses, by inspecting each edge for
+	 * a method-type transport (anything beyond plain walking connectors) whose destination matches.
+	 * Also detects whether any used method is bank-gated (only available in the post-bank state), i.e.
+	 * the route walks to a bank to withdraw the required item first.
+	 */
+	private MethodScan scanMethods(PathfinderConfig config, List<PathStep> path)
+	{
+		List<TeleportMethod> methods = new ArrayList<>();
+		boolean viaBank = false;
+		if (path == null)
+		{
+			return new MethodScan(methods, false);
+		}
+		for (int i = 1; i < path.size(); i++)
+		{
+			PathStep from = path.get(i - 1);
+			PathStep to = path.get(i);
+			boolean bankVisited = from.isBankVisited() || to.isBankVisited();
+			Transport chosen = matchMethodTransport(config, from.getPackedPosition(), to.getPackedPosition(), bankVisited);
+			if (chosen != null)
+			{
+				methods.add(TeleportMethod.fromTransport(chosen));
+				// Bank-gated: used in the post-bank state and not available without the bank.
+				if (bankVisited && !availableWithoutBank(config, from.getPackedPosition(), chosen))
+				{
+					viaBank = true;
+				}
+			}
+		}
+		return new MethodScan(methods, viaBank);
+	}
+
+	private static boolean availableWithoutBank(PathfinderConfig config, int origin, Transport transport)
+	{
+		for (Transport candidate : config.getTransportsPacked(false)
+			.getOrDefault(origin, TransportAvailability.EMPTY_TRANSPORTS))
+		{
+			if (candidate == transport)
+			{
+				return true;
+			}
+		}
+		for (Transport candidate : config.getUsableTeleports(false))
+		{
+			if (candidate == transport)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static final class MethodScan
+	{
+		private final List<TeleportMethod> methods;
+		private final boolean viaBank;
+
+		MethodScan(List<TeleportMethod> methods, boolean viaBank)
+		{
+			this.methods = methods;
+			this.viaBank = viaBank;
+		}
+	}
+
+	private static Transport matchMethodTransport(PathfinderConfig config, int origin, int destination, boolean bankVisited)
+	{
+		// Fixed-origin networks (fairy rings, spirit trees, boats, ...) keyed by their origin tile.
+		Transport[] atOrigin = config.getTransportsPacked(bankVisited)
+			.getOrDefault(origin, TransportAvailability.EMPTY_TRANSPORTS);
+		for (Transport transport : atOrigin)
+		{
+			if (transport.getDestination() == destination && TeleportMethod.isMethodType(transport.getType()))
+			{
+				return transport;
+			}
+		}
+		// Global teleports (spells/items/...): castable from anywhere, so the origin is wherever the
+		// player stood; match purely on destination.
+		for (Transport transport : config.getUsableTeleports(bankVisited))
+		{
+			if (transport.getDestination() == destination && TeleportMethod.isMethodType(transport.getType()))
+			{
+				return transport;
+			}
+		}
+		return null;
+	}
+
+	private static String signature(List<TeleportMethod> methods)
+	{
+		if (methods.isEmpty())
+		{
+			return "<walk-only>";
+		}
+		StringBuilder sb = new StringBuilder();
+		for (TeleportMethod method : methods)
+		{
+			sb.append(method.toString()).append('|');
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/shortestpath/ArrowHead.java
+++ b/src/main/java/shortestpath/ArrowHead.java
@@ -1,0 +1,45 @@
+package shortestpath;
+
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Path2D;
+
+/**
+ * Draws a small triangular arrowhead at the end of a line segment, rotated to the segment's
+ * direction, in the current colour of the graphics context.
+ * <p>
+ * Adapted from Quest Helper's {@code DirectionArrow.drawLineArrowHead}
+ * (Copyright (c) 2021, Zoinkwiz &lt;https://github.com/Zoinkwiz&gt;, BSD 2-Clause licence),
+ * as also used by the port-tasks plugin.
+ */
+public final class ArrowHead
+{
+	private ArrowHead()
+	{
+	}
+
+	/**
+	 * Fills an arrowhead pointing from (x1, y1) towards (x2, y2), with its tip at (x2, y2).
+	 *
+	 * @param size length of the arrowhead in pixels (its width is {@code size})
+	 */
+	public static void draw(Graphics2D graphics, double x1, double y1, double x2, double y2, double size)
+	{
+		Path2D head = new Path2D.Double();
+		head.moveTo(0, 0);
+		head.lineTo(-size / 2.0, -size);
+		head.lineTo(size / 2.0, -size);
+		head.closePath();
+
+		AffineTransform tx = new AffineTransform();
+		double angle = Math.atan2(y2 - y1, x2 - x1);
+		tx.translate(x2, y2);
+		tx.rotate(angle - Math.PI / 2d);
+
+		Graphics2D g = (Graphics2D) graphics.create();
+		// Compose (not replace) so the overlay's existing transform/clip stay intact.
+		g.transform(tx);
+		g.fill(head);
+		g.dispose();
+	}
+}

--- a/src/main/java/shortestpath/IconActionLabel.java
+++ b/src/main/java/shortestpath/IconActionLabel.java
@@ -1,0 +1,45 @@
+package shortestpath;
+
+import java.awt.Cursor;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+
+/**
+ * A clickable icon control, modelled on the tile-packs panel action labels: shows a base icon, swaps
+ * to a hover icon while the cursor is over it, runs an action on left-click, and carries a tooltip.
+ */
+class IconActionLabel extends JLabel
+{
+	IconActionLabel(ImageIcon icon, ImageIcon hoverIcon, String tooltip, Runnable onClick)
+	{
+		setIcon(icon);
+		setToolTipText(tooltip);
+		setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+		addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent e)
+			{
+				if (SwingUtilities.isLeftMouseButton(e))
+				{
+					onClick.run();
+				}
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent e)
+			{
+				setIcon(hoverIcon);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e)
+			{
+				setIcon(icon);
+			}
+		});
+	}
+}

--- a/src/main/java/shortestpath/MethodAvailability.java
+++ b/src/main/java/shortestpath/MethodAvailability.java
@@ -1,0 +1,36 @@
+package shortestpath;
+
+/**
+ * Why a teleport method can or cannot be used right now, for the alternative-routes panel's per-method
+ * status marker. Computed against live game state during the client-thread pathfinder refresh, so the
+ * panel can explain (missing item, in the bank, missing level/quest, not unlocked) why an entry is
+ * greyed out — in every mode, not just the possession-bypassing "All" modes.
+ */
+public enum MethodAvailability
+{
+	/** Usable right now from the inventory/equipment (all unlocks met). */
+	AVAILABLE,
+	/** Owned, but the required item is in the bank — withdraw it or use an "Inventory + bank" mode. */
+	IN_BANK,
+	/** Unlocked, but the required item isn't in the inventory, equipment or bank. */
+	MISSING_ITEM,
+	/** A skill level requirement isn't met. */
+	MISSING_LEVEL,
+	/** A quest requirement isn't met. */
+	MISSING_QUEST,
+	/** An unlock (diary, minigame, purchase, setting, ...) isn't met. */
+	LOCKED;
+
+	/**
+	 * The more-available of two statuses (lower ordinal = more available). Used to collapse the several
+	 * transports that can share one method identity down to a single, best-case status.
+	 */
+	public MethodAvailability best(MethodAvailability other)
+	{
+		if (other == null)
+		{
+			return this;
+		}
+		return ordinal() <= other.ordinal() ? this : other;
+	}
+}

--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -116,16 +116,24 @@ public class PathMapOverlay extends Overlay
 			Color colour = plugin.getPathColor();
 			java.util.List<PathStep> path = plugin.getPathfinder().getPath();
 			Point cursorPos = client.getMouseCanvasPosition();
-			for (int i = 0; i < path.size(); i++)
+			if (TileStyle.ARROW_LINE.equals(plugin.pathStyle))
 			{
 				graphics.setColor(colour);
-				int point = path.get(i).getPackedPosition();
-				int lastPoint = (i > 0) ? path.get(i - 1).getPackedPosition() : point;
-				if (WorldPointUtil.distanceBetween(point, lastPoint) > 1)
+				drawArrowPath(graphics, path);
+			}
+			else
+			{
+				for (int i = 0; i < path.size(); i++)
 				{
-					drawOnMap(graphics, lastPoint, point, true, cursorPos);
+					graphics.setColor(colour);
+					int point = path.get(i).getPackedPosition();
+					int lastPoint = (i > 0) ? path.get(i - 1).getPackedPosition() : point;
+					if (WorldPointUtil.distanceBetween(point, lastPoint) > 1)
+					{
+						drawOnMap(graphics, lastPoint, point, true, cursorPos);
+					}
+					drawOnMap(graphics, point, true, cursorPos);
 				}
-				drawOnMap(graphics, point, true, cursorPos);
 			}
 			for (int target : plugin.getPathfinder().getTargets())
 			{
@@ -138,6 +146,72 @@ public class PathMapOverlay extends Overlay
 		}
 
 		return null;
+	}
+
+	/**
+	 * Draws the path as a directed polyline: consecutive same-direction walking steps are compressed
+	 * into one straight segment, each segment ends in a small arrowhead showing travel direction, and
+	 * teleport/transport jumps are dashed. (Arrowhead technique adapted from Quest Helper's
+	 * DirectionArrow, see {@link ArrowHead}.)
+	 */
+	private void drawArrowPath(Graphics2D graphics, java.util.List<PathStep> path)
+	{
+		final java.awt.Stroke walkStroke = new BasicStroke(2, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
+		final java.awt.Stroke jumpStroke = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[]{9}, 0);
+
+		int i = 0;
+		while (i < path.size() - 1)
+		{
+			int from = path.get(i).getPackedPosition();
+			int next = path.get(i + 1).getPackedPosition();
+
+			if (WorldPointUtil.distanceBetween(from, next) > 1)
+			{
+				// Teleport/transport jump: dashed segment.
+				drawMapSegment(graphics, from, next, jumpStroke);
+				i++;
+				continue;
+			}
+
+			// Extend the straight walking run while the direction stays the same.
+			int dx = WorldPointUtil.unpackWorldX(next) - WorldPointUtil.unpackWorldX(from);
+			int dy = WorldPointUtil.unpackWorldY(next) - WorldPointUtil.unpackWorldY(from);
+			int j = i + 1;
+			while (j < path.size() - 1)
+			{
+				int a = path.get(j).getPackedPosition();
+				int b = path.get(j + 1).getPackedPosition();
+				if (WorldPointUtil.distanceBetween(a, b) > 1
+					|| WorldPointUtil.unpackWorldX(b) - WorldPointUtil.unpackWorldX(a) != dx
+					|| WorldPointUtil.unpackWorldY(b) - WorldPointUtil.unpackWorldY(a) != dy)
+				{
+					break;
+				}
+				j++;
+			}
+			drawMapSegment(graphics, from, path.get(j).getPackedPosition(), walkStroke);
+			i = j;
+		}
+	}
+
+	private void drawMapSegment(Graphics2D graphics, int from, int to, java.awt.Stroke stroke)
+	{
+		int x1 = plugin.mapWorldPointToGraphicsPointX(from);
+		int y1 = plugin.mapWorldPointToGraphicsPointY(from);
+		int x2 = plugin.mapWorldPointToGraphicsPointX(to);
+		int y2 = plugin.mapWorldPointToGraphicsPointY(to);
+		if (x1 == Integer.MIN_VALUE || y1 == Integer.MIN_VALUE
+			|| x2 == Integer.MIN_VALUE || y2 == Integer.MIN_VALUE)
+		{
+			return;
+		}
+		graphics.setStroke(stroke);
+		graphics.drawLine(x1, y1, x2, y2);
+		// Skip the head on segments too short to fit it (e.g. zoomed far out).
+		if (Math.hypot(x2 - x1, y2 - y1) >= 10)
+		{
+			ArrowHead.draw(graphics, x1, y1, x2, y2, 7);
+		}
 	}
 
 	private void drawOnMap(Graphics2D graphics, int point, boolean checkHover, Point cursorPos)

--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -114,7 +114,7 @@ public class PathMapOverlay extends Overlay
 		if (plugin.getPathfinder() != null)
 		{
 			Color colour = plugin.getPathColor();
-			java.util.List<PathStep> path = plugin.getPathfinder().getPath();
+			java.util.List<PathStep> path = plugin.getDisplayPath();
 			Point cursorPos = client.getMouseCanvasPosition();
 			if (TileStyle.ARROW_LINE.equals(plugin.pathStyle))
 			{

--- a/src/main/java/shortestpath/PathMapTooltipOverlay.java
+++ b/src/main/java/shortestpath/PathMapTooltipOverlay.java
@@ -52,7 +52,7 @@ public class PathMapTooltipOverlay extends Overlay
 
 		if (plugin.getPathfinder() != null)
 		{
-			List<PathStep> path = plugin.getPathfinder().getPath();
+			List<PathStep> path = plugin.getDisplayPath();
 			Point cursorPos = client.getMouseCanvasPosition();
 			for (int i = 0; i < path.size(); i++)
 			{
@@ -102,7 +102,7 @@ public class PathMapTooltipOverlay extends Overlay
 		}
 
 		List<String> rows = new ArrayList<>(Arrays.asList("Shortest path:",
-			n < 0 ? "Unused target" : ("Step " + n + " of " + plugin.getPathfinder().getPath().size())));
+			n < 0 ? "Unused target" : ("Step " + n + " of " + path.size())));
 		if (nextPoint != WorldPointUtil.UNDEFINED)
 		{
 			PathStep currentStep = path.get(pathIndex);

--- a/src/main/java/shortestpath/PathMinimapOverlay.java
+++ b/src/main/java/shortestpath/PathMinimapOverlay.java
@@ -65,7 +65,7 @@ public class PathMinimapOverlay extends Overlay
 		}
 		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 
-		java.util.List<PathStep> pathPoints = plugin.getPathfinder().getPath();
+		java.util.List<PathStep> pathPoints = plugin.getDisplayPath();
 		Color pathColor = plugin.getPathColor();
 		for (PathStep point : pathPoints)
 		{

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -7,7 +7,9 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.Stroke;
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -187,13 +189,19 @@ public class PathTileOverlay extends Overlay
 
 			List<PathStep> path = plugin.getPathfinder().getPath();
 			int counter = 0;
-			if (TileStyle.LINES.equals(plugin.pathStyle))
+			if (TileStyle.LINES.equals(plugin.pathStyle) || TileStyle.ARROW_LINE.equals(plugin.pathStyle))
 			{
+				boolean arrows = TileStyle.ARROW_LINE.equals(plugin.pathStyle);
 				for (int i = 1; i < path.size(); i++)
 				{
 					PathStep currentStep = path.get(i - 1);
 					PathStep nextStep = path.get(i);
-					drawLine(graphics, currentStep.getPackedPosition(), nextStep.getPackedPosition(), color, 1 + counter++);
+					// Arrowheads only where they carry information: at direction changes and the end.
+					boolean head = arrows && (i == path.size() - 1
+						|| directionChanges(currentStep.getPackedPosition(), nextStep.getPackedPosition(),
+							path.get(i + 1).getPackedPosition()));
+					drawLine(graphics, currentStep.getPackedPosition(), nextStep.getPackedPosition(), color,
+						1 + counter++, head);
 					drawTransportInfo(graphics, currentStep, nextStep, path, i - 1);
 				}
 			}
@@ -299,7 +307,16 @@ public class PathTileOverlay extends Overlay
 		}
 	}
 
-	private void drawLine(Graphics2D graphics, int startLoc, int endLoc, Color color, int counter)
+	private static boolean directionChanges(int previous, int current, int next)
+	{
+		int dx1 = WorldPointUtil.unpackWorldX(current) - WorldPointUtil.unpackWorldX(previous);
+		int dy1 = WorldPointUtil.unpackWorldY(current) - WorldPointUtil.unpackWorldY(previous);
+		int dx2 = WorldPointUtil.unpackWorldX(next) - WorldPointUtil.unpackWorldX(current);
+		int dy2 = WorldPointUtil.unpackWorldY(next) - WorldPointUtil.unpackWorldY(current);
+		return dx1 != dx2 || dy1 != dy2;
+	}
+
+	private void drawLine(Graphics2D graphics, int startLoc, int endLoc, Color color, int counter, boolean arrowHead)
 	{
 		PrimitiveIntList starts = WorldPointUtil.toLocalInstance(client, startLoc);
 		PrimitiveIntList ends = WorldPointUtil.toLocalInstance(client, endLoc);
@@ -342,6 +359,10 @@ public class PathTileOverlay extends Overlay
 		graphics.setColor(color);
 		graphics.setStroke(new BasicStroke(4));
 		graphics.draw(line);
+		if (arrowHead)
+		{
+			ArrowHead.draw(graphics, p1.getX(), p1.getY(), p2.getX(), p2.getY(), 12);
+		}
 
 		if (counter == 1)
 		{
@@ -408,6 +429,69 @@ public class PathTileOverlay extends Overlay
 			verticalOffset += drawLabelAtCanvasPoint(graphics, p, text, verticalOffset);
 		}
 		return verticalOffset;
+	}
+
+	/**
+	 * A pulsing "teleport from here" highlight: diamond rings expanding out from the tile and fading,
+	 * looping. Drawn every frame (scene overlays repaint continuously) off wall-clock time, so the motion
+	 * stays smooth regardless of game ticks. Anchored to the tile the player casts from — for a
+	 * cast-from-anywhere teleport that sits under the player, drawing the eye to "teleport now".
+	 */
+	private void drawTeleportPulse(Graphics2D graphics, int location)
+	{
+		PrimitiveIntList points = WorldPointUtil.toLocalInstance(client, location);
+		for (int i = 0; i < points.size(); i++)
+		{
+			LocalPoint lp = WorldPointUtil.toLocalPoint(client, points.get(i));
+			if (lp == null)
+			{
+				continue;
+			}
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+			if (poly == null || poly.npoints == 0)
+			{
+				continue;
+			}
+			final double cx = poly.getBounds().getCenterX();
+			final double cy = poly.getBounds().getCenterY();
+
+			final long period = 1400L;
+			final int rings = 2;
+			final Color base = plugin.colourTeleportPulse;
+			final Stroke previousStroke = graphics.getStroke();
+			graphics.setStroke(new BasicStroke(2.2f));
+			for (int r = 0; r < rings; r++)
+			{
+				// Stagger the two rings by half a period so one is always small/bright while the other
+				// is large/faint — a continuous outward pulse.
+				double phase = ((System.currentTimeMillis() + (long) (r * period / (double) rings)) % period)
+					/ (double) period;
+				double scale = 1.0 + phase * 2.6;
+				int alpha = (int) Math.round(170 * (1.0 - phase));
+				if (alpha <= 0)
+				{
+					continue;
+				}
+				Path2D ring = new Path2D.Double();
+				for (int v = 0; v < poly.npoints; v++)
+				{
+					double x = cx + (poly.xpoints[v] - cx) * scale;
+					double y = cy + (poly.ypoints[v] - cy) * scale;
+					if (v == 0)
+					{
+						ring.moveTo(x, y);
+					}
+					else
+					{
+						ring.lineTo(x, y);
+					}
+				}
+				ring.closePath();
+				graphics.setColor(new Color(base.getRed(), base.getGreen(), base.getBlue(), alpha));
+				graphics.draw(ring);
+			}
+			graphics.setStroke(previousStroke);
+		}
 	}
 
 	private double drawLabel(Graphics2D graphics, Point point, String text, int verticalOffset)
@@ -544,6 +628,22 @@ public class PathTileOverlay extends Overlay
 			}
 		}
 		Collection<Transport> transportsToShow = usableTransports.isEmpty() ? candidateTransports : usableTransports;
+
+		// Teleports ("use this item/spell") get a pulsing highlight on the tile you cast from, drawn
+		// once for the edge even if several teleport options share it.
+		boolean teleportEdge = false;
+		for (Transport transport : transportsToShow)
+		{
+			if (transport.getType() != null && transport.getType().isTeleport())
+			{
+				teleportEdge = true;
+				break;
+			}
+		}
+		if (teleportEdge && plugin.showTeleportPulse)
+		{
+			drawTeleportPulse(graphics, location);
+		}
 
 		for (Transport transport : transportsToShow)
 		{

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -173,7 +173,7 @@ public class PathTileOverlay extends Overlay
 			renderCollisionMap(graphics);
 		}
 
-		if (plugin.drawTiles && plugin.getPathfinder() != null && plugin.getPathfinder().getPath() != null)
+		if (plugin.drawTiles && plugin.getPathfinder() != null && !plugin.getDisplayPath().isEmpty())
 		{
 			Color colorCalculating = new Color(
 				plugin.colourPathCalculating.getRed(),
@@ -187,7 +187,7 @@ public class PathTileOverlay extends Overlay
 				pathColor.getBlue(),
 				pathColor.getAlpha() / 2);
 
-			List<PathStep> path = plugin.getPathfinder().getPath();
+			List<PathStep> path = plugin.getDisplayPath();
 			int counter = 0;
 			if (TileStyle.LINES.equals(plugin.pathStyle) || TileStyle.ARROW_LINE.equals(plugin.pathStyle))
 			{
@@ -376,7 +376,7 @@ public class PathTileOverlay extends Overlay
 		if (counter >= 0 && !TileCounter.DISABLED.equals(plugin.showTileCounter))
 		{
 			int n = plugin.tileCounterStep > 0 ? plugin.tileCounterStep : 1;
-			int s = plugin.getPathfinder().getPath().size();
+			int s = plugin.getDisplayPath().size();
 			if ((counter % n != 0) && (s != (counter + 1)))
 			{
 				return;

--- a/src/main/java/shortestpath/RouteIcons.java
+++ b/src/main/java/shortestpath/RouteIcons.java
@@ -1,0 +1,267 @@
+package shortestpath;
+
+import java.awt.AlphaComposite;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+import javax.swing.ImageIcon;
+
+/**
+ * Small 16px UI icons for the alternative-routes panel, rendered with Java2D so the plugin carries no
+ * image assets. Each action has a base (grey) and a hover (accent) variant, mirroring the
+ * base/hover icon swap used by the tile-packs panel controls.
+ */
+final class RouteIcons
+{
+	private static final int SIZE = 16;
+
+	private static final Color GREY = new Color(0xA8, 0xA8, 0xA8);
+	private static final Color LIGHT = new Color(0xED, 0xED, 0xED);
+	private static final Color RED = new Color(0xE3, 0x1C, 0x1C);
+	private static final Color GREEN = new Color(0x4C, 0xAF, 0x50);
+	private static final Color GREEN_LIGHT = new Color(0x7C, 0xD6, 0x80);
+	private static final Color ORANGE = new Color(0xFF, 0x98, 0x1F);
+	private static final Color ORANGE_LIGHT = new Color(0xFF, 0xC0, 0x6A);
+	private static final Color GOLD = new Color(0xF2, 0xC1, 0x4E);
+
+	// Show / hide a route on the map (map pin). Active = currently shown.
+	static final ImageIcon SHOW = new ImageIcon(pin(GREY));
+	static final ImageIcon SHOW_HOVER = new ImageIcon(pin(LIGHT));
+	static final ImageIcon SHOW_ACTIVE = new ImageIcon(pin(ORANGE));
+	static final ImageIcon SHOW_ACTIVE_HOVER = new ImageIcon(pin(ORANGE_LIGHT));
+	// Exclude a method from the next search (no-entry).
+	static final ImageIcon EXCLUDE = new ImageIcon(ban(GREY));
+	static final ImageIcon EXCLUDE_HOVER = new ImageIcon(ban(RED));
+	// Re-include an excluded method (plus).
+	static final ImageIcon INCLUDE = new ImageIcon(plus(GREY));
+	static final ImageIcon INCLUDE_HOVER = new ImageIcon(plus(GREEN));
+	// Recompute routes (circular refresh arrow).
+	static final ImageIcon REFRESH = new ImageIcon(refresh(GREY));
+	static final ImageIcon REFRESH_HOVER = new ImageIcon(refresh(LIGHT));
+	// Clear all exclusions (trash can).
+	static final ImageIcon CLEAR = new ImageIcon(trash(GREY));
+	static final ImageIcon CLEAR_HOVER = new ImageIcon(trash(RED));
+	// Catalog toggles: included (check), excluded (cross), partially-included category (dash).
+	static final ImageIcon CHECK = new ImageIcon(check(GREEN));
+	static final ImageIcon CHECK_HOVER = new ImageIcon(check(GREEN_LIGHT));
+	static final ImageIcon CROSS = new ImageIcon(cross(GREY));
+	static final ImageIcon CROSS_HOVER = new ImageIcon(cross(RED));
+	static final ImageIcon DASH = new ImageIcon(dash(ORANGE));
+	static final ImageIcon DASH_HOVER = new ImageIcon(dash(ORANGE_LIGHT));
+	// Expand/collapse a category.
+	static final ImageIcon CHEVRON_RIGHT = new ImageIcon(chevron(GREY, false));
+	static final ImageIcon CHEVRON_RIGHT_HOVER = new ImageIcon(chevron(LIGHT, false));
+	static final ImageIcon CHEVRON_DOWN = new ImageIcon(chevron(GREY, true));
+	static final ImageIcon CHEVRON_DOWN_HOVER = new ImageIcon(chevron(LIGHT, true));
+	// Method the player can't use right now (missing item/level/quest/unlock).
+	static final ImageIcon LOCKED = new ImageIcon(lock(ORANGE));
+	// Method whose required item is owned but sitting in the bank (route through a bank to grab it).
+	static final ImageIcon IN_BANK = new ImageIcon(coins(GOLD));
+
+	private RouteIcons()
+	{
+	}
+
+	private interface Drawer
+	{
+		void draw(Graphics2D g);
+	}
+
+	private static BufferedImage render(Drawer drawer)
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = image.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+		g.setStroke(new BasicStroke(1.7f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+		drawer.draw(g);
+		g.dispose();
+		return image;
+	}
+
+	private static BufferedImage pin(Color colour)
+	{
+		return render(g ->
+		{
+			final double cx = 8, cy = 6.4, r = 4.0;
+			Path2D body = new Path2D.Double();
+			body.moveTo(cx - 3.0, cy + 1.6);
+			body.curveTo(cx - 2.0, cy + 4.4, cx - 0.5, cy + 5.4, cx, 14.6);
+			body.curveTo(cx + 0.5, cy + 5.4, cx + 2.0, cy + 4.4, cx + 3.0, cy + 1.6);
+			body.closePath();
+			g.setColor(colour);
+			g.fill(new Ellipse2D.Double(cx - r, cy - r, 2 * r, 2 * r));
+			g.fill(body);
+			g.setComposite(AlphaComposite.Clear);
+			final double hr = 1.65;
+			g.fill(new Ellipse2D.Double(cx - hr, cy - hr, 2 * hr, 2 * hr));
+			g.setComposite(AlphaComposite.SrcOver);
+		});
+	}
+
+	private static BufferedImage ban(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			final double m = 1.7, d = SIZE - 2 * m;
+			g.draw(new Ellipse2D.Double(m, m, d, d));
+			g.draw(new Line2D.Double(5.0, 8.0, 11.0, 8.0));
+		});
+	}
+
+	private static BufferedImage plus(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			final double m = 1.7, d = SIZE - 2 * m;
+			g.draw(new Ellipse2D.Double(m, m, d, d));
+			g.draw(new Line2D.Double(8, 5, 8, 11));
+			g.draw(new Line2D.Double(5, 8, 11, 8));
+		});
+	}
+
+	private static BufferedImage refresh(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			final double m = 2.6, d = SIZE - 2 * m;
+			final double start = 65, extent = 250;
+			Arc2D arc = new Arc2D.Double(m, m, d, d, start, extent, Arc2D.OPEN);
+			g.draw(arc);
+			Point2D p0 = arc.getStartPoint();
+			Point2D p1 = new Arc2D.Double(m, m, d, d, start + 5, 1, Arc2D.OPEN).getStartPoint();
+			double angle = Math.atan2(p0.getY() - p1.getY(), p0.getX() - p1.getX());
+			arrowHead(g, p0.getX(), p0.getY(), angle, 3.4, colour);
+		});
+	}
+
+	private static BufferedImage trash(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			g.draw(new Line2D.Double(3.5, 4.6, 12.5, 4.6));
+			g.draw(new Line2D.Double(6.5, 4.6, 6.5, 3.2));
+			g.draw(new Line2D.Double(9.5, 4.6, 9.5, 3.2));
+			g.draw(new Line2D.Double(6.5, 3.2, 9.5, 3.2));
+			Path2D body = new Path2D.Double();
+			body.moveTo(4.4, 5.4);
+			body.lineTo(5.2, 13.0);
+			body.lineTo(10.8, 13.0);
+			body.lineTo(11.6, 5.4);
+			g.draw(body);
+			g.draw(new Line2D.Double(6.6, 6.4, 6.9, 12.0));
+			g.draw(new Line2D.Double(8.0, 6.4, 8.0, 12.0));
+			g.draw(new Line2D.Double(9.4, 6.4, 9.1, 12.0));
+		});
+	}
+
+	private static BufferedImage check(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			g.setStroke(new BasicStroke(1.9f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+			Path2D tick = new Path2D.Double();
+			tick.moveTo(3.5, 8.5);
+			tick.lineTo(6.6, 11.6);
+			tick.lineTo(12.5, 4.5);
+			g.draw(tick);
+		});
+	}
+
+	private static BufferedImage cross(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			g.setStroke(new BasicStroke(1.9f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+			g.draw(new Line2D.Double(4.2, 4.2, 11.8, 11.8));
+			g.draw(new Line2D.Double(11.8, 4.2, 4.2, 11.8));
+		});
+	}
+
+	private static BufferedImage dash(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			g.setStroke(new BasicStroke(1.9f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+			g.draw(new Line2D.Double(4.0, 8.0, 12.0, 8.0));
+		});
+	}
+
+	private static BufferedImage lock(Color colour)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			// Shackle
+			g.draw(new Arc2D.Double(4.75, 2.5, 6.5, 7.5, 0, 180, Arc2D.OPEN));
+			// Body
+			g.fillRoundRect(3, 7, 10, 6, 3, 3);
+		});
+	}
+
+	private static BufferedImage coins(Color colour)
+	{
+		return render(g ->
+		{
+			g.setStroke(new BasicStroke(1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+			final double x = 3.5, w = 9.0, h = 3.4;
+			// Bottom-to-top so the upper coins overlap the lower ones, reading as a stack.
+			final double[] ys = {9.6, 7.0, 4.4};
+			for (double y : ys)
+			{
+				g.setColor(colour);
+				g.fill(new Ellipse2D.Double(x, y, w, h));
+				g.setColor(colour.darker());
+				g.draw(new Ellipse2D.Double(x, y, w, h));
+			}
+		});
+	}
+
+	private static BufferedImage chevron(Color colour, boolean down)
+	{
+		return render(g ->
+		{
+			g.setColor(colour);
+			Path2D triangle = new Path2D.Double();
+			if (down)
+			{
+				triangle.moveTo(4.5, 6.0);
+				triangle.lineTo(11.5, 6.0);
+				triangle.lineTo(8.0, 11.0);
+			}
+			else
+			{
+				triangle.moveTo(6.0, 4.5);
+				triangle.lineTo(11.0, 8.0);
+				triangle.lineTo(6.0, 11.5);
+			}
+			triangle.closePath();
+			g.fill(triangle);
+		});
+	}
+
+	private static void arrowHead(Graphics2D g, double x, double y, double angle, double size, Color colour)
+	{
+		Path2D head = new Path2D.Double();
+		head.moveTo(x, y);
+		head.lineTo(x - size * Math.cos(angle - Math.PI / 6), y - size * Math.sin(angle - Math.PI / 6));
+		head.lineTo(x - size * Math.cos(angle + Math.PI / 6), y - size * Math.sin(angle + Math.PI / 6));
+		head.closePath();
+		g.setColor(colour);
+		g.fill(head);
+	}
+}

--- a/src/main/java/shortestpath/RouteOption.java
+++ b/src/main/java/shortestpath/RouteOption.java
@@ -1,0 +1,60 @@
+package shortestpath;
+
+import java.util.List;
+import lombok.Getter;
+import shortestpath.pathfinder.PathStep;
+
+/**
+ * One alternative route to the target, produced by {@link AlternativeRoutesService}. Each route is a
+ * shortest path under the constraint that it uses a different set of teleport/transport methods than
+ * the other routes in the same result list.
+ */
+@Getter
+public final class RouteOption
+{
+	/**
+	 * The full tile path, as returned by the pathfinder.
+	 */
+	private final List<PathStep> path;
+	/**
+	 * The teleport/transport methods used along the path, in travel order. Empty for a walk-only route.
+	 */
+	private final List<TeleportMethod> methods;
+	/**
+	 * Blended search cost (walk distance + transport ticks/penalties); lower is shorter.
+	 */
+	private final int totalCost;
+	/**
+	 * Whether the path actually reaches the exact target. When false it ends at the closest reachable
+	 * tile (mirrors Shortest Path's own behaviour for unreachable targets, e.g. an NPC/object tile).
+	 */
+	private final boolean reached;
+	/**
+	 * Whether one of this route's methods requires an item that must first be withdrawn from the bank
+	 * (the path includes a walk to a bank before that method is used).
+	 */
+	private final boolean viaBank;
+
+	public RouteOption(List<PathStep> path, List<TeleportMethod> methods, int totalCost, boolean reached,
+		boolean viaBank)
+	{
+		this.path = path;
+		this.methods = methods;
+		this.totalCost = totalCost;
+		this.reached = reached;
+		this.viaBank = viaBank;
+	}
+
+	/**
+	 * The method the route leans on first; the one the panel offers to exclude. Null for walk-only.
+	 */
+	public TeleportMethod primaryMethod()
+	{
+		return methods.isEmpty() ? null : methods.get(0);
+	}
+
+	public boolean isWalkOnly()
+	{
+		return methods.isEmpty();
+	}
+}

--- a/src/main/java/shortestpath/RouteOption.java
+++ b/src/main/java/shortestpath/RouteOption.java
@@ -26,6 +26,11 @@ public final class RouteOption
 	 */
 	private final int totalCost;
 	/**
+	 * The path's cost without any configured weights: walking distance plus transport travel times
+	 * only. Equal to {@link #totalCost} when no weights applied to this route.
+	 */
+	private final int rawCost;
+	/**
 	 * Whether the path actually reaches the exact target. When false it ends at the closest reachable
 	 * tile (mirrors Shortest Path's own behaviour for unreachable targets, e.g. an NPC/object tile).
 	 */
@@ -36,15 +41,35 @@ public final class RouteOption
 	 * bank visit. Lets the panel say <em>which</em> method the bank detour is for.
 	 */
 	private final Set<TeleportMethod> bankMethods;
+	/**
+	 * Tiles walked before each method, parallel to {@link #methods} (walking to a minecart, a fairy
+	 * ring, a bank, ...). Plain connectors along the way (doors, stairs, shortcuts) count into the leg.
+	 */
+	private final List<Integer> walkBeforeSteps;
+	/**
+	 * Tiles walked after the last method to the destination; the whole walk for walk-only routes.
+	 */
+	private final int trailingWalkSteps;
 
-	public RouteOption(List<PathStep> path, List<TeleportMethod> methods, int totalCost, boolean reached,
-		Set<TeleportMethod> bankMethods)
+	public RouteOption(List<PathStep> path, List<TeleportMethod> methods, int totalCost, int rawCost,
+		boolean reached, Set<TeleportMethod> bankMethods, List<Integer> walkBeforeSteps, int trailingWalkSteps)
 	{
 		this.path = path;
 		this.methods = methods;
 		this.totalCost = totalCost;
+		this.rawCost = rawCost;
 		this.reached = reached;
 		this.bankMethods = bankMethods;
+		this.walkBeforeSteps = walkBeforeSteps;
+		this.trailingWalkSteps = trailingWalkSteps;
+	}
+
+	/**
+	 * Tiles walked before the method at {@code index}, or 0 when unknown.
+	 */
+	public int walkBefore(int index)
+	{
+		return (index >= 0 && index < walkBeforeSteps.size()) ? walkBeforeSteps.get(index) : 0;
 	}
 
 	/**

--- a/src/main/java/shortestpath/RouteOption.java
+++ b/src/main/java/shortestpath/RouteOption.java
@@ -1,6 +1,7 @@
 package shortestpath;
 
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import shortestpath.pathfinder.PathStep;
 
@@ -30,19 +31,28 @@ public final class RouteOption
 	 */
 	private final boolean reached;
 	/**
-	 * Whether one of this route's methods requires an item that must first be withdrawn from the bank
-	 * (the path includes a walk to a bank before that method is used).
+	 * The subset of {@link #methods} that require an item that must first be withdrawn from the bank —
+	 * the path includes a walk to a bank before each of these is used. Empty when the route needs no
+	 * bank visit. Lets the panel say <em>which</em> method the bank detour is for.
 	 */
-	private final boolean viaBank;
+	private final Set<TeleportMethod> bankMethods;
 
 	public RouteOption(List<PathStep> path, List<TeleportMethod> methods, int totalCost, boolean reached,
-		boolean viaBank)
+		Set<TeleportMethod> bankMethods)
 	{
 		this.path = path;
 		this.methods = methods;
 		this.totalCost = totalCost;
 		this.reached = reached;
-		this.viaBank = viaBank;
+		this.bankMethods = bankMethods;
+	}
+
+	/**
+	 * Whether one of this route's methods requires a bank withdrawal first (see {@link #bankMethods}).
+	 */
+	public boolean isViaBank()
+	{
+		return !bankMethods.isEmpty();
 	}
 
 	/**

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -975,6 +975,22 @@ public interface ShortestPathConfig extends Config
 		return 0;
 	}
 
+	@Range(
+		max = 10000
+	)
+	@ConfigItem(
+		keyName = "costBankPickup",
+		name = "Bank pick-up threshold",
+		description = "How many extra tiles routing through a bank (to withdraw a required teleport item)<br>" +
+			"must save to be preferred over walking or other transports",
+		position = 69,
+		section = sectionThresholds
+	)
+	default int costBankPickup()
+	{
+		return 0;
+	}
+
 	@ConfigSection(
 		name = "Display",
 		description = "Options for displaying the path on the world map, minimap and scene tiles",

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -468,6 +468,33 @@ public interface ShortestPathConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "defaultRouteCount",
+		name = "Routes to find",
+		description = "How many alternative routes the side panel searches for by default<br>" +
+			"(the panel's \"Show more\" button can extend this per query)",
+		position = 36,
+		section = sectionSettings
+	)
+	@Range(min = 1, max = 25)
+	default int defaultRouteCount()
+	{
+		return 10;
+	}
+
+	@ConfigItem(
+		keyName = "routeCountStep",
+		name = "Show more increment",
+		description = "How many extra alternative routes the panel's \"Show more\" button fetches each time",
+		position = 37,
+		section = sectionSettings
+	)
+	@Range(min = 1, max = 25)
+	default int routeCountStep()
+	{
+		return 5;
+	}
+
 	@ConfigSection(
 		name = "Player-Owned House",
 		description = "Options for POH (Player-Owned House) teleports",

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -1021,13 +1021,25 @@ public interface ShortestPathConfig extends Config
 	@ConfigItem(
 		keyName = "pathStyle",
 		name = "Path style",
-		description = "Whether to display the path as tiles or a segmented line",
+		description = "Whether to display the path as tiles, a segmented line, or a line with direction arrows",
 		position = 73,
 		section = sectionDisplay
 	)
 	default TileStyle pathStyle()
 	{
 		return TileStyle.TILES;
+	}
+
+	@ConfigItem(
+		keyName = "showTeleportPulse",
+		name = "Teleport pulse",
+		description = "Animate a pulsing highlight on the tile when the path tells you to use a teleport",
+		position = 74,
+		section = sectionDisplay
+	)
+	default boolean showTeleportPulse()
+	{
+		return true;
 	}
 
 	@ConfigSection(
@@ -1114,6 +1126,18 @@ public interface ShortestPathConfig extends Config
 	default Color colourText()
 	{
 		return Color.WHITE;
+	}
+
+	@ConfigItem(
+		keyName = "colourTeleportPulse",
+		name = "Teleport pulse",
+		description = "Colour of the pulsing teleport highlight",
+		position = 81,
+		section = sectionColours
+	)
+	default Color colourTeleportPulse()
+	{
+		return new Color(0, 255, 255);
 	}
 
 	@ConfigSection(

--- a/src/main/java/shortestpath/ShortestPathPanel.java
+++ b/src/main/java/shortestpath/ShortestPathPanel.java
@@ -267,9 +267,7 @@ public class ShortestPathPanel extends PluginPanel
 		{
 			// Shortest Path has no active target. (Quest Helper draws its own line for some steps and
 			// doesn't hand Shortest Path a destination — set one on the map to find routes.)
-			status = "No Shortest Path destination set."
-				+ "<br>Quest Helper draws its own line for some steps."
-				+ "<br>Set a target on the map, then press \"Refresh routes\".";
+			status = "No Shortest Path destination set.";
 		}
 		// The bank container is only populated once the bank has been opened this session; without it
 		// Bank mode cannot see banked teleports (same constraint as Shortest Path itself).
@@ -361,8 +359,9 @@ public class ShortestPathPanel extends PluginPanel
 		methods.setBorder(new EmptyBorder(2, 6, 4, 4));
 		if (route.isViaBank())
 		{
-			methods.add(noteRow("<i>Walks to a bank first to withdraw the item</i>",
-				"A required teleport item is in your bank — the drawn path includes the walk to a bank to pick it up before teleporting"));
+			methods.add(noteRow("<i>Walks to a bank first — withdraws the item for "
+					+ escapeHtml(joinLabels(route.getBankMethods())) + "</i>",
+				"The marked method needs an item from your bank — the drawn path includes the walk to a bank to pick it up first"));
 		}
 		if (route.isWalkOnly())
 		{
@@ -372,7 +371,7 @@ public class ShortestPathPanel extends PluginPanel
 		{
 			for (TeleportMethod method : route.getMethods())
 			{
-				methods.add(buildMethodRow(method));
+				methods.add(buildMethodRow(method, route.getBankMethods()));
 			}
 		}
 		card.add(methods, BorderLayout.CENTER);
@@ -384,9 +383,11 @@ public class ShortestPathPanel extends PluginPanel
 	}
 
 	/**
-	 * A route-card method row: category dot + wrapped label + an exclude (✕) icon.
+	 * A route-card method row: category dot + wrapped label + an exclude (✕) icon. Methods whose
+	 * required item must first be withdrawn from the bank get a bank glyph, so it's clear which
+	 * method the route's bank detour is for.
 	 */
-	private JPanel buildMethodRow(TeleportMethod method)
+	private JPanel buildMethodRow(TeleportMethod method, Set<TeleportMethod> bankMethods)
 	{
 		JPanel row = new JPanel(new BorderLayout(5, 0));
 		row.setOpaque(false);
@@ -396,12 +397,22 @@ public class ShortestPathPanel extends PluginPanel
 		dot.setBorder(new EmptyBorder(2, 0, 0, 0));
 		dot.setToolTipText(method.category());
 		MethodAvailability status = cachedUnavailable.get(method);
-		if (status != null)
+		boolean bankGated = bankMethods.contains(method);
+		if (status != null || bankGated)
 		{
 			JPanel west = new JPanel(new FlowLayout(FlowLayout.LEFT, 2, 0));
 			west.setOpaque(false);
 			west.add(dot);
-			west.add(statusLabel(status));
+			if (bankGated)
+			{
+				JLabel bankMarker = new JLabel(RouteIcons.IN_BANK);
+				bankMarker.setToolTipText("This method needs an item from your bank — the route walks to a bank to withdraw it first");
+				west.add(bankMarker);
+			}
+			if (status != null)
+			{
+				west.add(statusLabel(status));
+			}
 			row.add(west, BorderLayout.WEST);
 		}
 		else
@@ -634,6 +645,25 @@ public class ShortestPathPanel extends PluginPanel
 			expandedCategories.remove(category);
 		}
 		render();
+	}
+
+	/**
+	 * Human list of method labels, e.g. "Fairy ring" or "Fairy ring and Cowbell amulet".
+	 */
+	private static String joinLabels(Set<TeleportMethod> methods)
+	{
+		StringBuilder joined = new StringBuilder();
+		int i = 0;
+		for (TeleportMethod method : methods)
+		{
+			if (i > 0)
+			{
+				joined.append(i == methods.size() - 1 ? " and " : ", ");
+			}
+			joined.append(method.label());
+			i++;
+		}
+		return joined.toString();
 	}
 
 	private String methodTooltip(TeleportMethod method)

--- a/src/main/java/shortestpath/ShortestPathPanel.java
+++ b/src/main/java/shortestpath/ShortestPathPanel.java
@@ -1,0 +1,785 @@
+package shortestpath;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.RenderingHints;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.PluginPanel;
+
+/**
+ * The "view": lists up to {@link AlternativeRoutesService#MAX_ROUTES} alternative routes to the
+ * target, then — below them — the full catalog of teleport/transport methods for the current mode,
+ * grouped into collapsible categories with per-method and per-category include/exclude toggles.
+ * <p>
+ * The route cards and the catalog share one exclusion set: the ✕ on a route's method and the
+ * check/cross in the catalog flip the same state. Clicking a route card shows it on the world map.
+ * Built on the tile-packs style: small icon controls with hover states and tooltips.
+ */
+public class ShortestPathPanel extends PluginPanel
+{
+	private static final int CONTROL_SIZE = 18;
+	private static final int METHOD_TEXT_WIDTH = 132;
+
+	// Stable, distinct-ish palette; categories hash into it so the same category always gets the
+	// same dot colour.
+	private static final Color[] CATEGORY_PALETTE =
+	{
+		new Color(0x5B, 0x9B, 0xD5), // blue
+		new Color(0x4C, 0xAF, 0x50), // green
+		new Color(0xE9, 0x7D, 0x3B), // orange
+		new Color(0xB4, 0x6F, 0xD4), // purple
+		new Color(0x4D, 0xB6, 0xAC), // teal
+		new Color(0xE5, 0x73, 0x99), // pink
+		new Color(0xC0, 0xA8, 0x3B), // gold
+		new Color(0x7E, 0x8C, 0x9A), // slate
+		new Color(0x8B, 0xC3, 0x4A), // lime
+		new Color(0xD1, 0x5B, 0x5B), // red
+	};
+
+	private final ShortestPathPlugin plugin;
+	private final JLabel statusLabel = new JLabel();
+	private final JPanel listPanel = new JPanel();
+	private JButton ownedButton;
+	private JButton allButton;
+	private JButton variantOneButton;
+	private JButton variantTwoButton;
+
+	// Cached last render input so expand/collapse can re-render without a round-trip to the plugin.
+	private List<RouteOption> cachedRoutes = List.of();
+	private List<TeleportMethod> cachedCatalog = List.of();
+	private Map<TeleportMethod, MethodAvailability> cachedUnavailable = Map.of();
+	private Set<TeleportMethod> cachedExclusions = Set.of();
+	private boolean cachedCalculating = false;
+	private boolean cachedHasTarget = false;
+	private final Set<String> expandedCategories = new HashSet<>();
+	// Whether the whole "Teleport methods" catalog section (shown at the top) is expanded. Collapsed
+	// by default so the routes stay the focus; the user opens it to browse/toggle methods.
+	private boolean catalogExpanded = false;
+
+	public ShortestPathPanel(ShortestPathPlugin plugin)
+	{
+		super(false);
+		this.plugin = plugin;
+		setLayout(new BorderLayout());
+		setBorder(new EmptyBorder(8, 8, 8, 8));
+		setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		add(buildHeader(), BorderLayout.NORTH);
+
+		listPanel.setLayout(new BoxLayout(listPanel, BoxLayout.Y_AXIS));
+		listPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		// Top-anchor the content so a short list keeps each row at its natural height.
+		JPanel listWrapper = new JPanel(new BorderLayout());
+		listWrapper.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		listWrapper.add(listPanel, BorderLayout.NORTH);
+		JScrollPane scroll = new JScrollPane(listWrapper,
+			ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+			ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		scroll.setBorder(BorderFactory.createEmptyBorder());
+		scroll.getVerticalScrollBar().setUnitIncrement(16);
+		// The sidebar scrollbar overlays the content (it doesn't shrink the viewport), so it clips the
+		// right edge of full-width cards. Reserve a matching gutter on the scrolling content for it.
+		int scrollbarWidth = scroll.getVerticalScrollBar().getPreferredSize().width;
+		listPanel.setBorder(new EmptyBorder(0, 0, 0, scrollbarWidth > 0 ? scrollbarWidth : 12));
+		add(scroll, BorderLayout.CENTER);
+
+		render();
+	}
+
+	private JPanel buildHeader()
+	{
+		JPanel header = new JPanel(new BorderLayout());
+		header.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		header.setBorder(new EmptyBorder(0, 0, 8, 0));
+
+		JPanel titleRow = new JPanel(new BorderLayout());
+		titleRow.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JLabel title = new JLabel("Alternative routes");
+		title.setFont(FontManager.getRunescapeBoldFont());
+		title.setForeground(ColorScheme.BRAND_ORANGE);
+		titleRow.add(title, BorderLayout.WEST);
+
+		JPanel actions = new JPanel(new FlowLayout(FlowLayout.TRAILING, 6, 0));
+		actions.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		actions.add(control(new IconActionLabel(RouteIcons.CLEAR, RouteIcons.CLEAR_HOVER,
+			"Re-include all excluded methods", plugin::clearExclusions)));
+		titleRow.add(actions, BorderLayout.EAST);
+
+		header.add(titleRow, BorderLayout.NORTH);
+
+		JPanel bottom = new JPanel(new BorderLayout());
+		bottom.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		// Two-level mode picker: family (Owned / All) on top, its two variants indented beneath so they
+		// read as sub-options of whichever family is selected.
+		JPanel modeRows = new JPanel(new BorderLayout(0, 4));
+		modeRows.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		modeRows.setBorder(new EmptyBorder(8, 0, 0, 0));
+
+		JPanel familyRow = new JPanel(new GridLayout(1, 2, 4, 0));
+		familyRow.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		ownedButton = new JButton("Owned");
+		ownedButton.setToolTipText("Only methods whose items you actually possess");
+		ownedButton.setFocusPainted(false);
+		ownedButton.addActionListener(e -> plugin.setRoutesMode(
+			plugin.getRoutesMode().isSecondVariant()
+				? AlternativeRoutesMode.OWNED_WITH_BANK : AlternativeRoutesMode.OWNED_INVENTORY));
+		allButton = new JButton("All");
+		allButton.setToolTipText("Ignore item possession");
+		allButton.setFocusPainted(false);
+		allButton.addActionListener(e -> plugin.setRoutesMode(
+			plugin.getRoutesMode().isSecondVariant()
+				? AlternativeRoutesMode.ALL_EVERYTHING : AlternativeRoutesMode.ALL_UNLOCKED));
+		familyRow.add(ownedButton);
+		familyRow.add(allButton);
+		modeRows.add(familyRow, BorderLayout.NORTH);
+
+		JPanel variantRow = new JPanel(new GridLayout(1, 2, 4, 0));
+		variantRow.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		variantOneButton = new JButton();
+		variantOneButton.setFont(FontManager.getRunescapeSmallFont());
+		variantOneButton.setFocusPainted(false);
+		variantOneButton.addActionListener(e -> plugin.setRoutesMode(
+			plugin.getRoutesMode().isOwned()
+				? AlternativeRoutesMode.OWNED_INVENTORY : AlternativeRoutesMode.ALL_UNLOCKED));
+		variantTwoButton = new JButton();
+		variantTwoButton.setFont(FontManager.getRunescapeSmallFont());
+		variantTwoButton.setFocusPainted(false);
+		variantTwoButton.addActionListener(e -> plugin.setRoutesMode(
+			plugin.getRoutesMode().isOwned()
+				? AlternativeRoutesMode.OWNED_WITH_BANK : AlternativeRoutesMode.ALL_EVERYTHING));
+		variantRow.add(variantOneButton);
+		variantRow.add(variantTwoButton);
+
+		// Nest the variants under the family row: a short left indent, a vertical rail acting as the
+		// "belongs to" connector, then the two variant buttons.
+		JPanel variantNest = new JPanel(new BorderLayout());
+		variantNest.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		JPanel rail = new JPanel();
+		rail.setBackground(ColorScheme.MEDIUM_GRAY_COLOR);
+		rail.setPreferredSize(new Dimension(2, 1));
+		JPanel railWrap = new JPanel(new BorderLayout());
+		railWrap.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		railWrap.setBorder(new EmptyBorder(0, 10, 0, 6));
+		railWrap.add(rail, BorderLayout.CENTER);
+		variantNest.add(railWrap, BorderLayout.WEST);
+		variantNest.add(variantRow, BorderLayout.CENTER);
+		modeRows.add(variantNest, BorderLayout.CENTER);
+
+		bottom.add(modeRows, BorderLayout.NORTH);
+
+		JPanel lower = new JPanel(new BorderLayout());
+		lower.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		JButton findButton = new JButton("Refresh routes to target");
+		findButton.setToolTipText("Recalculate alternative routes to the destination Shortest Path is currently set to");
+		findButton.setFocusPainted(false);
+		findButton.addActionListener(e -> plugin.recomputeAlternatives());
+		JPanel findWrap = new JPanel(new BorderLayout());
+		findWrap.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		findWrap.setBorder(new EmptyBorder(8, 0, 0, 0));
+		findWrap.add(findButton, BorderLayout.CENTER);
+		lower.add(findWrap, BorderLayout.NORTH);
+
+		statusLabel.setFont(FontManager.getRunescapeSmallFont());
+		statusLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		statusLabel.setBorder(new EmptyBorder(6, 0, 0, 0));
+		lower.add(statusLabel, BorderLayout.SOUTH);
+
+		bottom.add(lower, BorderLayout.SOUTH);
+
+		header.add(bottom, BorderLayout.SOUTH);
+
+		updateModeButtons();
+		return header;
+	}
+
+	/**
+	 * Stores the latest data and re-renders. Must be called on the Swing EDT.
+	 */
+	public void displayRoutes(List<RouteOption> routes, List<TeleportMethod> catalog,
+		Map<TeleportMethod, MethodAvailability> unavailable, Set<TeleportMethod> exclusions,
+		boolean calculating, boolean hasTarget)
+	{
+		cachedRoutes = routes != null ? routes : List.of();
+		cachedCatalog = catalog != null ? catalog : List.of();
+		cachedUnavailable = unavailable != null ? unavailable : Map.of();
+		cachedExclusions = exclusions != null ? exclusions : Set.of();
+		cachedCalculating = calculating;
+		cachedHasTarget = hasTarget;
+		render();
+	}
+
+	private void render()
+	{
+		updateModeButtons();
+		listPanel.removeAll();
+
+		String status;
+		if (cachedCalculating)
+		{
+			status = cachedRoutes.isEmpty()
+				? "Calculating routes…"
+				: ("Calculating… (" + cachedRoutes.size() + " so far)");
+		}
+		else if (!cachedRoutes.isEmpty())
+		{
+			status = cachedRoutes.size() + (cachedRoutes.size() == 1 ? " route found" : " routes found");
+		}
+		else if (cachedHasTarget)
+		{
+			// A search ran for the current target but produced nothing — distinct from "no target set".
+			status = "No routes found to the target."
+				+ (plugin.getRoutesMode() == AlternativeRoutesMode.ALL_EVERYTHING ? "" : "<br>Try a broader mode (Inv + bank, or All).");
+		}
+		else
+		{
+			// Shortest Path has no active target. (Quest Helper draws its own line for some steps and
+			// doesn't hand Shortest Path a destination — set one on the map to find routes.)
+			status = "No Shortest Path destination set."
+				+ "<br>Quest Helper draws its own line for some steps."
+				+ "<br>Set a target on the map, then press \"Refresh routes\".";
+		}
+		// The bank container is only populated once the bank has been opened this session; without it
+		// Bank mode cannot see banked teleports (same constraint as Shortest Path itself).
+		if (plugin.getRoutesMode() == AlternativeRoutesMode.OWNED_WITH_BANK && !plugin.isBankContentsKnown())
+		{
+			status += "<br><b>Bank contents unknown</b> — open your bank once so banked teleports can be found.";
+		}
+		statusLabel.setText("<html>" + status + "</html>");
+
+		// The teleport-methods catalog sits at the top (collapsed by default), so browsing/toggling
+		// methods is always one click away above the routes.
+		if (!cachedCatalog.isEmpty())
+		{
+			listPanel.add(buildCatalogSection());
+			listPanel.add(verticalGap(8));
+		}
+
+		// Routes are shown as they stream in (even while still calculating). The previous list was
+		// cleared when this generation started, so only the new routes appear. The highlighted card is
+		// the route actually drawn on the map — the explicitly selected one, or route 1 by default.
+		RouteOption selected = plugin.getDisplayedRoute();
+		for (int i = 0; i < cachedRoutes.size(); i++)
+		{
+			listPanel.add(buildRouteCard(i, cachedRoutes.get(i), cachedRoutes.get(i) == selected));
+			listPanel.add(verticalGap(4));
+		}
+		// Only offer "show more" once this generation has finished.
+		if (!cachedCalculating && !cachedRoutes.isEmpty() && plugin.canLoadMoreRoutes())
+		{
+			listPanel.add(buildShowMoreButton());
+			listPanel.add(verticalGap(4));
+		}
+
+		listPanel.revalidate();
+		listPanel.repaint();
+	}
+
+	private JPanel buildShowMoreButton()
+	{
+		JPanel wrap = new JPanel(new BorderLayout());
+		wrap.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		wrap.setAlignmentX(Component.LEFT_ALIGNMENT);
+		wrap.setMaximumSize(new Dimension(Integer.MAX_VALUE, 26));
+		JButton more = new JButton("Show more routes");
+		more.setFocusPainted(false);
+		more.setToolTipText("Search for more alternative routes");
+		more.addActionListener(e -> plugin.loadMoreRoutes());
+		wrap.add(more, BorderLayout.CENTER);
+		return wrap;
+	}
+
+	private JPanel buildRouteCard(int index, RouteOption route, boolean selected)
+	{
+		JPanel card = new JPanel(new BorderLayout());
+		card.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		card.setBorder(BorderFactory.createLineBorder(
+			selected ? ColorScheme.BRAND_ORANGE : ColorScheme.MEDIUM_GRAY_COLOR));
+		card.setAlignmentX(Component.LEFT_ALIGNMENT);
+		card.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		JPanel topRow = new JPanel(new BorderLayout());
+		topRow.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		topRow.setBorder(new EmptyBorder(3, 6, 3, 4));
+
+		JLabel name = new JLabel("Route " + (index + 1));
+		name.setFont(FontManager.getRunescapeBoldFont());
+		name.setForeground(selected ? ColorScheme.BRAND_ORANGE : ColorScheme.LIGHT_GRAY_COLOR);
+		if (!route.isReached())
+		{
+			name.setToolTipText("The exact target isn't reachable — this ends at the closest reachable tile");
+		}
+		topRow.add(name, BorderLayout.WEST);
+
+		JPanel right = new JPanel(new FlowLayout(FlowLayout.TRAILING, 5, 0));
+		right.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		JLabel cost = new JLabel("≈ " + route.getTotalCost());
+		cost.setFont(FontManager.getRunescapeSmallFont());
+		cost.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		cost.setToolTipText("Blended cost: walk distance + teleport ticks/penalties (lower is shorter)");
+		right.add(cost);
+		// Status indicator (orange when shown); the whole card is the click target, see makeSelectable.
+		right.add(control(new JLabel(selected ? RouteIcons.SHOW_ACTIVE : RouteIcons.SHOW)));
+		topRow.add(right, BorderLayout.EAST);
+		card.add(topRow, BorderLayout.NORTH);
+
+		JPanel methods = new JPanel();
+		methods.setLayout(new BoxLayout(methods, BoxLayout.Y_AXIS));
+		methods.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		methods.setBorder(new EmptyBorder(2, 6, 4, 4));
+		if (route.isViaBank())
+		{
+			methods.add(noteRow("<i>Walks to a bank first to withdraw the item</i>",
+				"A required teleport item is in your bank — the drawn path includes the walk to a bank to pick it up before teleporting"));
+		}
+		if (route.isWalkOnly())
+		{
+			methods.add(noteRow("<i>No teleports — walking the whole way</i>", null));
+		}
+		else
+		{
+			for (TeleportMethod method : route.getMethods())
+			{
+				methods.add(buildMethodRow(method));
+			}
+		}
+		card.add(methods, BorderLayout.CENTER);
+
+		card.setToolTipText(selected ? "Showing on map — click to hide" : "Click to show this route on the map");
+		card.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+		makeSelectable(card, index);
+		return card;
+	}
+
+	/**
+	 * A route-card method row: category dot + wrapped label + an exclude (✕) icon.
+	 */
+	private JPanel buildMethodRow(TeleportMethod method)
+	{
+		JPanel row = new JPanel(new BorderLayout(5, 0));
+		row.setOpaque(false);
+
+		JLabel dot = new JLabel(categoryDot(method.category()));
+		dot.setVerticalAlignment(SwingConstants.TOP);
+		dot.setBorder(new EmptyBorder(2, 0, 0, 0));
+		dot.setToolTipText(method.category());
+		MethodAvailability status = cachedUnavailable.get(method);
+		if (status != null)
+		{
+			JPanel west = new JPanel(new FlowLayout(FlowLayout.LEFT, 2, 0));
+			west.setOpaque(false);
+			west.add(dot);
+			west.add(statusLabel(status));
+			row.add(west, BorderLayout.WEST);
+		}
+		else
+		{
+			row.add(dot, BorderLayout.WEST);
+		}
+
+		JLabel text = wrappedLabel(escapeHtml(method.label()));
+		text.setToolTipText(methodTooltip(method));
+		row.add(text, BorderLayout.CENTER);
+
+		IconActionLabel exclude = new IconActionLabel(RouteIcons.EXCLUDE, RouteIcons.EXCLUDE_HOVER,
+			"Exclude \"" + method.label() + "\" from the next search", () -> plugin.excludeMethod(method));
+		JPanel actionWrap = new JPanel(new BorderLayout());
+		actionWrap.setOpaque(false);
+		actionWrap.add(control(exclude), BorderLayout.NORTH);
+		row.add(actionWrap, BorderLayout.EAST);
+
+		return row;
+	}
+
+	private JPanel buildCatalogSection()
+	{
+		JPanel section = new JPanel();
+		section.setLayout(new BoxLayout(section, BoxLayout.Y_AXIS));
+		section.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		section.setBorder(new EmptyBorder(0, 0, 0, 0));
+		section.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+		// Collapsible section header: chevron + title + method count.
+		JPanel titleRow = new JPanel(new BorderLayout(5, 0));
+		titleRow.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		titleRow.setBorder(new EmptyBorder(0, 0, 4, 0));
+		titleRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+		titleRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+		JLabel title = new JLabel("Teleport methods (" + cachedCatalog.size() + ")");
+		title.setFont(FontManager.getRunescapeBoldFont());
+		title.setForeground(ColorScheme.BRAND_ORANGE);
+		titleRow.add(title, BorderLayout.CENTER);
+		titleRow.add(control(new JLabel(catalogExpanded ? RouteIcons.CHEVRON_DOWN : RouteIcons.CHEVRON_RIGHT)),
+			BorderLayout.EAST);
+		titleRow.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+		titleRow.setToolTipText(catalogExpanded ? "Collapse the methods list" : "Expand the methods list");
+		addClickRecursively(titleRow, new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				catalogExpanded = !catalogExpanded;
+				render();
+			}
+		});
+		section.add(titleRow);
+
+		if (!catalogExpanded)
+		{
+			return section;
+		}
+
+		Map<String, List<TeleportMethod>> grouped = new TreeMap<>();
+		for (TeleportMethod method : cachedCatalog)
+		{
+			grouped.computeIfAbsent(method.category(), k -> new ArrayList<>()).add(method);
+		}
+		for (List<TeleportMethod> items : grouped.values())
+		{
+			items.sort(Comparator.comparing(m -> m.label().toLowerCase()));
+		}
+
+		for (Map.Entry<String, List<TeleportMethod>> entry : grouped.entrySet())
+		{
+			String category = entry.getKey();
+			List<TeleportMethod> items = entry.getValue();
+			section.add(buildCategoryHeader(category, items));
+			if (expandedCategories.contains(category))
+			{
+				for (TeleportMethod item : items)
+				{
+					section.add(buildCatalogItemRow(item));
+				}
+			}
+		}
+
+		return section;
+	}
+
+	private JPanel buildCategoryHeader(String category, List<TeleportMethod> items)
+	{
+		int excludedCount = 0;
+		for (TeleportMethod method : items)
+		{
+			if (cachedExclusions.contains(method))
+			{
+				excludedCount++;
+			}
+		}
+		boolean allIncluded = excludedCount == 0;
+		boolean allExcluded = excludedCount == items.size();
+		boolean expanded = expandedCategories.contains(category);
+
+		JPanel row = new JPanel(new BorderLayout(5, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		row.setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createMatteBorder(0, 0, 1, 0, ColorScheme.DARK_GRAY_COLOR),
+			new EmptyBorder(3, 4, 3, 4)));
+		row.setAlignmentX(Component.LEFT_ALIGNMENT);
+		row.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		ImageIcon icon;
+		ImageIcon hover;
+		String tip;
+		Runnable action;
+		if (allIncluded)
+		{
+			icon = RouteIcons.CHECK;
+			hover = RouteIcons.CHECK_HOVER;
+			tip = "All included — click to exclude every " + category.toLowerCase();
+			action = () -> plugin.excludeMethods(items);
+		}
+		else if (allExcluded)
+		{
+			icon = RouteIcons.CROSS;
+			hover = RouteIcons.CROSS_HOVER;
+			tip = "All excluded — click to include every " + category.toLowerCase();
+			action = () -> plugin.includeMethods(items);
+		}
+		else
+		{
+			icon = RouteIcons.DASH;
+			hover = RouteIcons.DASH_HOVER;
+			tip = (items.size() - excludedCount) + " of " + items.size() + " included — click to include all";
+			action = () -> plugin.includeMethods(items);
+		}
+		row.add(control(new IconActionLabel(icon, hover, tip, action)), BorderLayout.WEST);
+
+		String count = allIncluded
+			? " (" + items.size() + ")"
+			: " (" + (items.size() - excludedCount) + "/" + items.size() + ")";
+		JLabel name = new JLabel(category + count);
+		name.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		row.add(name, BorderLayout.CENTER);
+
+		row.add(control(new JLabel(expanded ? RouteIcons.CHEVRON_DOWN : RouteIcons.CHEVRON_RIGHT)), BorderLayout.EAST);
+
+		row.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+		row.setToolTipText(expanded ? "Collapse" : "Expand to toggle individual methods");
+		addClickRecursively(row, new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				toggleCategory(category);
+			}
+		});
+		return row;
+	}
+
+	private JPanel buildCatalogItemRow(TeleportMethod item)
+	{
+		boolean excluded = cachedExclusions.contains(item);
+
+		JPanel row = new JPanel(new BorderLayout(5, 0));
+		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		row.setBorder(new EmptyBorder(2, 18, 2, 4));
+		row.setAlignmentX(Component.LEFT_ALIGNMENT);
+		row.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+
+		IconActionLabel toggle = excluded
+			? new IconActionLabel(RouteIcons.CROSS, RouteIcons.CROSS_HOVER,
+				"Excluded — click to include", () -> plugin.includeMethod(item))
+			: new IconActionLabel(RouteIcons.CHECK, RouteIcons.CHECK_HOVER,
+				"Included — click to exclude", () -> plugin.excludeMethod(item));
+		JPanel west = new JPanel(new FlowLayout(FlowLayout.LEFT, 2, 0));
+		west.setOpaque(false);
+		west.add(control(toggle));
+		MethodAvailability status = cachedUnavailable.get(item);
+		if (status != null)
+		{
+			west.add(control(statusLabel(status)));
+		}
+		JPanel westWrap = new JPanel(new BorderLayout());
+		westWrap.setOpaque(false);
+		westWrap.add(west, BorderLayout.NORTH);
+		row.add(westWrap, BorderLayout.WEST);
+
+		JLabel text = wrappedLabel(escapeHtml(item.label()));
+		text.setToolTipText(methodTooltip(item));
+		if (excluded)
+		{
+			text.setForeground(ColorScheme.LIGHT_GRAY_COLOR.darker());
+		}
+		row.add(text, BorderLayout.CENTER);
+
+		return row;
+	}
+
+	/**
+	 * Marker for a method the player can't use in the current mode: a bank glyph for an item that's only
+	 * in the bank, a padlock for everything else, each with a reason tooltip.
+	 */
+	private static JLabel statusLabel(MethodAvailability status)
+	{
+		JLabel label = new JLabel(status == MethodAvailability.IN_BANK ? RouteIcons.IN_BANK : RouteIcons.LOCKED);
+		label.setToolTipText(statusReason(status));
+		return label;
+	}
+
+	private static String statusReason(MethodAvailability status)
+	{
+		switch (status)
+		{
+			case IN_BANK:
+				return "In your bank — switch to \"Inventory + bank\" or withdraw it";
+			case MISSING_ITEM:
+				return "You don't have the required item";
+			case MISSING_LEVEL:
+				return "Your skill level is too low";
+			case MISSING_QUEST:
+				return "Requires an unfinished quest";
+			case LOCKED:
+			default:
+				return "Not unlocked yet (diary, minigame, purchase or setting)";
+		}
+	}
+
+	private void toggleCategory(String category)
+	{
+		if (!expandedCategories.add(category))
+		{
+			expandedCategories.remove(category);
+		}
+		render();
+	}
+
+	private String methodTooltip(TeleportMethod method)
+	{
+		int destination = method.getDestination();
+		int x = WorldPointUtil.unpackWorldX(destination);
+		int y = WorldPointUtil.unpackWorldY(destination);
+		int plane = WorldPointUtil.unpackWorldPlane(destination);
+		return "<html><b>" + escapeHtml(method.category()) + "</b><br>"
+			+ escapeHtml(method.label()) + "<br>"
+			+ "Arrives at " + x + ", " + y + (plane > 0 ? " (plane " + plane + ")" : "")
+			+ "</html>";
+	}
+
+	private void makeSelectable(JPanel card, int index)
+	{
+		addClickRecursively(card, new MouseAdapter()
+		{
+			@Override
+			public void mouseClicked(MouseEvent e)
+			{
+				plugin.selectRoute(index);
+			}
+		});
+	}
+
+	/**
+	 * Attaches a click listener to a component and its descendants, skipping {@link IconActionLabel}s
+	 * so the icon controls keep their own action. Swing only delivers a click to the deepest component
+	 * under the cursor, hence the recursion.
+	 */
+	private void addClickRecursively(Component component, MouseListener listener)
+	{
+		if (component instanceof IconActionLabel)
+		{
+			return;
+		}
+		component.addMouseListener(listener);
+		if (component instanceof Container)
+		{
+			for (Component child : ((Container) component).getComponents())
+			{
+				addClickRecursively(child, listener);
+			}
+		}
+	}
+
+	private void updateModeButtons()
+	{
+		AlternativeRoutesMode mode = plugin.getRoutesMode();
+		boolean owned = mode.isOwned();
+		styleModeButton(ownedButton, owned);
+		styleModeButton(allButton, !owned);
+		if (owned)
+		{
+			variantOneButton.setText("Inventory");
+			variantOneButton.setToolTipText("Only items you carry (inventory + equipment)");
+			variantTwoButton.setText("Inv + bank");
+			variantTwoButton.setToolTipText("Also items in your bank — routes walk to a bank to withdraw them");
+		}
+		else
+		{
+			variantOneButton.setText("Available");
+			variantOneButton.setToolTipText("Ignore item possession, but only methods your character has unlocked (skills, quests, diaries)");
+			variantTwoButton.setText("Everything");
+			variantTwoButton.setToolTipText("Every method in the game, including ones your character can't use yet");
+		}
+		styleModeButton(variantOneButton, !mode.isSecondVariant());
+		styleModeButton(variantTwoButton, mode.isSecondVariant());
+	}
+
+	private static void styleModeButton(JButton button, boolean active)
+	{
+		button.setForeground(active ? ColorScheme.BRAND_ORANGE : ColorScheme.LIGHT_GRAY_COLOR);
+		button.setBackground(active ? ColorScheme.DARKER_GRAY_HOVER_COLOR : ColorScheme.DARKER_GRAY_COLOR);
+		button.setBorder(BorderFactory.createCompoundBorder(
+			BorderFactory.createLineBorder(active ? ColorScheme.BRAND_ORANGE : ColorScheme.MEDIUM_GRAY_COLOR),
+			new EmptyBorder(3, 0, 3, 0)));
+	}
+
+	/**
+	 * A full-width, left-aligned note row for a route card. Bare JLabels must not be added straight
+	 * into the vertical BoxLayout: they don't stretch and default to centred alignment, which floats
+	 * them into odd positions and clips them at the card edge.
+	 */
+	private JPanel noteRow(String innerHtml, String tooltip)
+	{
+		JPanel row = new JPanel(new BorderLayout());
+		row.setOpaque(false);
+		JLabel text = wrappedLabel(innerHtml);
+		if (tooltip != null)
+		{
+			text.setToolTipText(tooltip);
+		}
+		row.add(text, BorderLayout.WEST);
+		return row;
+	}
+
+	private JLabel wrappedLabel(String innerHtml)
+	{
+		JLabel label = new JLabel("<html><body style='width:" + METHOD_TEXT_WIDTH + "px'>" + innerHtml + "</body></html>");
+		label.setFont(FontManager.getRunescapeSmallFont());
+		label.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		label.setVerticalAlignment(SwingConstants.TOP);
+		return label;
+	}
+
+	private static JLabel control(JLabel label)
+	{
+		label.setPreferredSize(new Dimension(CONTROL_SIZE, CONTROL_SIZE));
+		label.setHorizontalAlignment(SwingConstants.CENTER);
+		return label;
+	}
+
+	private static Icon categoryDot(String category)
+	{
+		final int s = 9;
+		BufferedImage image = new BufferedImage(s, s, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = image.createGraphics();
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setColor(categoryColour(category));
+		g.fillRoundRect(0, 1, s - 1, s - 2, 4, 4);
+		g.dispose();
+		return new ImageIcon(image);
+	}
+
+	private static Color categoryColour(String category)
+	{
+		return CATEGORY_PALETTE[Math.floorMod(category.hashCode(), CATEGORY_PALETTE.length)];
+	}
+
+	private static String escapeHtml(String text)
+	{
+		if (text == null)
+		{
+			return "";
+		}
+		return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+	}
+
+	private static Component verticalGap(int height)
+	{
+		JPanel gap = new JPanel();
+		gap.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		gap.setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
+		gap.setPreferredSize(new Dimension(1, height));
+		return gap;
+	}
+}

--- a/src/main/java/shortestpath/ShortestPathPanel.java
+++ b/src/main/java/shortestpath/ShortestPathPanel.java
@@ -32,9 +32,12 @@ import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.components.IconTextField;
 
 /**
  * The "view": lists up to {@link AlternativeRoutesService#MAX_ROUTES} alternative routes to the
@@ -49,6 +52,8 @@ public class ShortestPathPanel extends PluginPanel
 {
 	private static final int CONTROL_SIZE = 18;
 	private static final int METHOD_TEXT_WIDTH = 132;
+	// Tallest the expanded teleport-methods box may grow before it scrolls internally.
+	private static final int CATALOG_MAX_HEIGHT = 240;
 
 	// Stable, distinct-ish palette; categories hash into it so the same category always gets the
 	// same dot colour.
@@ -68,6 +73,22 @@ public class ShortestPathPanel extends PluginPanel
 
 	private final ShortestPathPlugin plugin;
 	private final JLabel statusLabel = new JLabel();
+	private final JLabel bankWarningLabel = new JLabel();
+	// Fixed (non-scrolling) slot below the header holding the teleport-methods catalog.
+	private final JPanel catalogHolder = new JPanel();
+	// Filter box for the catalog; a persistent component so typing keeps focus while only the rows
+	// below repopulate. Shown only while the catalog is expanded.
+	private final IconTextField catalogSearch = new IconTextField();
+	// The scrollable rows box of the expanded catalog; repopulated in place when the filter changes.
+	private JPanel catalogRowsPanel;
+	private JScrollPane catalogRowsScroll;
+	// Snapshot of the inputs the catalog section was last built from. Routes stream several updates
+	// per generation; rebuilding ~1000 catalog rows on the EDT for each of them made the toggles
+	// unresponsive (the row under the cursor kept being replaced). Rebuild only when these change.
+	private List<TeleportMethod> renderedCatalog;
+	private Set<TeleportMethod> renderedExclusions;
+	private Map<TeleportMethod, MethodAvailability> renderedUnavailable;
+	private boolean renderedCatalogExpanded;
 	private final JPanel listPanel = new JPanel();
 	private JButton ownedButton;
 	private JButton allButton;
@@ -94,12 +115,49 @@ public class ShortestPathPanel extends PluginPanel
 		setBorder(new EmptyBorder(8, 8, 8, 8));
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
-		add(buildHeader(), BorderLayout.NORTH);
+		// Fixed top area: the header (title/modes/refresh/status) plus the teleport-methods catalog,
+		// which scrolls inside its own bounded box (see buildCatalogSection) instead of pushing the
+		// route list down. Only the routes scroll in the main area below.
+		catalogHolder.setLayout(new BoxLayout(catalogHolder, BoxLayout.Y_AXIS));
+		catalogHolder.setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+		catalogSearch.setIcon(IconTextField.Icon.SEARCH);
+		catalogSearch.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		catalogSearch.setHoverBackgroundColor(ColorScheme.DARK_GRAY_HOVER_COLOR);
+		catalogSearch.getDocument().addDocumentListener(new DocumentListener()
+		{
+			@Override
+			public void insertUpdate(DocumentEvent e)
+			{
+				populateCatalogRows();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e)
+			{
+				populateCatalogRows();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e)
+			{
+				populateCatalogRows();
+			}
+		});
+		JPanel top = new JPanel(new BorderLayout());
+		top.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		top.add(buildHeader(), BorderLayout.NORTH);
+		top.add(catalogHolder, BorderLayout.CENTER);
+		top.add(buildNotes(), BorderLayout.SOUTH);
+		add(top, BorderLayout.NORTH);
 
 		listPanel.setLayout(new BoxLayout(listPanel, BoxLayout.Y_AXIS));
 		listPanel.setBackground(ColorScheme.DARK_GRAY_COLOR);
-		// Top-anchor the content so a short list keeps each row at its natural height.
-		JPanel listWrapper = new JPanel(new BorderLayout());
+		// Top-anchor the content so a short list keeps each row at its natural height. The wrapper
+		// tracks the viewport width: without that, HORIZONTAL_SCROLLBAR_NEVER still lays the view out
+		// at its preferred width and CLIPS the overflow at the right edge (the "scrollbar eats the
+		// cards" effect) instead of shrinking the rows to fit.
+		ScrollableBox listWrapper = new ScrollableBox(new BorderLayout());
 		listWrapper.setBackground(ColorScheme.DARK_GRAY_COLOR);
 		listWrapper.add(listPanel, BorderLayout.NORTH);
 		JScrollPane scroll = new JScrollPane(listWrapper,
@@ -107,13 +165,52 @@ public class ShortestPathPanel extends PluginPanel
 			ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		scroll.setBorder(BorderFactory.createEmptyBorder());
 		scroll.getVerticalScrollBar().setUnitIncrement(16);
-		// The sidebar scrollbar overlays the content (it doesn't shrink the viewport), so it clips the
-		// right edge of full-width cards. Reserve a matching gutter on the scrolling content for it.
-		int scrollbarWidth = scroll.getVerticalScrollBar().getPreferredSize().width;
-		listPanel.setBorder(new EmptyBorder(0, 0, 0, scrollbarWidth > 0 ? scrollbarWidth : 12));
 		add(scroll, BorderLayout.CENTER);
 
 		render();
+	}
+
+	/**
+	 * A panel that always lays out at the scroll viewport's width. A plain JPanel inside a JScrollPane
+	 * keeps its preferred width even with the horizontal scrollbar disabled, so any row slightly wider
+	 * than the viewport pushes the whole content under the vertical scrollbar and gets clipped.
+	 */
+	private static final class ScrollableBox extends JPanel implements javax.swing.Scrollable
+	{
+		private ScrollableBox(java.awt.LayoutManager layout)
+		{
+			super(layout);
+		}
+
+		@Override
+		public Dimension getPreferredScrollableViewportSize()
+		{
+			return getPreferredSize();
+		}
+
+		@Override
+		public int getScrollableUnitIncrement(java.awt.Rectangle visibleRect, int orientation, int direction)
+		{
+			return 16;
+		}
+
+		@Override
+		public int getScrollableBlockIncrement(java.awt.Rectangle visibleRect, int orientation, int direction)
+		{
+			return Math.max(visibleRect.height - 16, 16);
+		}
+
+		@Override
+		public boolean getScrollableTracksViewportWidth()
+		{
+			return true;
+		}
+
+		@Override
+		public boolean getScrollableTracksViewportHeight()
+		{
+			return false;
+		}
 	}
 
 	private JPanel buildHeader()
@@ -212,10 +309,6 @@ public class ShortestPathPanel extends PluginPanel
 		findWrap.add(findButton, BorderLayout.CENTER);
 		lower.add(findWrap, BorderLayout.NORTH);
 
-		statusLabel.setFont(FontManager.getRunescapeSmallFont());
-		statusLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-		statusLabel.setBorder(new EmptyBorder(6, 0, 0, 0));
-		lower.add(statusLabel, BorderLayout.SOUTH);
 
 		bottom.add(lower, BorderLayout.SOUTH);
 
@@ -223,6 +316,35 @@ public class ShortestPathPanel extends PluginPanel
 
 		updateModeButtons();
 		return header;
+	}
+
+	/**
+	 * The status line ("N routes found", "No Shortest Path destination set", ...) and the red bank
+	 * warning. Shown below the teleport-methods catalog, directly above the route cards.
+	 */
+	private JPanel buildNotes()
+	{
+		// Red bank warning directly above the status line; only visible in "Inv + bank" mode until the
+		// bank has been opened once this session (before that, banked items are invisible to the plugin).
+		bankWarningLabel.setText("<html><b>Bank contents unknown</b> — open your bank once so banked items can be found.</html>");
+		bankWarningLabel.setFont(FontManager.getRunescapeSmallFont());
+		bankWarningLabel.setForeground(ColorScheme.PROGRESS_ERROR_COLOR);
+		bankWarningLabel.setBorder(new EmptyBorder(4, 0, 0, 0));
+		bankWarningLabel.setVisible(false);
+
+		statusLabel.setFont(FontManager.getRunescapeSmallFont());
+		statusLabel.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+		statusLabel.setBorder(new EmptyBorder(4, 0, 0, 0));
+
+		JPanel notes = new JPanel();
+		notes.setLayout(new BoxLayout(notes, BoxLayout.Y_AXIS));
+		notes.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		notes.setBorder(new EmptyBorder(0, 0, 6, 0));
+		bankWarningLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		statusLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+		notes.add(bankWarningLabel);
+		notes.add(statusLabel);
+		return notes;
 	}
 
 	/**
@@ -269,20 +391,38 @@ public class ShortestPathPanel extends PluginPanel
 			// doesn't hand Shortest Path a destination — set one on the map to find routes.)
 			status = "No Shortest Path destination set.";
 		}
-		// The bank container is only populated once the bank has been opened this session; without it
-		// Bank mode cannot see banked teleports (same constraint as Shortest Path itself).
-		if (plugin.getRoutesMode() == AlternativeRoutesMode.OWNED_WITH_BANK && !plugin.isBankContentsKnown())
+		// Method toggles no longer recalculate; flag a route list generated with different exclusions.
+		if (!cachedCalculating && cachedHasTarget && plugin.isRouteListStale())
 		{
-			status += "<br><b>Bank contents unknown</b> — open your bank once so banked teleports can be found.";
+			status += "<br><font color='#FF981F'>Exclusions changed — press \"Refresh routes\" to apply.</font>";
 		}
+		// The bank container is only populated once the bank has been opened this session; without it
+		// Bank mode cannot see banked items (same constraint as Shortest Path itself).
+		bankWarningLabel.setVisible(
+			plugin.getRoutesMode() == AlternativeRoutesMode.OWNED_WITH_BANK && !plugin.isBankContentsKnown());
 		statusLabel.setText("<html>" + status + "</html>");
 
-		// The teleport-methods catalog sits at the top (collapsed by default), so browsing/toggling
-		// methods is always one click away above the routes.
-		if (!cachedCatalog.isEmpty())
+		// The teleport-methods catalog lives in a fixed slot below the header (collapsed by default).
+		// Expanded it scrolls inside its own bounded box, so it never pushes the routes off screen.
+		// Rebuilt only when its inputs changed — streamed route updates leave it untouched so its
+		// toggles stay responsive while a generation is running.
+		boolean catalogDirty = !cachedCatalog.equals(renderedCatalog)
+			|| !cachedExclusions.equals(renderedExclusions)
+			|| !cachedUnavailable.equals(renderedUnavailable)
+			|| catalogExpanded != renderedCatalogExpanded;
+		if (catalogDirty)
 		{
-			listPanel.add(buildCatalogSection());
-			listPanel.add(verticalGap(8));
+			catalogHolder.removeAll();
+			if (!cachedCatalog.isEmpty())
+			{
+				catalogHolder.add(buildCatalogSection());
+			}
+			catalogHolder.revalidate();
+			catalogHolder.repaint();
+			renderedCatalog = cachedCatalog;
+			renderedExclusions = cachedExclusions;
+			renderedUnavailable = cachedUnavailable;
+			renderedCatalogExpanded = catalogExpanded;
 		}
 
 		// Routes are shown as they stream in (even while still calculating). The previous list was
@@ -343,10 +483,16 @@ public class ShortestPathPanel extends PluginPanel
 
 		JPanel right = new JPanel(new FlowLayout(FlowLayout.TRAILING, 5, 0));
 		right.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		JLabel cost = new JLabel("≈ " + route.getTotalCost());
+		// Weighted cost, plus — when configured weights changed it — the raw cost in parentheses.
+		boolean weighted = route.getRawCost() != route.getTotalCost();
+		JLabel cost = new JLabel("≈ " + route.getTotalCost()
+			+ (weighted ? " (" + route.getRawCost() + ")" : ""));
 		cost.setFont(FontManager.getRunescapeSmallFont());
 		cost.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
-		cost.setToolTipText("Blended cost: walk distance + teleport ticks/penalties (lower is shorter)");
+		cost.setToolTipText(weighted
+			? "<html>Blended cost incl. your configured method weights (lower is shorter).<br>"
+				+ "In parentheses: the raw cost — walk distance + travel time only.</html>"
+			: "Blended cost: walk distance + travel time (lower is shorter)");
 		right.add(cost);
 		// Status indicator (orange when shown); the whole card is the click target, see makeSelectable.
 		right.add(control(new JLabel(selected ? RouteIcons.SHOW_ACTIVE : RouteIcons.SHOW)));
@@ -359,20 +505,20 @@ public class ShortestPathPanel extends PluginPanel
 		methods.setBorder(new EmptyBorder(2, 6, 4, 4));
 		if (route.isViaBank())
 		{
-			methods.add(noteRow("<i>Walks to a bank first — withdraws the item for "
-					+ escapeHtml(joinLabels(route.getBankMethods())) + "</i>",
-				"The marked method needs an item from your bank — the drawn path includes the walk to a bank to pick it up first"));
+			// Kept to one line: the method that needs the bank is identified by the bank glyph on its
+			// own row below, and this note's tooltip names it too.
+			methods.add(noteRow("<i>Walks to a bank first</i>",
+				"<html>Withdraws the item for: <b>" + escapeHtml(joinLabels(route.getBankMethods()))
+					+ "</b><br>The drawn path includes the walk to a bank before that method is used</html>"));
 		}
-		if (route.isWalkOnly())
+		for (int m = 0; m < route.getMethods().size(); m++)
 		{
-			methods.add(noteRow("<i>No teleports — walking the whole way</i>", null));
+			methods.add(buildMethodRow(route.getMethods().get(m), route.getBankMethods(), route.walkBefore(m)));
 		}
-		else
+		// Trailing walking leg after the last method — the whole route for walk-only ones.
+		if (route.getTrailingWalkSteps() > 0 || route.isWalkOnly())
 		{
-			for (TeleportMethod method : route.getMethods())
-			{
-				methods.add(buildMethodRow(method, route.getBankMethods()));
-			}
+			methods.add(buildWalkRow(route.getTrailingWalkSteps()));
 		}
 		card.add(methods, BorderLayout.CENTER);
 
@@ -382,12 +528,38 @@ public class ShortestPathPanel extends PluginPanel
 		return card;
 	}
 
+	// Neutral dot colour for walking legs; deliberately outside the category palette so walking
+	// doesn't masquerade as a teleport category.
+	private static final Color WALK_DOT_COLOUR = new Color(0x9E, 0x9E, 0x9E);
+
+	/**
+	 * A walking-leg row, shaped exactly like a method row: a neutral grey dot in the category-dot
+	 * column, then the step count.
+	 */
+	private JPanel buildWalkRow(int steps)
+	{
+		JPanel row = new JPanel(new BorderLayout(5, 0));
+		row.setOpaque(false);
+
+		JLabel dot = new JLabel(dot(WALK_DOT_COLOUR));
+		dot.setVerticalAlignment(SwingConstants.TOP);
+		dot.setBorder(new EmptyBorder(2, 0, 0, 0));
+		dot.setToolTipText("Walking");
+		row.add(dot, BorderLayout.WEST);
+
+		JLabel text = wrappedLabel("(" + steps + ") Walk");
+		text.setToolTipText("Walk " + steps + " tiles to the destination");
+		row.add(text, BorderLayout.CENTER);
+		return row;
+	}
+
 	/**
 	 * A route-card method row: category dot + wrapped label + an exclude (✕) icon. Methods whose
 	 * required item must first be withdrawn from the bank get a bank glyph, so it's clear which
-	 * method the route's bank detour is for.
+	 * method the route's bank detour is for. {@code walkBefore} tiles of walking to reach the method
+	 * are shown as a "(N)" prefix on the label.
 	 */
-	private JPanel buildMethodRow(TeleportMethod method, Set<TeleportMethod> bankMethods)
+	private JPanel buildMethodRow(TeleportMethod method, Set<TeleportMethod> bankMethods, int walkBefore)
 	{
 		JPanel row = new JPanel(new BorderLayout(5, 0));
 		row.setOpaque(false);
@@ -420,8 +592,11 @@ public class ShortestPathPanel extends PluginPanel
 			row.add(dot, BorderLayout.WEST);
 		}
 
-		JLabel text = wrappedLabel(escapeHtml(method.label()));
-		text.setToolTipText(methodTooltip(method));
+		String prefix = walkBefore > 0 ? "(" + walkBefore + ") " : "";
+		JLabel text = wrappedLabel(prefix + escapeHtml(method.label()));
+		text.setToolTipText(walkBefore > 0
+			? "<html>Walk " + walkBefore + " tiles to reach this method.<br>" + methodTooltipBody(method) + "</html>"
+			: methodTooltip(method));
 		row.add(text, BorderLayout.CENTER);
 
 		IconActionLabel exclude = new IconActionLabel(RouteIcons.EXCLUDE, RouteIcons.EXCLUDE_HOVER,
@@ -448,9 +623,18 @@ public class ShortestPathPanel extends PluginPanel
 		titleRow.setBorder(new EmptyBorder(0, 0, 4, 0));
 		titleRow.setAlignmentX(Component.LEFT_ALIGNMENT);
 		titleRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-		JLabel title = new JLabel("Teleport methods (" + cachedCatalog.size() + ")");
+		int active = 0;
+		for (TeleportMethod method : cachedCatalog)
+		{
+			if (!cachedExclusions.contains(method))
+			{
+				active++;
+			}
+		}
+		JLabel title = new JLabel("Teleport methods (" + active + "/" + cachedCatalog.size() + ")");
 		title.setFont(FontManager.getRunescapeBoldFont());
 		title.setForeground(ColorScheme.BRAND_ORANGE);
+		title.setToolTipText(active + " of " + cachedCatalog.size() + " methods included in searches");
 		titleRow.add(title, BorderLayout.CENTER);
 		titleRow.add(control(new JLabel(catalogExpanded ? RouteIcons.CHEVRON_DOWN : RouteIcons.CHEVRON_RIGHT)),
 			BorderLayout.EAST);
@@ -469,37 +653,112 @@ public class ShortestPathPanel extends PluginPanel
 
 		if (!catalogExpanded)
 		{
+			catalogRowsPanel = null;
+			catalogRowsScroll = null;
+			section.setBorder(new EmptyBorder(0, 0, 4, 0));
 			return section;
 		}
+
+		// Filter box (persistent component, see the field comment) — only mounted while expanded.
+		catalogSearch.setAlignmentX(Component.LEFT_ALIGNMENT);
+		catalogSearch.setMaximumSize(new Dimension(Integer.MAX_VALUE, 30));
+		JPanel searchWrap = new JPanel(new BorderLayout());
+		searchWrap.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		searchWrap.setBorder(new EmptyBorder(0, 0, 4, 0));
+		searchWrap.setAlignmentX(Component.LEFT_ALIGNMENT);
+		searchWrap.setMaximumSize(new Dimension(Integer.MAX_VALUE, 34));
+		searchWrap.add(catalogSearch, BorderLayout.CENTER);
+		section.add(searchWrap);
+
+		// The method rows scroll inside their own bounded box with their own scrollbar, so a long
+		// (or fully expanded) catalog never pushes the route list off screen. The rows panel tracks
+		// the viewport width so the scrollbar sits beside the rows instead of clipping them.
+		ScrollableBox rows = new ScrollableBox(null);
+		rows.setLayout(new BoxLayout(rows, BoxLayout.Y_AXIS));
+		rows.setBackground(ColorScheme.DARK_GRAY_COLOR);
+		JScrollPane rowsScroll = new JScrollPane(rows,
+			ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+			ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		rowsScroll.setBorder(BorderFactory.createEmptyBorder());
+		rowsScroll.getVerticalScrollBar().setUnitIncrement(16);
+		rowsScroll.setAlignmentX(Component.LEFT_ALIGNMENT);
+		catalogRowsPanel = rows;
+		catalogRowsScroll = rowsScroll;
+		populateCatalogRows();
+		section.add(rowsScroll);
+		section.setBorder(new EmptyBorder(0, 0, 8, 0));
+
+		return section;
+	}
+
+	/**
+	 * (Re)fills the expanded catalog's rows box from the current filter text. Called on every filter
+	 * keystroke — repopulates in place so the search field keeps focus. While a filter is active,
+	 * matching categories are shown force-expanded (a filter that only matched collapsed categories
+	 * would otherwise look like it found nothing).
+	 */
+	private void populateCatalogRows()
+	{
+		JPanel rows = catalogRowsPanel;
+		JScrollPane rowsScroll = catalogRowsScroll;
+		if (rows == null || rowsScroll == null)
+		{
+			return;
+		}
+		rows.removeAll();
+
+		String filter = catalogSearch.getText() == null ? "" : catalogSearch.getText().trim().toLowerCase();
+		boolean filtering = !filter.isEmpty();
 
 		Map<String, List<TeleportMethod>> grouped = new TreeMap<>();
 		for (TeleportMethod method : cachedCatalog)
 		{
-			grouped.computeIfAbsent(method.category(), k -> new ArrayList<>()).add(method);
+			// A filter hit on the category keeps the whole category; otherwise match the method label.
+			if (!filtering
+				|| method.category().toLowerCase().contains(filter)
+				|| method.label().toLowerCase().contains(filter))
+			{
+				grouped.computeIfAbsent(method.category(), k -> new ArrayList<>()).add(method);
+			}
 		}
 		for (List<TeleportMethod> items : grouped.values())
 		{
 			items.sort(Comparator.comparing(m -> m.label().toLowerCase()));
 		}
 
+		if (grouped.isEmpty())
+		{
+			JLabel none = wrappedLabel("<i>No methods match \"" + escapeHtml(filter) + "\"</i>");
+			none.setBorder(new EmptyBorder(2, 4, 2, 0));
+			none.setAlignmentX(Component.LEFT_ALIGNMENT);
+			rows.add(none);
+		}
 		for (Map.Entry<String, List<TeleportMethod>> entry : grouped.entrySet())
 		{
 			String category = entry.getKey();
 			List<TeleportMethod> items = entry.getValue();
-			section.add(buildCategoryHeader(category, items));
-			if (expandedCategories.contains(category))
+			boolean expanded = filtering || expandedCategories.contains(category);
+			rows.add(buildCategoryHeader(category, items, expanded));
+			if (expanded)
 			{
 				for (TeleportMethod item : items)
 				{
-					section.add(buildCatalogItemRow(item));
+					rows.add(buildCatalogItemRow(item));
 				}
 			}
 		}
 
-		return section;
+		// Bounded height: natural size for short lists, capped so the routes below stay visible.
+		int height = Math.min(rows.getPreferredSize().height + 2, CATALOG_MAX_HEIGHT);
+		rowsScroll.setPreferredSize(new Dimension(10, height));
+		rowsScroll.setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
+		rows.revalidate();
+		rows.repaint();
+		catalogHolder.revalidate();
+		catalogHolder.repaint();
 	}
 
-	private JPanel buildCategoryHeader(String category, List<TeleportMethod> items)
+	private JPanel buildCategoryHeader(String category, List<TeleportMethod> items, boolean expanded)
 	{
 		int excludedCount = 0;
 		for (TeleportMethod method : items)
@@ -511,7 +770,6 @@ public class ShortestPathPanel extends PluginPanel
 		}
 		boolean allIncluded = excludedCount == 0;
 		boolean allExcluded = excludedCount == items.size();
-		boolean expanded = expandedCategories.contains(category);
 
 		JPanel row = new JPanel(new BorderLayout(5, 0));
 		row.setBackground(ColorScheme.DARKER_GRAY_COLOR);
@@ -644,7 +902,9 @@ public class ShortestPathPanel extends PluginPanel
 		{
 			expandedCategories.remove(category);
 		}
-		render();
+		// Repopulate the rows in place: cheaper than a full render, and the catalog section's dirty
+		// check (which doesn't track per-category expansion) would skip the rebuild anyway.
+		populateCatalogRows();
 	}
 
 	/**
@@ -668,14 +928,18 @@ public class ShortestPathPanel extends PluginPanel
 
 	private String methodTooltip(TeleportMethod method)
 	{
+		return "<html>" + methodTooltipBody(method) + "</html>";
+	}
+
+	private String methodTooltipBody(TeleportMethod method)
+	{
 		int destination = method.getDestination();
 		int x = WorldPointUtil.unpackWorldX(destination);
 		int y = WorldPointUtil.unpackWorldY(destination);
 		int plane = WorldPointUtil.unpackWorldPlane(destination);
-		return "<html><b>" + escapeHtml(method.category()) + "</b><br>"
+		return "<b>" + escapeHtml(method.category()) + "</b><br>"
 			+ escapeHtml(method.label()) + "<br>"
-			+ "Arrives at " + x + ", " + y + (plane > 0 ? " (plane " + plane + ")" : "")
-			+ "</html>";
+			+ "Arrives at " + x + ", " + y + (plane > 0 ? " (plane " + plane + ")" : "");
 	}
 
 	private void makeSelectable(JPanel card, int index)
@@ -780,11 +1044,16 @@ public class ShortestPathPanel extends PluginPanel
 
 	private static Icon categoryDot(String category)
 	{
+		return dot(categoryColour(category));
+	}
+
+	private static Icon dot(Color colour)
+	{
 		final int s = 9;
 		BufferedImage image = new BufferedImage(s, s, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g = image.createGraphics();
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-		g.setColor(categoryColour(category));
+		g.setColor(colour);
 		g.fillRoundRect(0, 1, s - 1, s - 2, 4, 4);
 		g.dispose();
 		return new ImageIcon(image);

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -1,6 +1,7 @@
 package shortestpath;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import java.awt.Color;
@@ -12,6 +13,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,15 +21,19 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.swing.SwingUtilities;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.KeyCode;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
@@ -61,7 +67,9 @@ import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.JagexColors;
+import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPoint;
 import net.runelite.client.ui.overlay.worldmap.WorldMapPointManager;
@@ -76,6 +84,7 @@ import shortestpath.pathfinder.TransportAvailability;
 import shortestpath.transport.Transport;
 import shortestpath.transport.TransportType;
 
+@Slf4j
 @SuppressWarnings("SameParameterValue")
 @PluginDescriptor(name = "Shortest Path", description = "Draws the shortest path to a chosen destination on the map<br>"
 	+
@@ -139,6 +148,10 @@ public class ShortestPathPlugin extends Plugin
 	@Inject
 	private ShortestPathConfig config;
 	@Inject
+	private ConfigManager configManager;
+	@Inject
+	private Gson gson;
+	@Inject
 	private EventBus eventBus;
 	@Inject
 	private OverlayManager overlayManager;
@@ -158,6 +171,39 @@ public class ShortestPathPlugin extends Plugin
 	private WorldMapPointManager worldMapPointManager;
 	@Inject
 	private KeyManager keyManager;
+	@Inject
+	private ClientToolbar clientToolbar;
+	// Alternative-routes feature: panel, async route generator, the methods the user has excluded, the
+	// generated routes, and which one is currently shown on the map.
+	private ShortestPathPanel altPanel;
+	private NavigationButton navButton;
+	private AlternativeRoutesService altRoutesService;
+	private static final String CONFIG_KEY_EXCLUSIONS = "alternativeRoutesExclusions";
+	private static final String CONFIG_KEY_MODE = "alternativeRoutesMode";
+	private final Set<TeleportMethod> userExclusions = ConcurrentHashMap.newKeySet();
+	// Which methods the alternatives consider: carried (default), carried + bank, or every teleport.
+	private volatile AlternativeRoutesMode routesMode = AlternativeRoutesMode.OWNED_INVENTORY;
+	// How many alternative routes to generate; grows when the user asks for more.
+	// Initialised from config in startUp (config is not injected at field-init time).
+	private int routeLimit = AlternativeRoutesService.MAX_ROUTES;
+	// Whether the last generation hit the limit (so more routes may exist).
+	private volatile boolean moreRoutesLikely = false;
+	private volatile List<RouteOption> alternativeRoutes = new ArrayList<>();
+	private volatile List<TeleportMethod> teleportCatalog = new ArrayList<>();
+	// Catalog methods the player can't use in the current mode, mapped to why (for the panel markers).
+	private volatile Map<TeleportMethod, MethodAvailability> unavailableMethods = Map.of();
+	private volatile RouteOption selectedRoute;
+	// Start/targets the alternatives were last generated from, reused by exclusion/mode/show-more edits
+	// so they re-run against the same destination. Volatile: read/written from client thread + Swing EDT.
+	private volatile int lastAltStart = WorldPointUtil.UNDEFINED;
+	private volatile Set<Integer> lastAltTargets = Set.of();
+	// Whether the client knows the bank's contents this session (the bank container is only populated
+	// once the bank has been opened). Used by the panel to explain why Bank mode finds nothing.
+	private volatile boolean bankContentsKnown = false;
+	// True while a generation is computing for the current target. Used to suppress the classic-path
+	// fallback on the map until the first alternative streams in, so the displayed path never flashes
+	// a route that the mode's list won't contain (the classic path follows the SP config, not the mode).
+	private volatile boolean altGenerationInFlight = false;
 	private Point lastMenuOpenedPoint;
 	private WorldMapPoint marker;
 	private int lastLocation = WorldPointUtil.packWorldPoint(0, 0, 0);
@@ -316,6 +362,36 @@ public class ShortestPathPlugin extends Plugin
 			overlayManager.add(debugOverlayPanel);
 		}
 
+		loadExclusions();
+		loadRoutesMode();
+		routeLimit = defaultRouteLimit();
+		altPanel = new ShortestPathPanel(this);
+		altRoutesService = new AlternativeRoutesService(clientThread, pathfinderConfig.copyForPlanning());
+		navButton = NavigationButton.builder()
+			.tooltip("Alternative routes")
+			.icon(MARKER_IMAGE)
+			.priority(70)
+			.panel(altPanel)
+			.build();
+		clientToolbar.addNavigation(navButton);
+
+		// Populate the teleport-methods catalog so it's visible before any target is set, and check
+		// whether the bank contents are already known this session.
+		if (GameState.LOGGED_IN.equals(client.getGameState()))
+		{
+			clientThread.invokeLater(() ->
+			{
+				ItemContainer liveBank = client.getItemContainer(InventoryID.BANK);
+				if (liveBank != null && liveBank.getItems().length > 0)
+				{
+					pathfinderConfig.bank = liveBank;
+					pathfinderConfig.setBankSnapshot(liveBank.getItems());
+					bankContentsKnown = true;
+				}
+			});
+			triggerAlternatives(WorldPointUtil.UNDEFINED, new HashSet<>());
+		}
+
 		keyManager.registerKeyListener(clearPathKeylistener);
 	}
 
@@ -327,6 +403,17 @@ public class ShortestPathPlugin extends Plugin
 		overlayManager.remove(pathMapOverlay);
 		overlayManager.remove(pathMapTooltipOverlay);
 		overlayManager.remove(debugOverlayPanel);
+
+		if (navButton != null)
+		{
+			clientToolbar.removeNavigation(navButton);
+			navButton = null;
+		}
+		if (altRoutesService != null)
+		{
+			altRoutesService.shutdown();
+			altRoutesService = null;
+		}
 
 		if (pathfindingExecutor != null)
 		{
@@ -356,6 +443,9 @@ public class ShortestPathPlugin extends Plugin
 
 		getClientThread().invokeLater(() ->
 		{
+			// The panel's method catalog is the single customization surface: methods the user has
+			// excluded there are also excluded from the classic path.
+			pathfinderConfig.setExcludedMethods(getUserExclusions());
 			pathfinderConfig.refresh();
 			pathfinderConfig.filterLocations(ends, canReviveFiltered);
 			synchronized (pathfinderMutex)
@@ -400,6 +490,15 @@ public class ShortestPathPlugin extends Plugin
 
 	public Color getPathColor()
 	{
+		// A displayed alternative route is a static snapshot: colour it by whether it reached the target,
+		// never by the classic pathfinder's background re-anchoring (which would otherwise flash the drawn
+		// route blue every time you walk far enough to trigger a recalculation).
+		RouteOption displayed = getDisplayedRoute();
+		if (displayed != null)
+		{
+			return displayed.isReached() ? colourPath : colourPathUnreachable;
+		}
+
 		if (pathfinder == null || !pathfinder.isDone())
 		{
 			return colourPathCalculating;
@@ -466,6 +565,11 @@ public class ShortestPathPlugin extends Plugin
 		}
 
 		// Transport option changed; rerun pathfinding
+		if ("defaultRouteCount".equals(event.getKey()))
+		{
+			routeLimit = defaultRouteLimit();
+		}
+
 		if (TRANSPORT_OPTIONS_REGEX.matcher(event.getKey()).find())
 		{
 			if (pathfinder != null)
@@ -489,6 +593,8 @@ public class ShortestPathPlugin extends Plugin
 		}
 
 		pendingTasks.add(new PendingTask(client.getTickCount() + 1, pathfinderConfig::refresh));
+		// Refresh the teleport-methods catalog (and any current routes) now that game state is available.
+		pendingTasks.add(new PendingTask(client.getTickCount() + 1, this::recomputeAlternatives));
 	}
 
 	/**
@@ -594,7 +700,10 @@ public class ShortestPathPlugin extends Plugin
 			}
 
 			boolean useOld = targets.isEmpty() && pathfinder != null;
-			restartPathfinding(start, useOld ? pathfinder.getTargets() : targets, useOld);
+			Set<Integer> ends = useOld ? new HashSet<>(pathfinder.getTargets()) : targets;
+			// Alternatives are computed manually (the panel's "Find routes" button reads the current
+			// target), so other-plugin requests like Quest Helper just set the path here.
+			restartPathfinding(start, ends, useOld);
 		}
 		else if (PLUGIN_MESSAGE_CLEAR.equals(action))
 		{
@@ -654,6 +763,8 @@ public class ShortestPathPlugin extends Plugin
 				pendingTasks.remove(i--).run();
 			}
 		}
+
+		maybeAutoComputeAlternatives();
 
 		Player localPlayer = client.getLocalPlayer();
 		if (localPlayer == null || pathfinder == null)
@@ -778,6 +889,10 @@ public class ShortestPathPlugin extends Plugin
 			return;
 		}
 		pathfinderConfig.bank = event.getItemContainer();
+		// Snapshot the items now, while the bank is open: the client may empty the live container
+		// (and thereby every reference to it) once the interface closes.
+		pathfinderConfig.setBankSnapshot(event.getItemContainer().getItems());
+		bankContentsKnown = true;
 	}
 
 	@Subscribe
@@ -1359,6 +1474,10 @@ public class ShortestPathPlugin extends Plugin
 			worldMapPointManager.removeIf(x -> x == marker);
 			marker = null;
 			startPointSet = false;
+			selectedRoute = null;
+			routeLimit = defaultRouteLimit();
+			// Keep the teleport-methods catalog visible with no target selected.
+			triggerAlternatives(WorldPointUtil.UNDEFINED, new HashSet<>());
 		}
 		else
 		{
@@ -1388,6 +1507,7 @@ public class ShortestPathPlugin extends Plugin
 			{
 				destinations.addAll(pathfinder.getTargets());
 			}
+			// Alternatives are computed manually via the panel's "Find routes" button.
 			restartPathfinding(start, destinations, append);
 		}
 	}
@@ -1400,6 +1520,408 @@ public class ShortestPathPlugin extends Plugin
 		}
 		startPointSet = true;
 		restartPathfinding(start, pathfinder.getTargets());
+	}
+
+	// --- Alternative-routes feature (driven by ShortestPathPanel) ---
+
+	public RouteOption getSelectedRoute()
+	{
+		return selectedRoute;
+	}
+
+	/**
+	 * The route currently being displayed: the explicitly selected one, or — when the alternatives
+	 * were computed for the pathfinder's current destination — the first (best) route of the list
+	 * under the currently selected mode. Null when neither applies (falls back to the classic path).
+	 */
+	public RouteOption getDisplayedRoute()
+	{
+		RouteOption route = selectedRoute;
+		if (route != null)
+		{
+			return route;
+		}
+		List<RouteOption> routes = alternativeRoutes;
+		if (routes.isEmpty())
+		{
+			return null;
+		}
+		// Only substitute the first alternative when it was computed for the current destination;
+		// a stale list (target changed since "Find routes") must not override the live path.
+		Pathfinder current = pathfinder;
+		if (current == null || !lastAltTargets.equals(current.getTargets()))
+		{
+			return null;
+		}
+		return routes.get(0);
+	}
+
+	/**
+	 * The path the overlays should draw: the displayed alternative route if any (the selected one,
+	 * or by default the first route of the current alternatives list, so the drawn path reflects the
+	 * chosen mode/exclusions), otherwise the classic live pathfinder path.
+	 */
+	public List<PathStep> getDisplayPath()
+	{
+		RouteOption route = getDisplayedRoute();
+		if (route != null)
+		{
+			return route.getPath();
+		}
+		// While the alternatives for the current destination are still computing, draw nothing rather
+		// than the classic path: the classic path follows the SP config (not the panel's mode) and can
+		// use methods the list will never contain. The first streamed route replaces it in <1s.
+		Pathfinder current = pathfinder;
+		if (altGenerationInFlight && current != null && lastAltTargets.equals(current.getTargets()))
+		{
+			return List.of();
+		}
+		return current != null ? current.getPath() : List.of();
+	}
+
+	public List<RouteOption> getAlternativeRoutes()
+	{
+		return alternativeRoutes;
+	}
+
+	public Set<TeleportMethod> getUserExclusions()
+	{
+		return new HashSet<>(userExclusions);
+	}
+
+	public void selectRoute(int index)
+	{
+		List<RouteOption> routes = alternativeRoutes;
+		if (index >= 0 && index < routes.size())
+		{
+			RouteOption route = routes.get(index);
+			// Toggle: clicking the route that's already shown hides it.
+			selectedRoute = (selectedRoute == route) ? null : route;
+			refreshPanel(false);
+		}
+	}
+
+	public void excludeMethod(TeleportMethod method)
+	{
+		if (method != null && userExclusions.add(method))
+		{
+			saveExclusions();
+			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+		}
+	}
+
+	public void includeMethod(TeleportMethod method)
+	{
+		if (method != null && userExclusions.remove(method))
+		{
+			saveExclusions();
+			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+		}
+	}
+
+	public void excludeMethods(Collection<TeleportMethod> methods)
+	{
+		boolean changed = false;
+		if (methods != null)
+		{
+			for (TeleportMethod method : methods)
+			{
+				changed |= userExclusions.add(method);
+			}
+		}
+		if (changed)
+		{
+			saveExclusions();
+			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+		}
+	}
+
+	public void includeMethods(Collection<TeleportMethod> methods)
+	{
+		boolean changed = false;
+		if (methods != null)
+		{
+			for (TeleportMethod method : methods)
+			{
+				changed |= userExclusions.remove(method);
+			}
+		}
+		if (changed)
+		{
+			saveExclusions();
+			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+		}
+	}
+
+	public void clearExclusions()
+	{
+		if (!userExclusions.isEmpty())
+		{
+			userExclusions.clear();
+			saveExclusions();
+			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+		}
+	}
+
+	/**
+	 * Manually (re)compute the alternative routes for whatever destination Shortest Path currently has
+	 * set — read live from the active pathfinder. With no target set, just refreshes the methods catalog.
+	 */
+	public void recomputeAlternatives()
+	{
+		getClientThread().invokeLater(() ->
+		{
+			Pathfinder current = pathfinder;
+			if (current != null && !current.getTargets().isEmpty())
+			{
+				int start = altStart(current);
+				log.debug("[alt-routes] Find routes: SP target set, spStart={}, searchStart={}, target={}",
+					WorldPointUtil.unpackWorldPoint(current.getStart()),
+					WorldPointUtil.unpackWorldPoint(start),
+					WorldPointUtil.unpackWorldPoint(current.getTargets().iterator().next()));
+				routeLimit = defaultRouteLimit();
+				triggerAlternatives(start, new HashSet<>(current.getTargets()));
+			}
+			else
+			{
+				log.debug("[alt-routes] Find routes: no SP target (pathfinder={})",
+					current == null ? "null" : "targets-empty");
+				triggerAlternatives(WorldPointUtil.UNDEFINED, new HashSet<>());
+			}
+		});
+	}
+
+	/**
+	 * The start tile to search alternatives from: the player's current (instance-correct) location,
+	 * matching what Shortest Path itself uses for recalculation, falling back to the pathfinder's own
+	 * start. Must be called on the client thread.
+	 */
+	private int altStart(Pathfinder current)
+	{
+		Player localPlayer = client.getLocalPlayer();
+		if (localPlayer != null)
+		{
+			return WorldPointUtil.fromLocalInstance(client, localPlayer);
+		}
+		return current.getStart();
+	}
+
+	/**
+	 * The configured number of routes to search for per query (clamped to the service's hard cap).
+	 */
+	private int defaultRouteLimit()
+	{
+		int configured = override("defaultRouteCount", config.defaultRouteCount());
+		return Math.max(1, Math.min(configured, 25));
+	}
+
+	public boolean canLoadMoreRoutes()
+	{
+		return moreRoutesLikely;
+	}
+
+	public void loadMoreRoutes()
+	{
+		if (lastAltTargets.isEmpty() || !moreRoutesLikely)
+		{
+			return;
+		}
+		int step = Math.max(1, Math.min(override("routeCountStep", config.routeCountStep()), 25));
+		routeLimit += step;
+		triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+	}
+
+	public AlternativeRoutesMode getRoutesMode()
+	{
+		return routesMode;
+	}
+
+	/**
+	 * Whether the bank's contents are known this session (false until the bank has been opened once).
+	 * Bank mode cannot see banked teleports until this is true — same constraint as Shortest Path's
+	 * own INVENTORY_AND_BANK setting.
+	 */
+	public boolean isBankContentsKnown()
+	{
+		return bankContentsKnown;
+	}
+
+	public void setRoutesMode(AlternativeRoutesMode mode)
+	{
+		if (mode == null || this.routesMode == mode)
+		{
+			return;
+		}
+		this.routesMode = mode;
+		saveRoutesMode();
+		triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+	}
+
+	/**
+	 * Light auto-detect, run each game tick: when Shortest Path's destination changes (a new target set
+	 * manually, by Quest Helper, on reaching the previous one, etc.) compute the alternatives once.
+	 * Deliberately keyed on the target SET only — never on start/movement — so the live path recalcs
+	 * that thrashed the old approach are ignored. If it ever misses, the panel's "Find routes" button
+	 * forces a recompute.
+	 */
+	private void maybeAutoComputeAlternatives()
+	{
+		if (altRoutesService == null)
+		{
+			return;
+		}
+		Pathfinder current = pathfinder;
+		Set<Integer> targets = (current != null) ? current.getTargets() : Set.of();
+		if (targets.isEmpty() || targets.equals(lastAltTargets))
+		{
+			return;
+		}
+		routeLimit = defaultRouteLimit();
+		triggerAlternatives(altStart(current), new HashSet<>(targets));
+	}
+
+	private void triggerAlternatives(int start, Set<Integer> targets)
+	{
+		if (altRoutesService == null)
+		{
+			return;
+		}
+		Set<Integer> ends = (targets == null) ? new HashSet<>() : new HashSet<>(targets);
+		lastAltStart = start;
+		lastAltTargets = Set.copyOf(ends);
+
+		// Clear the previous routes immediately (the catalog stays); the new routes stream in one by
+		// one as they are found. With no target this still streams just the teleport-methods catalog.
+		alternativeRoutes = new ArrayList<>();
+		moreRoutesLikely = false;
+		altGenerationInFlight = !ends.isEmpty();
+		final List<TeleportMethod> catalog = teleportCatalog;
+		final boolean hasTarget = !ends.isEmpty();
+		if (altPanel != null)
+		{
+			final Map<TeleportMethod, MethodAvailability> unavailable = unavailableMethods;
+			SwingUtilities.invokeLater(() ->
+				altPanel.displayRoutes(List.of(), catalog, unavailable, getUserExclusions(), true, hasTarget));
+		}
+		altRoutesService.generate(start, ends, userExclusions, routesMode, routeLimit, this::onAlternativeRoutesUpdate);
+	}
+
+	private void onAlternativeRoutesUpdate(List<RouteOption> routes, List<TeleportMethod> catalog,
+		Map<TeleportMethod, MethodAvailability> unavailable, boolean done)
+	{
+		alternativeRoutes = routes;
+		teleportCatalog = catalog;
+		unavailableMethods = unavailable;
+		if (done)
+		{
+			// If walking there is already on the list we've stopped at it, so there's nothing more to
+			// find; otherwise "more likely" when the generation filled every requested slot.
+			boolean stoppedAtWalk = routes.stream().anyMatch(RouteOption::isWalkOnly);
+			moreRoutesLikely = !stoppedAtWalk && !routes.isEmpty() && routes.size() >= routeLimit;
+			// Generation finished; if it produced nothing the classic path may draw again as fallback.
+			altGenerationInFlight = false;
+		}
+		final boolean hasTarget = !lastAltTargets.isEmpty();
+		SwingUtilities.invokeLater(() ->
+		{
+			if (selectedRoute != null && !routes.contains(selectedRoute))
+			{
+				selectedRoute = null;
+			}
+			if (altPanel != null)
+			{
+				altPanel.displayRoutes(routes, catalog, unavailable, getUserExclusions(), !done, hasTarget);
+			}
+		});
+	}
+
+
+	private void refreshPanel(boolean calculating)
+	{
+		final boolean hasTarget = !lastAltTargets.isEmpty();
+		if (altPanel != null)
+		{
+			SwingUtilities.invokeLater(() ->
+				altPanel.displayRoutes(alternativeRoutes, teleportCatalog, unavailableMethods,
+					getUserExclusions(), calculating, hasTarget));
+		}
+	}
+
+	private void saveExclusions()
+	{
+		try
+		{
+			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_EXCLUSIONS,
+				gson.toJson(new ArrayList<>(userExclusions)));
+		}
+		catch (Exception e)
+		{
+			log.warn("Failed to save alternative-route exclusions", e);
+		}
+	}
+
+	private void loadExclusions()
+	{
+		try
+		{
+			String json = configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY_EXCLUSIONS);
+			if (json == null || json.isEmpty())
+			{
+				return;
+			}
+			TeleportMethod[] saved = gson.fromJson(json, TeleportMethod[].class);
+			if (saved != null)
+			{
+				for (TeleportMethod method : saved)
+				{
+					if (method != null && method.getType() != null)
+					{
+						userExclusions.add(method);
+					}
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			log.warn("Failed to load alternative-route exclusions", e);
+		}
+	}
+
+	private void saveRoutesMode()
+	{
+		configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_MODE, routesMode.name());
+	}
+
+	private void loadRoutesMode()
+	{
+		String value = configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY_MODE);
+		if (value == null || value.isEmpty())
+		{
+			return;
+		}
+		try
+		{
+			routesMode = AlternativeRoutesMode.valueOf(value);
+		}
+		catch (IllegalArgumentException e)
+		{
+			// Legacy 3-mode names from before the Owned/All split.
+			switch (value)
+			{
+				case "AVAILABLE":
+					routesMode = AlternativeRoutesMode.OWNED_INVENTORY;
+					break;
+				case "AVAILABLE_WITH_BANK":
+					routesMode = AlternativeRoutesMode.OWNED_WITH_BANK;
+					break;
+				case "ALL_TELEPORTS":
+					routesMode = AlternativeRoutesMode.ALL_UNLOCKED;
+					break;
+				default:
+					log.warn("Unknown alternative-routes mode '{}'", value);
+					break;
+			}
+		}
 	}
 
 	public int calculateMapPoint(int pointX, int pointY)

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -490,13 +490,13 @@ public class ShortestPathPlugin extends Plugin
 
 	public Color getPathColor()
 	{
-		// A displayed alternative route is a static snapshot: colour it by whether it reached the target,
+		// A displayed alternative route is a static snapshot: colour it from its own endpoint,
 		// never by the classic pathfinder's background re-anchoring (which would otherwise flash the drawn
 		// route blue every time you walk far enough to trigger a recalculation).
 		RouteOption displayed = getDisplayedRoute();
 		if (displayed != null)
 		{
-			return displayed.isReached() ? colourPath : colourPathUnreachable;
+			return isRouteEndTooFar(displayed) ? colourPathUnreachable : colourPath;
 		}
 
 		if (pathfinder == null || !pathfinder.isDone())
@@ -516,6 +516,33 @@ public class ShortestPathPlugin extends Plugin
 		}
 
 		return colourPath;
+	}
+
+	/**
+	 * Mirrors {@link #isPathUnreachable()}'s tolerance for a displayed alternative route: a route that
+	 * stops at the closest reachable tile (e.g. because the exact target tile is an NPC/object spot)
+	 * still counts as reached for colouring while its endpoint is within the configured
+	 * unreachable-distance threshold — only genuinely far endpoints get the unreachable colour.
+	 */
+	private boolean isRouteEndTooFar(RouteOption route)
+	{
+		if (route.isReached())
+		{
+			return false;
+		}
+		List<PathStep> path = route.getPath();
+		Set<Integer> targets = lastAltTargets;
+		if (path == null || path.isEmpty() || targets.isEmpty())
+		{
+			return false;
+		}
+		int endPoint = path.get(path.size() - 1).getPackedPosition();
+		int closestTargetDistance = Integer.MAX_VALUE;
+		for (int target : targets)
+		{
+			closestTargetDistance = Math.min(closestTargetDistance, WorldPointUtil.distanceBetween(target, endPoint));
+		}
+		return closestTargetDistance > unreachableTargetDistance;
 	}
 
 	public boolean isPathUnreachable()

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -124,6 +124,8 @@ public class ShortestPathPlugin extends Plugin
 	Color colourPathUnreachable;
 	Color colourText;
 	Color colourTransports;
+	Color colourTeleportPulse;
+	boolean showTeleportPulse;
 	int tileCounterStep;
 	int unreachableTargetDistance;
 	String unreachableText;
@@ -1264,6 +1266,7 @@ public class ShortestPathPlugin extends Plugin
 		colourPathUnreachable = override("colourPathUnreachable", config.colourPathUnreachable());
 		colourText = override("colourText", config.colourText());
 		colourTransports = override("colourTransports", config.colourTransports());
+		colourTeleportPulse = override("colourTeleportPulse", config.colourTeleportPulse());
 
 		tileCounterStep = override("tileCounterStep", config.tileCounterStep());
 		unreachableTargetDistance = override("unreachableTargetDistanceThreshold", config.unreachableTargetDistance());
@@ -1271,6 +1274,7 @@ public class ShortestPathPlugin extends Plugin
 
 		showTileCounter = override("showTileCounter", config.showTileCounter());
 		pathStyle = override("pathStyle", config.pathStyle());
+		showTeleportPulse = override("showTeleportPulse", config.showTeleportPulse());
 	}
 
 	private String simplify(String text)

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -181,6 +181,9 @@ public class ShortestPathPlugin extends Plugin
 	private static final String CONFIG_KEY_EXCLUSIONS = "alternativeRoutesExclusions";
 	private static final String CONFIG_KEY_MODE = "alternativeRoutesMode";
 	private final Set<TeleportMethod> userExclusions = ConcurrentHashMap.newKeySet();
+	// The exclusions the current route list was generated with; diverging from userExclusions means
+	// the list is stale until the user refreshes (method toggles no longer auto-recalculate).
+	private volatile Set<TeleportMethod> generatedExclusions = Set.of();
 	// Which methods the alternatives consider: carried (default), carried + bank, or every teleport.
 	private volatile AlternativeRoutesMode routesMode = AlternativeRoutesMode.OWNED_INVENTORY;
 	// How many alternative routes to generate; grows when the user asks for more.
@@ -919,7 +922,13 @@ public class ShortestPathPlugin extends Plugin
 		// Snapshot the items now, while the bank is open: the client may empty the live container
 		// (and thereby every reference to it) once the interface closes.
 		pathfinderConfig.setBankSnapshot(event.getItemContainer().getItems());
+		boolean firstSight = !bankContentsKnown;
 		bankContentsKnown = true;
+		if (firstSight)
+		{
+			// Clear the panel's "bank contents unknown" warning the moment the bank is first seen.
+			refreshPanel(altGenerationInFlight);
+		}
 	}
 
 	@Subscribe
@@ -1595,15 +1604,24 @@ public class ShortestPathPlugin extends Plugin
 		{
 			return route.getPath();
 		}
-		// While the alternatives for the current destination are still computing, draw nothing rather
-		// than the classic path: the classic path follows the SP config (not the panel's mode) and can
-		// use methods the list will never contain. The first streamed route replaces it in <1s.
 		Pathfinder current = pathfinder;
-		if (altGenerationInFlight && current != null && lastAltTargets.equals(current.getTargets()))
+		if (current == null)
 		{
 			return List.of();
 		}
-		return current != null ? current.getPath() : List.of();
+		// The classic path is only a fallback here: route 1 replaces it as soon as the alternatives
+		// stream in. Drawing it in the meantime made the world path visibly jump around after setting
+		// a target — the progressive search frontier first, then its final shape, then blank, then
+		// route 1. Keep the world empty instead while the classic search is still running, while the
+		// alternatives are computing, or while their auto-trigger for this target is still pending
+		// (it fires on the next game tick). The classic path still draws when a generation finishes
+		// without producing any routes.
+		if (!current.getTargets().isEmpty()
+			&& (!current.isDone() || altGenerationInFlight || !lastAltTargets.equals(current.getTargets())))
+		{
+			return List.of();
+		}
+		return current.getPath();
 	}
 
 	public List<RouteOption> getAlternativeRoutes()
@@ -1633,7 +1651,9 @@ public class ShortestPathPlugin extends Plugin
 		if (method != null && userExclusions.add(method))
 		{
 			saveExclusions();
-			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+			// No recalculation here: exclusions apply on the next "Refresh routes to target" (or any
+			// other recompute); this just refreshes the panel so the catalog icons and counts update.
+			refreshPanel(altGenerationInFlight);
 		}
 	}
 
@@ -1642,7 +1662,9 @@ public class ShortestPathPlugin extends Plugin
 		if (method != null && userExclusions.remove(method))
 		{
 			saveExclusions();
-			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+			// No recalculation here: exclusions apply on the next "Refresh routes to target" (or any
+			// other recompute); this just refreshes the panel so the catalog icons and counts update.
+			refreshPanel(altGenerationInFlight);
 		}
 	}
 
@@ -1659,7 +1681,9 @@ public class ShortestPathPlugin extends Plugin
 		if (changed)
 		{
 			saveExclusions();
-			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+			// No recalculation here: exclusions apply on the next "Refresh routes to target" (or any
+			// other recompute); this just refreshes the panel so the catalog icons and counts update.
+			refreshPanel(altGenerationInFlight);
 		}
 	}
 
@@ -1676,7 +1700,9 @@ public class ShortestPathPlugin extends Plugin
 		if (changed)
 		{
 			saveExclusions();
-			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+			// No recalculation here: exclusions apply on the next "Refresh routes to target" (or any
+			// other recompute); this just refreshes the panel so the catalog icons and counts update.
+			refreshPanel(altGenerationInFlight);
 		}
 	}
 
@@ -1686,7 +1712,9 @@ public class ShortestPathPlugin extends Plugin
 		{
 			userExclusions.clear();
 			saveExclusions();
-			triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
+			// No recalculation here: exclusions apply on the next "Refresh routes to target" (or any
+			// other recompute); this just refreshes the panel so the catalog icons and counts update.
+			refreshPanel(altGenerationInFlight);
 		}
 	}
 
@@ -1758,6 +1786,15 @@ public class ShortestPathPlugin extends Plugin
 		triggerAlternatives(lastAltStart, new HashSet<>(lastAltTargets));
 	}
 
+	/**
+	 * Whether the displayed route list was generated with different method exclusions than are
+	 * currently selected — i.e. the user toggled methods since and hasn't pressed Refresh yet.
+	 */
+	public boolean isRouteListStale()
+	{
+		return !userExclusions.equals(generatedExclusions);
+	}
+
 	public AlternativeRoutesMode getRoutesMode()
 	{
 		return routesMode;
@@ -1822,6 +1859,9 @@ public class ShortestPathPlugin extends Plugin
 		alternativeRoutes = new ArrayList<>();
 		moreRoutesLikely = false;
 		altGenerationInFlight = !ends.isEmpty();
+		// Snapshot the exclusions this generation runs with, so the panel can flag the route list as
+		// stale once the user toggles methods afterwards (recalculation is manual via Refresh).
+		generatedExclusions = getUserExclusions();
 		final List<TeleportMethod> catalog = teleportCatalog;
 		final boolean hasTarget = !ends.isEmpty();
 		if (altPanel != null)

--- a/src/main/java/shortestpath/TeleportMethod.java
+++ b/src/main/java/shortestpath/TeleportMethod.java
@@ -1,0 +1,155 @@
+package shortestpath;
+
+import lombok.Getter;
+import shortestpath.transport.Transport;
+import shortestpath.transport.TransportType;
+
+/**
+ * A stable, human-meaningful identity for a single teleport/transport option, used by the
+ * alternative-routes feature both as the row shown in the side panel and as the key that the user
+ * can exclude from the next search.
+ * <p>
+ * Identity is {@code (type, displayInfo, destination)}: the {@link TransportType} groups options
+ * into a category (Spells, Fairy Rings, Items, ...), {@code displayInfo} is the per-option label the
+ * data files carry (e.g. "Varrock Teleport", "Ardougne cloak: Monastery", or a fairy-ring code), and
+ * the packed {@code destination} disambiguates options that carry no display info.
+ */
+@Getter
+public final class TeleportMethod
+{
+	private final TransportType type;
+	private final String displayInfo;
+	private final int destination;
+
+	public TeleportMethod(TransportType type, String displayInfo, int destination)
+	{
+		this.type = type;
+		this.displayInfo = (displayInfo == null || displayInfo.isEmpty()) ? null : displayInfo;
+		this.destination = destination;
+	}
+
+	public static TeleportMethod fromTransport(Transport transport)
+	{
+		return new TeleportMethod(transport.getType(), transport.getDisplayInfo(), transport.getDestination());
+	}
+
+	/**
+	 * The grouping bucket shown as a section header in the panel.
+	 */
+	public String category()
+	{
+		return categoryOf(type);
+	}
+
+	/**
+	 * The per-option label shown in the panel row. Falls back to the category plus the destination
+	 * tile when the data file carries no display info (common for spells whose info is the spell name).
+	 */
+	public String label()
+	{
+		if (displayInfo != null)
+		{
+			return displayInfo;
+		}
+		int x = WorldPointUtil.unpackWorldX(destination);
+		int y = WorldPointUtil.unpackWorldY(destination);
+		return category() + " (" + x + ", " + y + ")";
+	}
+
+	/**
+	 * Whether a transport type counts as a travel "method" worth listing and excluding. Plain local
+	 * connectors (doors/ladders/stairs and agility/grapple shortcuts) are walking, not a method.
+	 */
+	public static boolean isMethodType(TransportType type)
+	{
+		return type != null
+			&& type != TransportType.TRANSPORT
+			&& type != TransportType.AGILITY_SHORTCUT
+			&& type != TransportType.GRAPPLE_SHORTCUT;
+	}
+
+	public static String categoryOf(TransportType type)
+	{
+		if (type == null)
+		{
+			return "Other";
+		}
+		switch (type)
+		{
+			case TELEPORTATION_SPELL:
+				return "Spells";
+			case TELEPORTATION_ITEM:
+				return "Items";
+			case TELEPORTATION_BOX:
+				return "Jewellery box";
+			case TELEPORTATION_LEVER:
+				return "Levers";
+			case TELEPORTATION_MINIGAME:
+				return "Minigame teleports";
+			case TELEPORTATION_PORTAL:
+			case TELEPORTATION_PORTAL_POH:
+				return "Portals";
+			case FAIRY_RING:
+				return "Fairy rings";
+			case SPIRIT_TREE:
+				return "Spirit trees";
+			case GNOME_GLIDER:
+				return "Gnome gliders";
+			case HOT_AIR_BALLOON:
+				return "Hot air balloons";
+			case MAGIC_CARPET:
+				return "Magic carpets";
+			case MAGIC_MUSHTREE:
+				return "Mushtrees";
+			case MINECART:
+				return "Minecarts";
+			case QUETZAL:
+			case QUETZAL_WHISTLE:
+				return "Quetzals";
+			case WILDERNESS_OBELISK:
+				return "Obelisks";
+			case BOAT:
+			case CHARTER_SHIP:
+			case SHIP:
+				return "Boats & ships";
+			case CANOE:
+				return "Canoes";
+			case SEASONAL_TRANSPORTS:
+				return "Seasonal";
+			default:
+				return "Other";
+		}
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (!(o instanceof TeleportMethod))
+		{
+			return false;
+		}
+		TeleportMethod other = (TeleportMethod) o;
+		return destination == other.destination
+			&& type == other.type
+			&& (displayInfo == null ? other.displayInfo == null : displayInfo.equals(other.displayInfo));
+	}
+
+	@Override
+	public int hashCode()
+	{
+		int result = type == null ? 0 : type.hashCode();
+		result = 31 * result + (displayInfo == null ? 0 : displayInfo.hashCode());
+		result = 31 * result + destination;
+		return result;
+	}
+
+	@Override
+	public String toString()
+	{
+		return category() + ": " + label();
+	}
+}

--- a/src/main/java/shortestpath/TileStyle.java
+++ b/src/main/java/shortestpath/TileStyle.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 public enum TileStyle
 {
 	TILES("Tiles"),
-	LINES("Lines");
+	LINES("Lines"),
+	ARROW_LINE("Arrow line");
 
 	private final String type;
 

--- a/src/main/java/shortestpath/pathfinder/CollisionMap.java
+++ b/src/main/java/shortestpath/pathfinder/CollisionMap.java
@@ -124,7 +124,12 @@ public class CollisionMap
 			: 0;
 		for (Transport transport : transports)
 		{
-			boolean delayedVisit = transport.getType().sharesDestinationsWith() != null;
+			int bankSurcharge = bankPickupCost(config, pathBankVisited, packedPosition, transport);
+			// Bank-surcharged transports are enqueued as delayed visits: their cost no longer matches
+			// their creation order, so claiming the destination at enqueue (which for banked nodes also
+			// claims the unbanked plane, see VisitedTiles#set) could block a cheaper plain-walking path.
+			// Delayed visits are deduplicated at dequeue instead, in cost order.
+			boolean delayedVisit = transport.getType().sharesDestinationsWith() != null || bankSurcharge > 0;
 			// Do not consider a transport if we have already visited its target tile.
 			// For transports that share destinations with a teleport, skip this check
 			// so both can compete in the priority queue (delayed visit).
@@ -141,7 +146,7 @@ public class CollisionMap
 				transport.getDestination(),
 				node,
 				transport.getDuration(),
-				config.getAdditionalTransportCost(transport) + chainPenalty,
+				config.getAdditionalTransportCost(transport) + chainPenalty + bankSurcharge,
 				pathBankVisited,
 				delayedVisit,
 				delayedVisit ? config.getDifferentialCost(transport) : 0));
@@ -233,7 +238,11 @@ public class CollisionMap
 		int maxWildernessLevel = graph.abstractKind(node).maxWildernessLevel();
 		for (Transport transport : config.getUsableTeleports(bankVisited))
 		{
-			boolean delayedVisit = transport.getType().sharesDestinationsWith() != null;
+			int bankSurcharge = bankPickupCost(config, bankVisited, Transport.UNDEFINED_ORIGIN, transport);
+			// Bank-surcharged teleports are delayed visits (see getTileNeighbors): claiming their
+			// destination at enqueue would also claim the unbanked plane and could block a cheaper
+			// plain-walking path; dedup happens at dequeue instead, in cost order.
+			boolean delayedVisit = transport.getType().sharesDestinationsWith() != null || bankSurcharge > 0;
 			if (!delayedVisit && visited.get(transport.getDestination(), bankVisited))
 			{
 				continue;
@@ -255,11 +264,56 @@ public class CollisionMap
 				transport.getDestination(),
 				node,
 				transport.getDuration(),
-				config.getAdditionalTransportCost(transport),
+				config.getAdditionalTransportCost(transport) + bankSurcharge,
 				bankVisited,
 				delayedVisit,
 				differentialCost));
 		}
 		return neighbors;
+	}
+
+	/**
+	 * The bank pick-up surcharge for taking {@code transport} in the given bank state: the configured
+	 * cost when the transport is only available because the path visited a bank (i.e. it is absent from
+	 * the unbanked availability), otherwise zero. Charged on the transport edge itself — transport nodes
+	 * are ordered by the cost min-heap, so the surcharge steers the search without disturbing the FIFO
+	 * walking frontier, whose ordering assumes uniform step costs.
+	 */
+	private static int bankPickupCost(PathfinderConfig config, boolean bankVisited, int origin, Transport transport)
+	{
+		final int cost = config.getBankPickupCost();
+		if (!bankVisited || cost == 0)
+		{
+			return 0;
+		}
+		return availableWithoutBank(config, origin, transport) ? 0 : cost;
+	}
+
+	/**
+	 * Whether this transport is also in the unbanked availability (same identity): global teleports
+	 * (undefined origin) are matched in the unbanked teleport list, fixed-origin transports in the
+	 * unbanked per-tile transport map.
+	 */
+	private static boolean availableWithoutBank(PathfinderConfig config, int origin, Transport transport)
+	{
+		if (transport.getOrigin() == Transport.UNDEFINED_ORIGIN)
+		{
+			for (Transport candidate : config.getUsableTeleports(false))
+			{
+				if (candidate == transport)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+		for (Transport candidate : config.getTransportsPacked(false).getOrDefault(origin, TransportAvailability.EMPTY_TRANSPORTS))
+		{
+			if (candidate == transport)
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/shortestpath/pathfinder/Pathfinder.java
+++ b/src/main/java/shortestpath/pathfinder/Pathfinder.java
@@ -39,6 +39,9 @@ public class Pathfinder implements Runnable
 	// Built once on the worker thread when the search finishes, then served to the render thread so
 	// it never walks the node chain (which is released) after the search is done.
 	private volatile List<PathStep> finalPath = null;
+	// Accumulated cost of the path to bestLastNode, captured before the node graph is released so
+	// alternative-route ranking has a total cost without re-walking the (released) chain.
+	private volatile int finalCost = -1;
 	private volatile int closestReachedPoint = WorldPointUtil.UNDEFINED;
 	private int bestRemainingDistance = Integer.MAX_VALUE;
 	private int bestTravelledDistance = Integer.MAX_VALUE;
@@ -158,6 +161,7 @@ public class Pathfinder implements Runnable
 			reached,
 			currentPath,
 			closestReachedPoint,
+			finalCost,
 			currentStats.getNodesChecked(),
 			currentStats.getTransportsChecked(),
 			currentStats.getElapsedTimeNanos(),
@@ -361,11 +365,13 @@ public class Pathfinder implements Runnable
 		{
 			finalPath = graph.getPathSteps(lastNode);
 			closestReachedPoint = graph.getClosestTilePosition(lastNode);
+			finalCost = graph.cost(lastNode);
 		}
 		else
 		{
 			finalPath = pathSteps;
 			closestReachedPoint = start;
+			finalCost = 0;
 		}
 
 		done = !cancelled;

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -128,6 +128,13 @@ public class PathfinderConfig
 	private JewelleryBoxTier pohJewelleryBoxTier;
 	private int costConsumableTeleportationItems;
 	private int currencyThreshold;
+	/**
+	 * One-off cost surcharge for entering the banked state (routing through a bank to withdraw a
+	 * required item), so banking is only chosen when it saves more than this many tiles overall.
+	 * Applies wherever bank routing is enabled ({@link #isBankPathEnabled()}).
+	 */
+	@Getter
+	private int bankPickupCost;
 	@Getter
 	private boolean isOnSailingBoat;
 
@@ -286,6 +293,7 @@ public class PathfinderConfig
 
 		// Note: Transport type costs are now managed by transportTypeConfig.getCost()
 		costConsumableTeleportationItems = ShortestPathPlugin.override("costConsumableTeleportationItems", config.costConsumableTeleportationItems());
+		bankPickupCost = ShortestPathPlugin.override("costBankPickup", config.costBankPickup());
 
 		if (GameState.LOGGED_IN.equals(client.getGameState()))
 		{

--- a/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderConfig.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,9 +30,11 @@ import shortestpath.Destination;
 import shortestpath.DestinationRequirements;
 import shortestpath.ItemVariations;
 import shortestpath.JewelleryBoxTier;
+import shortestpath.MethodAvailability;
 import shortestpath.PrimitiveIntHashMap;
 import shortestpath.ShortestPathConfig;
 import shortestpath.ShortestPathPlugin;
+import shortestpath.TeleportMethod;
 import shortestpath.TeleportationItem;
 import shortestpath.WorldPointUtil;
 import shortestpath.leagues.LeagueModeState;
@@ -94,9 +98,16 @@ public class PathfinderConfig
 	private final Map<Quest, QuestState> questStates = new HashMap<>();
 	private final Map<Integer, Integer> varbitValues = new HashMap<>();
 	private final Map<Integer, Integer> varPlayerValues = new HashMap<>();
+	// Not final: parallel-seed copies share the primary planning copy's (already refreshed) instance.
 	@Getter
-	private final LeagueModeState leagueModeState = new LeagueModeState();
+	private LeagueModeState leagueModeState = new LeagueModeState();
 	public ItemContainer bank = null;
+	/**
+	 * Copy of the bank's items captured while the bank interface was open (ItemContainerChanged).
+	 * The live {@link #bank} container can be emptied by the client once the interface closes, which
+	 * also empties every reference to it — so bank-aware item checks fall back to this snapshot.
+	 */
+	private Item[] bankSnapshot = null;
 	public Set<String> availableSpiritTrees = null;
 	/**
 	 * Bank tiles the player may use for path banking state (requirements satisfied). Rebuilt in {@link #refresh()}.
@@ -110,6 +121,23 @@ public class PathfinderConfig
 	 */
 	private TransportAvailability transportAvailabilityWithoutBank;
 	private TransportAvailability transportAvailabilityWithBank;
+	/**
+	 * Planning copies only: the transports that passed every gate in the last client-thread
+	 * {@link #refresh()}. Since alt-routes exclusions only ever REMOVE entries, per-exclusion
+	 * availability can be rebuilt from these off the client thread
+	 * ({@link #rebuildAvailabilityWithExclusions}) without re-reading any game state.
+	 */
+	private List<Transport> baseUsableWithoutBank;
+	private List<Transport> baseUsableWithBank;
+	/**
+	 * Planning copies: every method-type transport that structurally exists in the world (independent of
+	 * item possession, character unlocks, config toggles and the user's own exclusions), mapped to
+	 * whether the player can use it right now and, if not, why. Built during the last client-thread
+	 * {@link #refresh()}; drives the panel's full teleport-method catalog and its per-method availability
+	 * markers in every mode. Insertion-ordered so the catalog keeps a stable order.
+	 */
+	@Getter
+	private Map<TeleportMethod, MethodAvailability> methodAvailability = Collections.emptyMap();
 	/**
 	 * Reference that points to either allDestinations or filteredDestinations
 	 */
@@ -129,14 +157,50 @@ public class PathfinderConfig
 	private int costConsumableTeleportationItems;
 	private int currencyThreshold;
 	/**
-	 * One-off cost surcharge for entering the banked state (routing through a bank to withdraw a
-	 * required item), so banking is only chosen when it saves more than this many tiles overall.
+	 * Extra search cost (in tiles) charged once when a path first detours through a bank to withdraw a
+	 * teleport item, so the pathfinder only banks when it saves more than this many tiles overall.
 	 * Applies wherever bank routing is enabled ({@link #isBankPathEnabled()}).
 	 */
 	@Getter
 	private int bankPickupCost;
 	@Getter
 	private boolean isOnSailingBoat;
+	/**
+	 * Alternative-routes "planning" mode. When true the per-player possession/unlock gates (transport
+	 * type toggles, item/rune/level/quest/var requirements, jewellery-box tier) are bypassed so the
+	 * search offers every teleport that exists in the game, regardless of whether the player can use
+	 * it right now. Structural world rules (sailing, POH master switch, league regions, POH variants,
+	 * planted spirit trees) still apply. Used by the alternative-routes service, never by the main path.
+	 */
+	private boolean planningMode = false;
+	/**
+	 * Alternative-routes "All" family: bypass item possession and the config-preference gates (type
+	 * toggles, consumable rules, jewellery tier) while still respecting character unlocks (skills,
+	 * quests, varbits) unless {@link #planningMode} is also set. Both "All" variants set this; only
+	 * "Everything" also sets {@code planningMode}.
+	 */
+	private boolean bypassItemPossession = false;
+	/**
+	 * True on the alternative-routes planning copy (not the main path config). Gates the per-mode
+	 * item/bank overrides applied in {@link #refresh()}.
+	 */
+	private boolean planningCopy = false;
+	/**
+	 * On planning copies: the main config this copy was created from. Used to fall back to the bank
+	 * container the main config captured from ItemContainerChanged events, since
+	 * {@code client.getItemContainer(BANK)} can return null once the bank interface is closed.
+	 */
+	private PathfinderConfig planningSource;
+	/**
+	 * Alternative-routes "owned with bank" mode: when true (and possession is not bypassed), the
+	 * planning copy offers teleport items in the bank and routes through a bank to pick them up.
+	 */
+	private boolean considerBank = false;
+	/**
+	 * Teleport methods the user has switched off in the alternative-routes panel; excluded from the
+	 * next search so a different method is forced.
+	 */
+	private Set<TeleportMethod> excludedMethods = Collections.emptySet();
 
 	public PathfinderConfig(Client client, ShortestPathConfig config)
 	{
@@ -173,6 +237,157 @@ public class PathfinderConfig
 		this.filteredDestinations = filteredDestinations;
 		this.destinations = allDestinations;
 		this.bankRequirements = bankRequirements;
+	}
+
+	/**
+	 * Builds a second config that shares this one's heavy immutable data (collision map, loaded
+	 * transports, destinations, bank requirements) so the alternative-routes service can run its own
+	 * searches without reloading the ~20 MB collision map or re-parsing the transport data. The copy
+	 * keeps its own mutable availability/state, so its {@link #refresh()} passes never disturb the
+	 * main path's config.
+	 */
+	protected PathfinderConfig(PathfinderConfig source)
+	{
+		this.client = source.client;
+		this.config = source.config;
+		this.transportTypeConfig = new TransportTypeConfig(source.config);
+		this.mapData = source.mapData;
+		this.map = ThreadLocal.withInitial(() -> new CollisionMap(this.mapData));
+		this.allTransports = source.allTransports;
+		this.transportAvailabilityWithoutBank = new TransportAvailability.Builder(this.allTransports.length).build();
+		this.transportAvailabilityWithBank = new TransportAvailability.Builder(this.allTransports.length).build();
+		this.allDestinations = source.allDestinations;
+		this.filteredDestinations = source.filteredDestinations;
+		this.destinations = source.allDestinations;
+		this.bankRequirements = source.bankRequirements;
+	}
+
+	/**
+	 * A planning-mode sibling of this config for the alternative-routes feature (see {@link #planningMode}).
+	 */
+	public PathfinderConfig copyForPlanning()
+	{
+		PathfinderConfig copy = newPlanningCopy();
+		copy.planningCopy = true;
+		copy.planningMode = true;
+		copy.bypassItemPossession = true;
+		copy.planningSource = this;
+		return copy;
+	}
+
+	/**
+	 * The copy allocation used by {@link #copyForPlanning()}; overridable so test subclasses can keep
+	 * their quest/varbit bypasses on the planning copy.
+	 */
+	protected PathfinderConfig newPlanningCopy()
+	{
+		return new PathfinderConfig(this);
+	}
+
+	/**
+	 * A sibling of this (already refreshed) planning copy for a parallel seed-search worker: shares
+	 * the immutable data plus every piece of refresh-derived state a search reads, so the worker can
+	 * {@link #rebuildAvailabilityWithExclusions rebuild} and search without any client-thread work.
+	 * The searcher-visible mutable state (transport availability) is per-copy, and the collision map
+	 * is per-thread, so concurrent searches don't interfere.
+	 */
+	public PathfinderConfig copyForParallelSearch()
+	{
+		PathfinderConfig copy = newPlanningCopy();
+		copy.planningCopy = true;
+		copy.planningMode = planningMode;
+		copy.bypassItemPossession = bypassItemPossession;
+		copy.considerBank = considerBank;
+		copy.excludedMethods = excludedMethods;
+		// Search-time state derived by the last refresh() of this config.
+		copy.calculationCutoffMillis = calculationCutoffMillis;
+		copy.avoidWilderness = avoidWilderness;
+		copy.includeBankPath = includeBankPath;
+		copy.accessibleBankTiles = accessibleBankTiles;
+		copy.destinations = destinations;
+		copy.leagueModeState = leagueModeState;
+		copy.costConsumableTeleportationItems = costConsumableTeleportationItems;
+		copy.currencyThreshold = currencyThreshold;
+		copy.bankPickupCost = bankPickupCost;
+		copy.bank = bank;
+		copy.bankSnapshot = bankSnapshot;
+		copy.planningSource = planningSource;
+		// Base availability lists (rebuild inputs) and the current availability as a starting point.
+		copy.baseUsableWithoutBank = baseUsableWithoutBank;
+		copy.baseUsableWithBank = baseUsableWithBank;
+		copy.transportAvailabilityWithoutBank = transportAvailabilityWithoutBank;
+		copy.transportAvailabilityWithBank = transportAvailabilityWithBank;
+		copy.transportTypeConfig.setTeleportationItemSetting(transportTypeConfig.getTeleportationItemSetting());
+		return copy;
+	}
+
+	/**
+	 * Captures a copy of the bank's items; called from ItemContainerChanged while the bank is open,
+	 * when the contents are guaranteed present.
+	 */
+	public void setBankSnapshot(Item[] items)
+	{
+		if (items != null && items.length > 0)
+		{
+			this.bankSnapshot = items.clone();
+		}
+	}
+
+	/**
+	 * The bank items to use for bank-aware checks: the live container while it has contents, else the
+	 * snapshot captured while the bank was open (this config's own, or the main config's for planning
+	 * copies). Null when the bank has never been seen this session.
+	 */
+	private Item[] resolveBankItems()
+	{
+		Item[] live = (bank != null) ? bank.getItems() : null;
+		if (live != null && live.length > 0)
+		{
+			return live;
+		}
+		if (bankSnapshot != null)
+		{
+			return bankSnapshot;
+		}
+		return (planningSource != null) ? planningSource.resolveBankItems() : live;
+	}
+
+	public void setExcludedMethods(Set<TeleportMethod> excludedMethods)
+	{
+		this.excludedMethods = (excludedMethods == null || excludedMethods.isEmpty())
+			? Collections.emptySet() : new HashSet<>(excludedMethods);
+	}
+
+	/**
+	 * For the planning copy: whether to also consider teleport items in the bank (routing through a
+	 * bank to pick them up). Ignored in full planning mode, which offers everything anyway.
+	 */
+	public void setConsiderBank(boolean considerBank)
+	{
+		this.considerBank = considerBank;
+	}
+
+	public boolean isPlanningMode()
+	{
+		return planningMode;
+	}
+
+	/**
+	 * Toggles whether this (planning) config bypasses character unlocks as well ({@code true} = the
+	 * "Everything" variant) or respects them. Takes effect on the next {@link #refresh()}.
+	 */
+	public void setPlanningMode(boolean planningMode)
+	{
+		this.planningMode = planningMode;
+	}
+
+	/**
+	 * Toggles whether item possession (and config-preference gates) are bypassed — the "All" family.
+	 * Takes effect on the next {@link #refresh()}.
+	 */
+	public void setBypassItemPossession(boolean bypassItemPossession)
+	{
+		this.bypassItemPossession = bypassItemPossession;
 	}
 
 	/**
@@ -243,6 +458,18 @@ public class PathfinderConfig
 		return getTransportAvailability(bankVisited).getUsableTeleports();
 	}
 
+	/**
+	 * The full teleport-method catalog: every distinct travel method (teleports + networks, never plain
+	 * walking connectors) that structurally exists in the world, regardless of whether the current mode
+	 * can route through it. Mode-independent, so flipping between Owned/All keeps the same catalog; each
+	 * entry's usability is reported separately by {@link #getMethodAvailability()}. Built during the last
+	 * client-thread {@link #refresh()} on a planning copy.
+	 */
+	public Set<TeleportMethod> getMethodCatalog()
+	{
+		return new LinkedHashSet<>(methodAvailability.keySet());
+	}
+
 	public TransportAvailability getTransportAvailability(boolean bankVisited)
 	{
 		return bankVisited ? transportAvailabilityWithBank : transportAvailabilityWithoutBank;
@@ -294,6 +521,26 @@ public class PathfinderConfig
 		// Note: Transport type costs are now managed by transportTypeConfig.getCost()
 		costConsumableTeleportationItems = ShortestPathPlugin.override("costConsumableTeleportationItems", config.costConsumableTeleportationItems());
 		bankPickupCost = ShortestPathPlugin.override("costBankPickup", config.costBankPickup());
+
+		// Alternative-routes "Owned" family: restrict teleport items to what the player possesses —
+		// inventory + equipment only, or additionally the bank (routing through a bank to pick items
+		// up). The "All" family bypasses possession via bypassItemPossession/planningMode instead.
+		if (planningCopy && !bypassItemPossession)
+		{
+			if (considerBank)
+			{
+				// Bank items are resolved at read time (resolveBankItems): live container when it has
+				// contents, else the snapshot captured while the bank was open (own or the main
+				// config's) — the client can empty the live container once the interface closes.
+				includeBankPath = true;
+				transportTypeConfig.setTeleportationItemSetting(TeleportationItem.INVENTORY_AND_BANK);
+			}
+			else
+			{
+				includeBankPath = false;
+				transportTypeConfig.setTeleportationItemSetting(TeleportationItem.INVENTORY);
+			}
+		}
 
 		if (GameState.LOGGED_IN.equals(client.getGameState()))
 		{
@@ -491,6 +738,15 @@ public class PathfinderConfig
 
 		TransportAvailability.Builder withoutBank = new TransportAvailability.Builder(allTransports.length);
 		TransportAvailability.Builder withBank = new TransportAvailability.Builder(allTransports.length);
+		// Planning copies capture the usable-transport base lists so per-exclusion rebuilds can run
+		// off the client thread. Valid because the alt-routes service always runs this client-thread
+		// refresh with an empty exclusion set (the catalog pass).
+		List<Transport> baseWithoutBank = planningCopy ? new ArrayList<>(allTransports.length / 4) : null;
+		List<Transport> baseWithBank = planningCopy ? new ArrayList<>(allTransports.length / 4) : null;
+		// Planning copies build the full teleport-method catalog (every structurally-possible method,
+		// independent of the current mode/possession/unlocks) alongside a per-method availability status,
+		// so the panel can show — and explain — the methods the player can't use right now in any mode.
+		Map<TeleportMethod, MethodAvailability> catalog = planningCopy ? new LinkedHashMap<>() : null;
 		for (Transport transport : allTransports)
 		{
 			for (Quest quest : transport.getQuests())
@@ -516,23 +772,164 @@ public class PathfinderConfig
 				}
 			}
 
+			// Catalog + availability: record every method-type transport that structurally exists, with
+			// why the player can (or can't) use it. Runs before the mode/possession/unlock filter below so
+			// the catalog is the same full set in every mode; user exclusions are intentionally ignored
+			// here (excluded methods still appear in the catalog, flagged separately).
+			if (catalog != null && TeleportMethod.isMethodType(transport.getType()) && passesStructuralGates(transport))
+			{
+				catalog.merge(TeleportMethod.fromTransport(transport), classifyAvailability(transport),
+					MethodAvailability::best);
+			}
+
 			if (!useTransport(transport))
 			{
 				continue;
 			}
 
-			boolean usableWithoutBank = hasRequiredItems(transport, true, true, false, true);
-			boolean usableWithBank = hasRequiredItems(transport, true, true, includeBankPath, true);
+			boolean usableWithoutBank = bypassItemPossession || hasRequiredItems(transport, true, true, false, true);
+			boolean usableWithBank = bypassItemPossession || hasRequiredItems(transport, true, true, includeBankPath, true);
 			if (usableWithoutBank)
 			{
 				withoutBank.add(transport);
+				if (baseWithoutBank != null)
+				{
+					baseWithoutBank.add(transport);
+				}
 			}
 			if (usableWithBank)
 			{
 				withBank.add(transport);
+				if (baseWithBank != null)
+				{
+					baseWithBank.add(transport);
+				}
 			}
 		}
 
+		withoutBank.remapPohTransports();
+		withBank.remapPohTransports();
+		transportAvailabilityWithoutBank = withoutBank.build();
+		transportAvailabilityWithBank = withBank.build();
+		if (planningCopy)
+		{
+			baseUsableWithoutBank = baseWithoutBank;
+			baseUsableWithBank = baseWithBank;
+			methodAvailability = (catalog != null) ? Collections.unmodifiableMap(catalog) : Collections.emptyMap();
+		}
+	}
+
+	/**
+	 * Classifies why the player can or cannot use this transport right now, independent of the mode's
+	 * possession/unlock bypasses and of the (hidden) teleportation-item config setting. Checks the
+	 * character-unlock gates first (missing level/quest/unlock), then item possession, distinguishing
+	 * "in the bank" from "not owned at all". Assumes the caller has already limited the input to
+	 * method-type transports that {@link #passesStructuralGates(Transport) structurally exist}.
+	 */
+	private MethodAvailability classifyAvailability(Transport transport)
+	{
+		TransportType type = transport.getType();
+
+		// Type-level unlock gates: these networks are gated by a quest/quest-progress at the transport-type
+		// level (via disableUnless above), not by per-transport requirements, so classify them explicitly.
+		if (TransportType.GNOME_GLIDER.equals(type)
+			&& !QuestState.FINISHED.equals(getQuestState(Quest.THE_GRAND_TREE)))
+		{
+			return MethodAvailability.MISSING_QUEST;
+		}
+		if (TransportType.MAGIC_MUSHTREE.equals(type)
+			&& !QuestState.FINISHED.equals(getQuestState(Quest.BONE_VOYAGE)))
+		{
+			return MethodAvailability.MISSING_QUEST;
+		}
+		if (TransportType.SPIRIT_TREE.equals(type)
+			&& !QuestState.FINISHED.equals(getQuestState(Quest.TREE_GNOME_VILLAGE)))
+		{
+			return MethodAvailability.MISSING_QUEST;
+		}
+		if (TransportType.FAIRY_RING.equals(type)
+			&& client.getVarbitValue(VarbitID.FAIRY2_QUEENCURE_QUEST) <= 39)
+		{
+			return MethodAvailability.MISSING_QUEST;
+		}
+
+		// Per-transport unlock gates.
+		if (!hasRequiredLevels(transport))
+		{
+			return MethodAvailability.MISSING_LEVEL;
+		}
+		if (transport.isQuestLocked() && !completedQuests(transport))
+		{
+			return MethodAvailability.MISSING_QUEST;
+		}
+		if (varbitChecks(transport) || varPlayerChecks(transport))
+		{
+			return MethodAvailability.LOCKED;
+		}
+
+		// Fairy rings additionally need a Dramen/Lunar staff unless the Lumbridge Elite diary is complete
+		// (mirrors hasRequiredItems' special case).
+		if (TransportType.FAIRY_RING.equals(type)
+			&& varbitValues.getOrDefault(VarbitID.LUMBRIDGE_DIARY_ELITE_COMPLETE, 0) != 1)
+		{
+			return classifyItems(DRAMEN_STAFF);
+		}
+		return classifyItems(transport.getItemRequirements());
+	}
+
+	/**
+	 * Item-possession half of {@link #classifyAvailability}: AVAILABLE if the requirement is satisfied
+	 * from the inventory/equipment (rune pouch included), else IN_BANK if the bank could supply it, else
+	 * MISSING_ITEM. The bank read here always consults the bank (unlike the routing checks, which gate it
+	 * on the teleportation-item setting) so a banked item is reported the same way in every mode.
+	 */
+	private MethodAvailability classifyItems(TransportItems items)
+	{
+		if (items == null)
+		{
+			return MethodAvailability.AVAILABLE;
+		}
+		if (hasRequiredItems(items, true, true, false, true))
+		{
+			return MethodAvailability.AVAILABLE;
+		}
+		if (hasRequiredItems(items, true, true, true, true, true))
+		{
+			return MethodAvailability.IN_BANK;
+		}
+		return MethodAvailability.MISSING_ITEM;
+	}
+
+	/**
+	 * Rebuilds the transport availability from the base lists captured by the last client-thread
+	 * {@link #refresh()}, applying only the given exclusion filter. Pure computation over cached
+	 * data — safe to call from the alt-routes worker thread, eliminating a client-thread round-trip
+	 * per search. Planning copies only; no-op until a refresh has captured the base lists.
+	 */
+	public void rebuildAvailabilityWithExclusions(Set<TeleportMethod> excluded)
+	{
+		List<Transport> baseWithoutBank = baseUsableWithoutBank;
+		List<Transport> baseWithBank = baseUsableWithBank;
+		if (baseWithoutBank == null || baseWithBank == null)
+		{
+			return;
+		}
+		TransportAvailability.Builder withoutBank = new TransportAvailability.Builder(baseWithoutBank.size());
+		for (Transport transport : baseWithoutBank)
+		{
+			if (excluded.isEmpty() || !excluded.contains(TeleportMethod.fromTransport(transport)))
+			{
+				withoutBank.add(transport);
+			}
+		}
+		TransportAvailability.Builder withBank = new TransportAvailability.Builder(baseWithBank.size());
+		for (Transport transport : baseWithBank)
+		{
+			if (excluded.isEmpty() || !excluded.contains(TeleportMethod.fromTransport(transport)))
+			{
+				withBank.add(transport);
+			}
+		}
 		withoutBank.remapPohTransports();
 		withBank.remapPohTransports();
 		transportAvailabilityWithoutBank = withoutBank.build();
@@ -670,15 +1067,92 @@ public class PathfinderConfig
 
 	private boolean useTransport(Transport transport)
 	{
-		// Sailing: suppress teleports while the player is aboard a boat.
-		// We don't model sailing navigation, so teleporting away mid-ocean would produce
-		// confusing suggestions. Pathfinding resumes normally after disembarking.
-		if (isOnSailingBoat && transport.getType().isTeleport())
+		// Alternative-routes exclusion: the user switched this exact method off for the next search.
+		if (!excludedMethods.isEmpty() && excludedMethods.contains(TeleportMethod.fromTransport(transport)))
 		{
 			return false;
 		}
 
-		// Master POH gate - if POH is disabled, reject all POH transports
+		// Structural world rules (sailing, POH master switch, league regions, POH variants, planted
+		// spirit trees): apply in every mode, including the catalog pass and full planning mode.
+		if (!passesStructuralGates(transport))
+		{
+			return false;
+		}
+
+		final boolean isQuestLocked = transport.isQuestLocked();
+		TransportType type = transport.getType();
+
+		// Config-preference gates (type toggles, consumable/None item rules, jewellery-box tier):
+		// bypassed by the alternative-routes "All" family. See PathfinderConfig#bypassItemPossession.
+		if (!bypassItemPossession)
+		{
+			// Check if transport type is enabled in config
+			if (!transportTypeConfig.isEnabled(type))
+			{
+				return false;
+			}
+
+			// Handle special cases for teleportation items and seasonal transports
+			if (!checkTeleportationItemRules(transport, type))
+			{
+				return false;
+			}
+
+			// Handle jewellery box tier filtering
+			if (TransportType.TELEPORTATION_BOX.equals(type) && !checkJewelleryBoxTier(transport))
+			{
+				return false;
+			}
+		}
+
+		// Character-unlock gates (skills, quests, varbits/varplayers): only bypassed by the full
+		// planning mode ("Everything"); the "All available" variant keeps them.
+		if (!planningMode)
+		{
+			if (!hasRequiredLevels(transport))
+			{
+				return false;
+			}
+
+			if (isQuestLocked && !completedQuests(transport))
+			{
+				return false;
+			}
+
+			if (varbitChecks(transport))
+			{
+				return false;
+			}
+
+			if (varPlayerChecks(transport))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Structural world rules a transport must satisfy regardless of the search mode: not teleporting off
+	 * a sailing boat, the POH master switch, league region unlocks, POH-variant sub-settings, and planted
+	 * spirit-tree availability. These depend on the state of the world, not on the player's possessions or
+	 * character unlocks, so they gate the main path, the "All" planning modes, and the method catalog
+	 * alike. Deliberately excludes the user's alt-routes exclusions (the catalog lists excluded methods).
+	 */
+	private boolean passesStructuralGates(Transport transport)
+	{
+		TransportType type = transport.getType();
+
+		// Sailing: suppress teleports while the player is aboard a boat. We don't model sailing
+		// navigation, so teleporting away mid-ocean would produce confusing suggestions.
+		if (isOnSailingBoat && type.isTeleport())
+		{
+			return false;
+		}
+
+		// Master POH gate - if POH is disabled, reject all POH transports.
 		if (!usePoh)
 		{
 			int originX = WorldPointUtil.unpackWorldX(transport.getOrigin());
@@ -691,59 +1165,15 @@ public class PathfinderConfig
 			}
 		}
 
-		// League region gate: in seasonal mode, drop transports that touch the
-		// always-blocked region or a region the player has not unlocked.
+		// League region gate: in seasonal mode, drop transports that touch the always-blocked region or
+		// a region the player has not unlocked.
 		if (!isTransportRegionAllowed(transport))
 		{
 			return false;
 		}
 
-		final boolean isQuestLocked = transport.isQuestLocked();
-		TransportType type = transport.getType();
-
-		// Check if transport type is enabled in config
-		if (!transportTypeConfig.isEnabled(type))
-		{
-			return false;
-		}
-
-		// Handle POH variants for types that have them
+		// POH variants (fairy ring / spirit tree / obelisk inside the POH) depend on POH sub-settings.
 		if (!checkPohVariant(transport, type))
-		{
-			return false;
-		}
-
-		// Handle special cases for teleportation items and seasonal transports
-		if (!checkTeleportationItemRules(transport, type))
-		{
-			return false;
-		}
-
-		// Handle jewellery box tier filtering
-		if (TransportType.TELEPORTATION_BOX.equals(type))
-		{
-			if (!checkJewelleryBoxTier(transport))
-			{
-				return false;
-			}
-		}
-
-		if (!hasRequiredLevels(transport))
-		{
-			return false;
-		}
-
-		if (isQuestLocked && !completedQuests(transport))
-		{
-			return false;
-		}
-
-		if (varbitChecks(transport))
-		{
-			return false;
-		}
-
-		if (varPlayerChecks(transport))
 		{
 			return false;
 		}
@@ -970,15 +1400,30 @@ public class PathfinderConfig
 			checkInventory, checkEquipment, checkBank, checkRunePouch);
 	}
 
-	/**
-	 * Checks if the player has all the required equipment and inventory items for the transport
-	 */
 	private boolean hasRequiredItems(
 		TransportItems transportItems,
 		boolean checkInventory,
 		boolean checkEquipment,
 		boolean checkBank,
 		boolean checkRunePouch)
+	{
+		return hasRequiredItems(transportItems, checkInventory, checkEquipment, checkBank, checkRunePouch, false);
+	}
+
+	/**
+	 * Checks if the player has all the required equipment and inventory items for the transport.
+	 *
+	 * @param forceBank when true the bank is consulted regardless of the teleportation-item setting
+	 *                  (the normal routing checks only read the bank in an "inventory + bank" setting).
+	 *                  Used by availability classification to detect banked items in any mode.
+	 */
+	private boolean hasRequiredItems(
+		TransportItems transportItems,
+		boolean checkInventory,
+		boolean checkEquipment,
+		boolean checkBank,
+		boolean checkRunePouch,
+		boolean forceBank)
 	{
 		if (transportItems == null)
 		{
@@ -1019,11 +1464,13 @@ public class PathfinderConfig
 		if (checkBank)
 		{
 			TeleportationItem teleportSetting = transportTypeConfig.getTeleportationItemSetting();
-			if (bank != null
-				&& (TeleportationItem.INVENTORY_AND_BANK.equals(teleportSetting)
+			Item[] bankItems = resolveBankItems();
+			if (bankItems != null
+				&& (forceBank
+				|| TeleportationItem.INVENTORY_AND_BANK.equals(teleportSetting)
 				|| TeleportationItem.INVENTORY_AND_BANK_NON_CONSUMABLE.equals(teleportSetting)))
 			{
-				for (Item item : bank.getItems())
+				for (Item item : bankItems)
 				{
 					if (item.getId() >= 0 && item.getQuantity() > 0)
 					{

--- a/src/main/java/shortestpath/pathfinder/PathfinderResult.java
+++ b/src/main/java/shortestpath/pathfinder/PathfinderResult.java
@@ -11,6 +11,11 @@ public class PathfinderResult
 	private final boolean reached;
 	private final List<PathStep> pathSteps;
 	private final int closestReachedPoint;
+	/**
+	 * Accumulated search cost (blended walk distance + transport ticks/penalties) of the returned
+	 * path. Used to rank alternative routes against each other.
+	 */
+	private final int totalCost;
 	private final int nodesChecked;
 	private final int transportsChecked;
 	private final long elapsedNanos;
@@ -22,6 +27,7 @@ public class PathfinderResult
 		boolean reached,
 		List<PathStep> pathSteps,
 		int closestReachedPoint,
+		int totalCost,
 		int nodesChecked,
 		int transportsChecked,
 		long elapsedNanos,
@@ -32,6 +38,7 @@ public class PathfinderResult
 		this.reached = reached;
 		this.pathSteps = pathSteps;
 		this.closestReachedPoint = closestReachedPoint;
+		this.totalCost = totalCost;
 		this.nodesChecked = nodesChecked;
 		this.transportsChecked = transportsChecked;
 		this.elapsedNanos = elapsedNanos;

--- a/src/main/java/shortestpath/transport/TransportTypeConfig.java
+++ b/src/main/java/shortestpath/transport/TransportTypeConfig.java
@@ -136,6 +136,18 @@ public class TransportTypeConfig
 	}
 
 	/**
+	 * Overrides the teleportation-item setting (used by the alternative-routes planning copy to force a
+	 * mode independent of the user's config). Keeps the teleport-item/box enabled states consistent.
+	 */
+	public void setTeleportationItemSetting(TeleportationItem setting)
+	{
+		this.teleportationItemSetting = setting;
+		boolean enabled = setting != TeleportationItem.NONE;
+		enabledStates.put(TransportType.TELEPORTATION_ITEM, enabled);
+		enabledStates.put(TransportType.TELEPORTATION_BOX, enabled);
+	}
+
+	/**
 	 * Sets the enabled state for a transport type.
 	 * Used for runtime modifications (e.g., disabling fairy rings without dramen
 	 * staff).

--- a/src/test/java/shortestpath/ArrowHeadTest.java
+++ b/src/test/java/shortestpath/ArrowHeadTest.java
@@ -1,0 +1,75 @@
+package shortestpath;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ArrowHeadTest
+{
+	private static final int SIZE = 40;
+	private static final int OPAQUE_WHITE = 0xFFFFFFFF;
+
+	private static BufferedImage drawHead(double x1, double y1, double x2, double y2)
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setColor(Color.WHITE);
+		ArrowHead.draw(graphics, x1, y1, x2, y2, 8);
+		graphics.dispose();
+		return image;
+	}
+
+	private static boolean painted(BufferedImage image, int x, int y)
+	{
+		return (image.getRGB(x, y) >>> 24) != 0;
+	}
+
+	@Test
+	public void tipIsAtSegmentEnd()
+	{
+		BufferedImage image = drawHead(10, 20, 30, 20);
+		assertTrue("A pixel just behind the tip must be painted", painted(image, 29, 20));
+		assertTrue("Nothing may be painted past the tip", !painted(image, 32, 20));
+	}
+
+	@Test
+	public void headPointsAlongSegmentDirection()
+	{
+		// East-pointing: the body extends west of the tip, not north/south of the segment axis by more
+		// than the head's half-width, and nothing lands near the segment's start.
+		BufferedImage east = drawHead(10, 20, 30, 20);
+		assertTrue("Body extends back along the segment", painted(east, 24, 20));
+		assertTrue("Start of the segment stays unpainted", !painted(east, 12, 20));
+
+		// South-pointing: same shape rotated 90°.
+		BufferedImage south = drawHead(20, 10, 20, 30);
+		assertTrue("Body extends back along the segment", painted(south, 20, 24));
+		assertTrue("Start of the segment stays unpainted", !painted(south, 20, 12));
+	}
+
+	@Test
+	public void usesCurrentGraphicsColour()
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setColor(Color.WHITE);
+		ArrowHead.draw(graphics, 10, 20, 30, 20, 8);
+		graphics.dispose();
+		assertEquals("Head is filled with the graphics' current colour", OPAQUE_WHITE, image.getRGB(28, 20));
+	}
+
+	@Test
+	public void restoresGraphicsTransform()
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setColor(Color.WHITE);
+		java.awt.geom.AffineTransform before = graphics.getTransform();
+		ArrowHead.draw(graphics, 10, 20, 30, 20, 8);
+		assertEquals("Drawing must not disturb the caller's transform", before, graphics.getTransform());
+		graphics.dispose();
+	}
+}

--- a/src/test/java/shortestpath/pathfinder/AlternativeRoutesBankModeTest.java
+++ b/src/test/java/shortestpath/pathfinder/AlternativeRoutesBankModeTest.java
@@ -1,0 +1,136 @@
+package shortestpath.pathfinder;
+
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Skill;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+import shortestpath.ShortestPathConfig;
+import shortestpath.TeleportationItem;
+import shortestpath.WorldPointUtil;
+
+/**
+ * Verifies the alternative-routes "Bank" mode replicates Shortest Path's bank-pickup behaviour on
+ * the planning copy: a teleport item that exists only in the bank must produce a route that walks to
+ * a bank, flips into bankVisited state, and then teleports — even when the user's own Shortest Path
+ * config has teleport items disabled.
+ * <p>
+ * Mirrors {@code PathfinderTest.testCowbellAmuletInBankUsedAfterBankVisit} (Varrock centre → Cowbell
+ * amulet destination, expected path length 36) so any divergence from the main plugin's behaviour
+ * fails the parity assertion.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AlternativeRoutesBankModeTest
+{
+	private static final int VARROCK_CENTRE = WorldPointUtil.packWorldPoint(3213, 3424, 0);
+	private static final int COWBELL_DESTINATION = WorldPointUtil.packWorldPoint(3259, 3277, 0);
+	private static final int COWBELL_AMULET = 33104;
+
+	@Mock
+	Client client;
+	@Mock
+	ItemContainer bank;
+	@Mock
+	ShortestPathConfig config;
+
+	@Before
+	public void before()
+	{
+		when(config.calculationCutoff()).thenReturn(30);
+		when(config.currencyThreshold()).thenReturn(10000000);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		when(client.getClientThread()).thenReturn(Thread.currentThread());
+		when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+		// The user's own Shortest Path config is deliberately restrictive: teleport items OFF.
+		// The Owned modes force their own item setting, so they must work independently of it.
+		when(config.useTeleportationItems()).thenReturn(TeleportationItem.NONE);
+	}
+
+	/**
+	 * A planning copy in the "Owned" family: inventory-only, or inventory + bank.
+	 */
+	private PathfinderConfig planningCopy(boolean considerBank)
+	{
+		return planningCopy(considerBank, new TestPathfinderConfig(client, config));
+	}
+
+	private PathfinderConfig planningCopy(boolean considerBank, PathfinderConfig base)
+	{
+		PathfinderConfig planning = base.copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setBypassItemPossession(false);
+		planning.setConsiderBank(considerBank);
+		planning.refresh();
+		return planning;
+	}
+
+	private Pathfinder run(PathfinderConfig planning)
+	{
+		Pathfinder pathfinder = new Pathfinder(planning, VARROCK_CENTRE, Set.of(COWBELL_DESTINATION));
+		pathfinder.run();
+		return pathfinder;
+	}
+
+	@Test
+	public void bankModeUsesBankedTeleportViaBankVisit()
+	{
+		// Bank open: the live container (event-captured by onItemContainerChanged) has the amulet.
+		doReturn(new Item[]{new Item(COWBELL_AMULET, 1)}).when(bank).getItems();
+		PathfinderConfig base = new TestPathfinderConfig(client, config);
+		base.bank = bank;
+
+		Pathfinder pathfinder = run(planningCopy(true, base));
+
+		assertTrue("Bank mode should reach the target", pathfinder.getResult().isReached());
+		assertTrue("Route should pass through a bank (bankVisited state)",
+			pathfinder.getPath().stream().anyMatch(PathStep::isBankVisited));
+		// Parity with PathfinderTest.testCowbellAmuletInBankUsedAfterBankVisit (main plugin behaviour).
+		assertEquals("Bank-mode route should match the main plugin's bank-pickup path length",
+			36, pathfinder.getPath().size());
+	}
+
+	@Test
+	public void bankModeSurvivesLiveContainerEmptiedOnBankClose()
+	{
+		// Regression (user-reported): once the bank interface closes, the client can EMPTY the live
+		// container — and with it every reference to it, including the event-captured one. The items
+		// snapshot taken while the bank was open must keep bank routes working.
+		doReturn(new Item[0]).when(bank).getItems(); // live container emptied on close
+		PathfinderConfig base = new TestPathfinderConfig(client, config);
+		base.bank = bank;
+		base.setBankSnapshot(new Item[]{new Item(COWBELL_AMULET, 1)}); // captured while the bank was open
+
+		Pathfinder pathfinder = run(planningCopy(true, base));
+
+		assertTrue("Bank mode should reach the target using the bank snapshot", pathfinder.getResult().isReached());
+		assertTrue("Route should pass through a bank (bankVisited state)",
+			pathfinder.getPath().stream().anyMatch(PathStep::isBankVisited));
+		assertEquals("Route should match the bank-pickup path length", 36, pathfinder.getPath().size());
+	}
+
+	@Test
+	public void inventoryModeDoesNotUseBankedItems()
+	{
+		// Same scenario but in Owned/Inventory mode: the amulet is only in the bank, so the route
+		// must not use it nor route through a bank.
+		Pathfinder pathfinder = run(planningCopy(false));
+
+		assertTrue("Walking route should still reach the target", pathfinder.getResult().isReached());
+		assertFalse("Inventory mode must not enter bankVisited state",
+			pathfinder.getPath().stream().anyMatch(PathStep::isBankVisited));
+		assertTrue("Without the banked teleport the route must be longer than the bank-mode route",
+			pathfinder.getPath().size() > 36);
+	}
+}

--- a/src/test/java/shortestpath/pathfinder/AlternativeRoutesServiceTest.java
+++ b/src/test/java/shortestpath/pathfinder/AlternativeRoutesServiceTest.java
@@ -1,0 +1,392 @@
+package shortestpath.pathfinder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Skill;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.callback.ClientThread;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+import shortestpath.AlternativeRoutesMode;
+import shortestpath.AlternativeRoutesService;
+import shortestpath.MethodAvailability;
+import shortestpath.RouteOption;
+import shortestpath.ShortestPathConfig;
+import shortestpath.TeleportMethod;
+import shortestpath.TeleportationItem;
+import shortestpath.WorldPointUtil;
+import shortestpath.transport.TransportType;
+
+/**
+ * Covers the alternative-routes generator: the walk cheapest case now stops at the pure-walk option
+ * (nothing costlier shown after it), teleport weights are charged into route cost, and user exclusions
+ * keep a method out of the results.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AlternativeRoutesServiceTest
+{
+	// Two tiles west of Varrock centre: walking (cost 2) beats every teleport, so walking is the whole
+	// route list.
+	private static final int START = WorldPointUtil.packWorldPoint(3215, 3424, 0);
+	private static final int TARGET = WorldPointUtil.packWorldPoint(3213, 3424, 0);
+	// Lumbridge, far south: here the Varrock Teleport lands on TARGET (Varrock centre) and beats the long
+	// walk, so a teleport route is the cheapest and does show up — used to test weights and exclusions.
+	private static final int FAR_START = WorldPointUtil.packWorldPoint(3222, 3218, 0);
+
+	@Mock
+	Client client;
+	@Mock
+	ClientThread clientThread;
+	@Mock
+	ItemContainer inventory;
+	@Mock
+	ItemContainer bank;
+	@Mock
+	ShortestPathConfig config;
+
+	@Before
+	public void before()
+	{
+		when(config.calculationCutoff()).thenReturn(30);
+		when(config.currencyThreshold()).thenReturn(10000000);
+		when(config.useTeleportationSpells()).thenReturn(true);
+		when(config.useTeleportationItems()).thenReturn(TeleportationItem.NONE);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		when(client.getClientThread()).thenAnswer(invocation -> Thread.currentThread());
+		when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+		// Runes for Varrock Teleport in the inventory.
+		doReturn(new Item[]{
+			new Item(ItemID.LAWRUNE, 10),
+			new Item(ItemID.AIRRUNE, 30),
+			new Item(ItemID.FIRERUNE, 10),
+		}).when(inventory).getItems();
+		when(client.getItemContainer(InventoryID.INV)).thenReturn(inventory);
+		// The service bounces refreshes onto the client thread; run them inline.
+		doAnswer(invocation ->
+		{
+			((Runnable) invocation.getArgument(0)).run();
+			return null;
+		}).when(clientThread).invokeLater(any(Runnable.class));
+	}
+
+	@Test
+	public void walkBestRouteStopsAtWalk() throws Exception
+	{
+		// Walking the 2 tiles beats every teleport, so we stop at the pure-walk option: the result is
+		// just the walk route, with no costlier teleport routes tacked on after it.
+		PathfinderConfig planning = new TestPathfinderConfig(client, config).copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setConsiderBank(false);
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		CountDownLatch done = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> finalRoutes = new AtomicReference<>(List.of());
+		service.generate(START, Set.of(TARGET), Set.of(), AlternativeRoutesMode.OWNED_INVENTORY, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					finalRoutes.set(routes);
+					done.countDown();
+				}
+			});
+		assertTrue("Generation should complete", done.await(120, TimeUnit.SECONDS));
+		service.shutdown();
+
+		List<RouteOption> routes = finalRoutes.get();
+		assertTrue("Expected the walking route", !routes.isEmpty());
+		assertTrue("The last route must be the pure-walk option (nothing shown after it)",
+			routes.get(routes.size() - 1).isWalkOnly());
+		assertTrue("No teleport route should be shown once walking is the cheapest option",
+			routes.stream().noneMatch(r -> r.getMethods().stream().anyMatch(
+				m -> m.getType() == TransportType.TELEPORTATION_SPELL)));
+		assertTrue("Every route should reach the target",
+			routes.stream().allMatch(RouteOption::isReached));
+	}
+
+	@Test
+	public void teleportWeightIsChargedIntoRouteCost() throws Exception
+	{
+		// Far from Varrock the teleport (landing on the target) beats the long walk, so it shows up.
+		// With a 100-step weight on teleport spells, that route's cost must carry the surcharge.
+		when(config.costTeleportationSpells()).thenReturn(100);
+		PathfinderConfig planning = new TestPathfinderConfig(client, config).copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setConsiderBank(false);
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		CountDownLatch done = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> finalRoutes = new AtomicReference<>(List.of());
+		service.generate(FAR_START, Set.of(TARGET), Set.of(), AlternativeRoutesMode.OWNED_INVENTORY, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					finalRoutes.set(routes);
+					done.countDown();
+				}
+			});
+		assertTrue("Generation should complete", done.await(120, TimeUnit.SECONDS));
+		service.shutdown();
+
+		RouteOption spellRoute = finalRoutes.get().stream()
+			.filter(r -> r.getMethods().stream().anyMatch(m -> m.getType() == TransportType.TELEPORTATION_SPELL))
+			.findFirst().orElse(null);
+		assertTrue("A Varrock Teleport route should be the cheapest way there", spellRoute != null);
+		assertTrue("The teleport route must carry the 100-step weight, got " + spellRoute.getTotalCost(),
+			spellRoute.getTotalCost() >= 100);
+	}
+
+	@Test
+	public void bankModeRouteShowsWalkToBankBeforeTeleport() throws Exception
+	{
+		// Cowbell amulet only in the bank (Varrock centre -> cowbell destination). The route must
+		// contain the walked leg to a bank BEFORE the teleport jump — not teleport from the start tile.
+		int varrockCentre = WorldPointUtil.packWorldPoint(3213, 3424, 0);
+		int cowbellDestination = WorldPointUtil.packWorldPoint(3259, 3277, 0);
+		doReturn(new Item[]{new Item(33104, 1)}).when(bank).getItems();
+		PathfinderConfig base = new TestPathfinderConfig(client, config);
+		base.bank = bank; // what ShortestPathPlugin.onItemContainerChanged does while the bank is open
+
+		PathfinderConfig planning = base.copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setConsiderBank(true);
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		CountDownLatch done = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> finalRoutes = new AtomicReference<>(List.of());
+		service.generate(varrockCentre, Set.of(cowbellDestination), Set.of(), AlternativeRoutesMode.OWNED_WITH_BANK, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					finalRoutes.set(routes);
+					done.countDown();
+				}
+			});
+		assertTrue("Generation should complete", done.await(120, TimeUnit.SECONDS));
+		service.shutdown();
+
+		RouteOption bankedRoute = finalRoutes.get().stream()
+			.filter(r -> r.getMethods().stream().anyMatch(m -> m.getType() == TransportType.TELEPORTATION_ITEM))
+			.findFirst().orElse(null);
+		assertTrue("A route using the banked teleport item should exist", bankedRoute != null);
+
+		List<PathStep> path = bankedRoute.getPath();
+		int firstBankVisited = -1;
+		for (int i = 0; i < path.size(); i++)
+		{
+			if (path.get(i).isBankVisited())
+			{
+				firstBankVisited = i;
+				break;
+			}
+		}
+		assertTrue("Route must pass through a bank (bankVisited must flip)", firstBankVisited >= 0);
+		assertTrue("Route must include the walked leg to the bank before the teleport, but bankVisited "
+				+ "flipped at step " + firstBankVisited + " of " + path.size(),
+			firstBankVisited > 5);
+		assertTrue("Route must be flagged as going via the bank (panel indicator)", bankedRoute.isViaBank());
+	}
+
+	@Test
+	public void userExcludedTeleportIsNotSeeded() throws Exception
+	{
+		PathfinderConfig planning = new TestPathfinderConfig(client, config).copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setConsiderBank(false);
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		// Far from Varrock the Varrock Teleport (landing on the target) is the cheapest route, so it
+		// surfaces. Capture its method identity from a first, unexcluded run.
+		CountDownLatch firstDone = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> firstRoutes = new AtomicReference<>(List.of());
+		service.generate(FAR_START, Set.of(TARGET), Set.of(), AlternativeRoutesMode.OWNED_INVENTORY, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					firstRoutes.set(routes);
+					firstDone.countDown();
+				}
+			});
+		assertTrue(firstDone.await(120, TimeUnit.SECONDS));
+		Set<TeleportMethod> spellMethods = new java.util.HashSet<>();
+		for (RouteOption route : firstRoutes.get())
+		{
+			for (TeleportMethod method : route.getMethods())
+			{
+				if (method.getType() == TransportType.TELEPORTATION_SPELL)
+				{
+					spellMethods.add(method);
+				}
+			}
+		}
+		assertTrue("Precondition: a spell route was found", !spellMethods.isEmpty());
+
+		// Re-run with those methods excluded: no spell route may appear.
+		CountDownLatch secondDone = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> secondRoutes = new AtomicReference<>(List.of());
+		service.generate(FAR_START, Set.of(TARGET), spellMethods, AlternativeRoutesMode.OWNED_INVENTORY, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					secondRoutes.set(routes);
+					secondDone.countDown();
+				}
+			});
+		assertTrue(secondDone.await(120, TimeUnit.SECONDS));
+		service.shutdown();
+
+		assertTrue("Excluded spell must not be seeded back in",
+			secondRoutes.get().stream().noneMatch(r -> r.getMethods().stream().anyMatch(spellMethods::contains)));
+	}
+
+	@Test
+	public void inBankMethodFlaggedUnavailableOnlyOutsideBankMode() throws Exception
+	{
+		// Cowbell amulet only in the bank: Owned/Inventory must flag its method IN_BANK in the
+		// unavailable map, while Owned/Inv+bank treats it as usable (its routes walk to a bank), so it
+		// must NOT be flagged there. The catalog contains the method either way.
+		int cowbellDestination = WorldPointUtil.packWorldPoint(3259, 3277, 0);
+		PathfinderConfig base = new TestPathfinderConfig(client, config);
+		base.setBankSnapshot(new Item[]{new Item(33104, 1)});
+		PathfinderConfig planning = base.copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setConsiderBank(false);
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		Map<TeleportMethod, MethodAvailability> inventoryUnavailable =
+			finalUnavailable(service, AlternativeRoutesMode.OWNED_INVENTORY);
+		Map<TeleportMethod, MethodAvailability> bankUnavailable =
+			finalUnavailable(service, AlternativeRoutesMode.OWNED_WITH_BANK);
+		service.shutdown();
+
+		TeleportMethod cowbell = planning.getMethodCatalog().stream()
+			.filter(m -> m.getType() == TransportType.TELEPORTATION_ITEM && m.getDestination() == cowbellDestination)
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("Cowbell amulet method missing from the catalog"));
+		assertTrue("Inventory mode must flag the banked item as IN_BANK",
+			inventoryUnavailable.get(cowbell) == MethodAvailability.IN_BANK);
+		assertTrue("Inv+bank mode must treat the banked item as usable (not flagged)",
+			!bankUnavailable.containsKey(cowbell));
+	}
+
+	/**
+	 * Runs one generation in the given mode and returns the final update's unavailable map.
+	 */
+	private Map<TeleportMethod, MethodAvailability> finalUnavailable(
+		AlternativeRoutesService service, AlternativeRoutesMode mode) throws Exception
+	{
+		CountDownLatch done = new CountDownLatch(1);
+		AtomicReference<Map<TeleportMethod, MethodAvailability>> result = new AtomicReference<>(Map.of());
+		service.generate(START, Set.of(TARGET), Set.of(), mode, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					result.set(unavailable);
+					done.countDown();
+				}
+			});
+		assertTrue("Generation should complete", done.await(120, TimeUnit.SECONDS));
+		return result.get();
+	}
+
+	@Test
+	public void bankPickupWeightChargedExactlyOnceIntoBankedRouteCost() throws Exception
+	{
+		// Run the same bank-pickup scenario twice: first with no bank-pickup weight, then with a
+		// 60-step weight (small enough that banking still beats the ~147-tile walk, so the route isn't
+		// dropped by the stop-at-walk rule). The banked route's cost must rise by exactly the weight —
+		// charged once on entering the banked state, not per edge.
+		when(config.costBankPickup()).thenReturn(0, 60);
+		int varrockCentre = WorldPointUtil.packWorldPoint(3213, 3424, 0);
+		int cowbellDestination = WorldPointUtil.packWorldPoint(3259, 3277, 0);
+		doReturn(new Item[]{new Item(33104, 1)}).when(bank).getItems();
+		PathfinderConfig base = new TestPathfinderConfig(client, config);
+		base.bank = bank;
+		PathfinderConfig planning = base.copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setConsiderBank(true);
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		int baseline = bankedRouteCost(service, varrockCentre, cowbellDestination);
+		int weighted = bankedRouteCost(service, varrockCentre, cowbellDestination);
+		service.shutdown();
+
+		assertTrue("Baseline banked route should cost something, got " + baseline, baseline > 0);
+		assertTrue("Banked route must carry the 60-step bank-pickup weight exactly once ("
+				+ baseline + " -> " + weighted + ")",
+			weighted == baseline + 60);
+	}
+
+	/**
+	 * Runs one Owned/Inv+bank generation and returns the via-bank route's total cost.
+	 */
+	private int bankedRouteCost(AlternativeRoutesService service, int start, int target) throws Exception
+	{
+		CountDownLatch done = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> finalRoutes = new AtomicReference<>(List.of());
+		service.generate(start, Set.of(target), Set.of(), AlternativeRoutesMode.OWNED_WITH_BANK, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					finalRoutes.set(routes);
+					done.countDown();
+				}
+			});
+		assertTrue("Generation should complete", done.await(120, TimeUnit.SECONDS));
+		RouteOption bankedRoute = finalRoutes.get().stream()
+			.filter(RouteOption::isViaBank)
+			.findFirst().orElse(null);
+		assertTrue("A route via the bank should exist", bankedRoute != null);
+		return bankedRoute.getTotalCost();
+	}
+
+	@Test
+	public void everythingModeSurfacesTeleportsWithoutOwnedItems() throws Exception
+	{
+		// No inventory at all: the Owned modes could only walk, but "Everything" bypasses possession,
+		// so teleport routes must still be offered.
+		when(client.getItemContainer(InventoryID.INV)).thenReturn(null);
+		PathfinderConfig planning = new TestPathfinderConfig(client, config).copyForPlanning();
+		AlternativeRoutesService service = new AlternativeRoutesService(clientThread, planning);
+
+		CountDownLatch done = new CountDownLatch(1);
+		AtomicReference<List<RouteOption>> finalRoutes = new AtomicReference<>(List.of());
+		service.generate(FAR_START, Set.of(TARGET), Set.of(), AlternativeRoutesMode.ALL_EVERYTHING, 10,
+			(routes, catalog, unavailable, isDone) ->
+			{
+				if (isDone)
+				{
+					finalRoutes.set(routes);
+					done.countDown();
+				}
+			});
+		assertTrue("Generation should complete", done.await(120, TimeUnit.SECONDS));
+		service.shutdown();
+
+		assertTrue("Everything mode must offer teleport routes despite owning no items",
+			finalRoutes.get().stream().anyMatch(r -> !r.getMethods().isEmpty()));
+	}
+}

--- a/src/test/java/shortestpath/pathfinder/AlternativeRoutesServiceTest.java
+++ b/src/test/java/shortestpath/pathfinder/AlternativeRoutesServiceTest.java
@@ -204,6 +204,13 @@ public class AlternativeRoutesServiceTest
 				+ "flipped at step " + firstBankVisited + " of " + path.size(),
 			firstBankVisited > 5);
 		assertTrue("Route must be flagged as going via the bank (panel indicator)", bankedRoute.isViaBank());
+		// The detour must be attributed to the right method: the banked teleport item, and only it —
+		// so the panel can say which method the bank walk is for (user report: an equipped Ardougne
+		// cloak looked like the reason for a bank trip that was actually for a banked item).
+		assertTrue("The bank detour must be attributed to the teleport-item method",
+			bankedRoute.getBankMethods().stream().anyMatch(m -> m.getType() == TransportType.TELEPORTATION_ITEM));
+		assertTrue("Only bank-gated methods may be attributed to the bank detour",
+			bankedRoute.getMethods().containsAll(bankedRoute.getBankMethods()));
 	}
 
 	@Test

--- a/src/test/java/shortestpath/pathfinder/BankPickupCostTest.java
+++ b/src/test/java/shortestpath/pathfinder/BankPickupCostTest.java
@@ -1,0 +1,138 @@
+package shortestpath.pathfinder;
+
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Skill;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+import shortestpath.ShortestPathConfig;
+import shortestpath.TeleportationItem;
+import shortestpath.WorldPointUtil;
+
+/**
+ * Covers the bank pick-up cost ("Bank pick-up threshold"): a one-off surcharge charged when the
+ * route first enters the banked state, so routing through a bank to withdraw a teleport item only
+ * wins when it saves more than that many tiles overall.
+ * <p>
+ * Scenario mirrors {@code PathfinderTest.testCowbellAmuletInBankUsedAfterBankVisit}: Varrock centre
+ * to the Cowbell amulet destination with the amulet only in the bank — banking + teleporting takes
+ * 36 steps, plain walking considerably more.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BankPickupCostTest
+{
+	private static final int VARROCK_CENTRE = WorldPointUtil.packWorldPoint(3213, 3424, 0);
+	private static final int COWBELL_DESTINATION = WorldPointUtil.packWorldPoint(3259, 3277, 0);
+	private static final int COWBELL_AMULET = 33104;
+	private static final int BANKED_ROUTE_LENGTH = 36;
+
+	@Mock
+	Client client;
+	@Mock
+	ItemContainer bank;
+	@Mock
+	ShortestPathConfig config;
+
+	@Before
+	public void before()
+	{
+		when(config.calculationCutoff()).thenReturn(30);
+		when(config.currencyThreshold()).thenReturn(10000000);
+		when(config.includeBankPath()).thenReturn(true);
+		when(config.useTeleportationItems()).thenReturn(TeleportationItem.INVENTORY_AND_BANK);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		when(client.getClientThread()).thenReturn(Thread.currentThread());
+		when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+		doReturn(new Item[]{new Item(COWBELL_AMULET, 1)}).when(bank).getItems();
+	}
+
+	private Pathfinder run(int bankPickupCost)
+	{
+		when(config.costBankPickup()).thenReturn(bankPickupCost);
+		PathfinderConfig pathfinderConfig = new TestPathfinderConfig(client, config);
+		pathfinderConfig.bank = bank;
+		pathfinderConfig.refresh();
+		Pathfinder pathfinder = new Pathfinder(pathfinderConfig, VARROCK_CENTRE, Set.of(COWBELL_DESTINATION));
+		pathfinder.run();
+		return pathfinder;
+	}
+
+	@Test
+	public void bankRouteUsedWhenPickupCostIsFree()
+	{
+		Pathfinder pathfinder = run(0);
+		assertTrue("Route should pass through a bank (bankVisited state)",
+			pathfinder.getPath().stream().anyMatch(PathStep::isBankVisited));
+		assertEquals("Route should match the known bank-pickup path length",
+			BANKED_ROUTE_LENGTH, pathfinder.getPath().size());
+	}
+
+	@Test
+	public void smallPickupCostKeepsWorthwhileBankRoute()
+	{
+		// Banking saves far more than 20 tiles here, so a small surcharge must not change the route.
+		Pathfinder pathfinder = run(20);
+		assertTrue("Banking still wins when it saves more than the surcharge",
+			pathfinder.getPath().stream().anyMatch(PathStep::isBankVisited));
+		assertEquals("The surcharge must not distort a still-worthwhile route",
+			BANKED_ROUTE_LENGTH, pathfinder.getPath().size());
+	}
+
+	@Test
+	public void pickupCostExceedingSavingsAvoidsBanking()
+	{
+		// The bankVisited flag flips whenever the walk merely crosses a bank tile, so the observable
+		// for "did not bank for the item" is the absence of the teleport jump, not the flag.
+		Pathfinder pathfinder = run(10000);
+		assertTrue("The target must still be reached by walking", pathfinder.getResult().isReached());
+		assertFalse("A surcharge larger than the saving must not use the banked teleport",
+			hasTeleportJump(pathfinder));
+		assertTrue("The walking route is longer than the banked route",
+			pathfinder.getPath().size() > BANKED_ROUTE_LENGTH);
+	}
+
+	@Test
+	public void inventoryTeleportDoesNotPayTheSurcharge()
+	{
+		// With the amulet in the inventory the teleport works without banking, so even a huge
+		// surcharge must not deter it — only bank-gated transports pay.
+		ItemContainer inventory = org.mockito.Mockito.mock(ItemContainer.class);
+		doReturn(new Item[]{new Item(COWBELL_AMULET, 1)}).when(inventory).getItems();
+		when(client.getItemContainer(net.runelite.api.gameval.InventoryID.INV)).thenReturn(inventory);
+
+		Pathfinder pathfinder = run(10000);
+		assertTrue("The inventory teleport should still be used", hasTeleportJump(pathfinder));
+		assertTrue("Teleporting from the start is far shorter than walking to a bank first",
+			pathfinder.getPath().size() < BANKED_ROUTE_LENGTH);
+	}
+
+	/**
+	 * Whether any consecutive path steps are further apart than walking allows — with every transport
+	 * type disabled except teleportation items, only the cowbell teleport can produce such a jump.
+	 */
+	private static boolean hasTeleportJump(Pathfinder pathfinder)
+	{
+		java.util.List<PathStep> path = pathfinder.getPath();
+		for (int i = 1; i < path.size(); i++)
+		{
+			if (WorldPointUtil.distanceBetween(
+				path.get(i - 1).getPackedPosition(), path.get(i).getPackedPosition()) > 2)
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/test/java/shortestpath/pathfinder/MethodAvailabilityCatalogTest.java
+++ b/src/test/java/shortestpath/pathfinder/MethodAvailabilityCatalogTest.java
@@ -1,0 +1,185 @@
+package shortestpath.pathfinder;
+
+import java.util.Map;
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Skill;
+import net.runelite.api.gameval.InventoryID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+import shortestpath.MethodAvailability;
+import shortestpath.ShortestPathConfig;
+import shortestpath.TeleportMethod;
+import shortestpath.TeleportationItem;
+import shortestpath.WorldPointUtil;
+import shortestpath.transport.TransportType;
+
+/**
+ * Covers the teleport-method catalog and its per-method availability classification
+ * ({@link PathfinderConfig#getMethodAvailability()}): the catalog must be the same full set in every
+ * mode, and each method must carry the reason the player can(not) use it right now — independent of
+ * the mode's possession/unlock bypasses.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MethodAvailabilityCatalogTest
+{
+	private static final int COWBELL_DESTINATION = WorldPointUtil.packWorldPoint(3259, 3277, 0);
+	private static final int COWBELL_AMULET = 33104;
+
+	@Mock
+	Client client;
+	@Mock
+	ItemContainer inventory;
+	@Mock
+	ItemContainer bank;
+	@Mock
+	ShortestPathConfig config;
+
+	@Before
+	public void before()
+	{
+		when(config.calculationCutoff()).thenReturn(30);
+		when(config.currencyThreshold()).thenReturn(10000000);
+		when(client.getGameState()).thenReturn(GameState.LOGGED_IN);
+		when(client.getClientThread()).thenReturn(Thread.currentThread());
+		when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(99);
+		// Classification must be independent of the (hidden) teleportation-item setting.
+		when(config.useTeleportationItems()).thenReturn(TeleportationItem.NONE);
+	}
+
+	/**
+	 * An Owned/Inventory planning copy, refreshed so the catalog is built.
+	 */
+	private PathfinderConfig refreshedPlanningCopy(PathfinderConfig base)
+	{
+		PathfinderConfig planning = base.copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setBypassItemPossession(false);
+		planning.setConsiderBank(false);
+		planning.refresh();
+		return planning;
+	}
+
+	private static TeleportMethod cowbellMethod(Map<TeleportMethod, MethodAvailability> catalog)
+	{
+		return catalog.keySet().stream()
+			.filter(m -> m.getType() == TransportType.TELEPORTATION_ITEM && m.getDestination() == COWBELL_DESTINATION)
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("Cowbell amulet method missing from the catalog"));
+	}
+
+	@Test
+	public void itemInInventoryClassifiesAvailable()
+	{
+		doReturn(new Item[]{new Item(COWBELL_AMULET, 1)}).when(inventory).getItems();
+		when(client.getItemContainer(InventoryID.INV)).thenReturn(inventory);
+
+		Map<TeleportMethod, MethodAvailability> catalog =
+			refreshedPlanningCopy(new TestPathfinderConfig(client, config)).getMethodAvailability();
+
+		assertEquals(MethodAvailability.AVAILABLE, catalog.get(cowbellMethod(catalog)));
+	}
+
+	@Test
+	public void itemOnlyInBankClassifiesInBank()
+	{
+		// Bank contents known only via the snapshot captured while the bank was open — the classifier
+		// must consult it in EVERY mode (here Owned/Inventory), not just the bank mode.
+		PathfinderConfig base = new TestPathfinderConfig(client, config);
+		base.setBankSnapshot(new Item[]{new Item(COWBELL_AMULET, 1)});
+
+		Map<TeleportMethod, MethodAvailability> catalog =
+			refreshedPlanningCopy(base).getMethodAvailability();
+
+		assertEquals(MethodAvailability.IN_BANK, catalog.get(cowbellMethod(catalog)));
+	}
+
+	@Test
+	public void itemNowhereClassifiesMissingItem()
+	{
+		Map<TeleportMethod, MethodAvailability> catalog =
+			refreshedPlanningCopy(new TestPathfinderConfig(client, config)).getMethodAvailability();
+
+		assertEquals(MethodAvailability.MISSING_ITEM, catalog.get(cowbellMethod(catalog)));
+	}
+
+	@Test
+	public void lowSkillLevelClassifiesMissingLevel()
+	{
+		// Magic level 3: Varrock Teleport (25 Magic) is level-gated before any item check.
+		when(client.getBoostedSkillLevel(any(Skill.class))).thenReturn(3);
+
+		Map<TeleportMethod, MethodAvailability> catalog =
+			refreshedPlanningCopy(new TestPathfinderConfig(client, config)).getMethodAvailability();
+
+		TeleportMethod varrockTeleport = catalog.keySet().stream()
+			.filter(m -> m.getType() == TransportType.TELEPORTATION_SPELL
+				&& m.getDisplayInfo() != null && m.getDisplayInfo().startsWith("Varrock Teleport"))
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("Varrock Teleport method missing from the catalog"));
+		assertEquals(MethodAvailability.MISSING_LEVEL, catalog.get(varrockTeleport));
+	}
+
+	@Test
+	public void fairyRingsClassifyMissingQuestWithoutQuestProgress()
+	{
+		// The fairy-ring network is gated on Fairytale II progress (varbit, unstubbed = 0). The type-level
+		// classifier must report MISSING_QUEST for every fairy-ring method.
+		Map<TeleportMethod, MethodAvailability> catalog =
+			refreshedPlanningCopy(new TestPathfinderConfig(client, config)).getMethodAvailability();
+
+		boolean sawFairyRing = false;
+		for (Map.Entry<TeleportMethod, MethodAvailability> entry : catalog.entrySet())
+		{
+			if (entry.getKey().getType() == TransportType.FAIRY_RING)
+			{
+				sawFairyRing = true;
+				assertEquals("Fairy ring " + entry.getKey().label(),
+					MethodAvailability.MISSING_QUEST, entry.getValue());
+			}
+		}
+		assertTrue("Catalog should contain fairy-ring methods", sawFairyRing);
+	}
+
+	@Test
+	public void catalogKeySetIsIdenticalAcrossModes()
+	{
+		// The catalog is the full method universe in every mode; only the availability markers differ.
+		PathfinderConfig planning = new TestPathfinderConfig(client, config).copyForPlanning();
+		planning.setPlanningMode(false);
+		planning.setBypassItemPossession(false);
+		planning.setConsiderBank(false);
+		planning.refresh();
+		Set<TeleportMethod> ownedCatalog = planning.getMethodCatalog();
+
+		planning.setPlanningMode(true);
+		planning.setBypassItemPossession(true);
+		planning.refresh();
+		Set<TeleportMethod> everythingCatalog = planning.getMethodCatalog();
+
+		assertFalse("Catalog should not be empty", ownedCatalog.isEmpty());
+		assertEquals("Owned and Everything modes must expose the same catalog",
+			everythingCatalog, ownedCatalog);
+	}
+
+	@Test
+	public void bestPrefersMoreAvailableStatus()
+	{
+		assertEquals(MethodAvailability.AVAILABLE, MethodAvailability.AVAILABLE.best(MethodAvailability.IN_BANK));
+		assertEquals(MethodAvailability.AVAILABLE, MethodAvailability.MISSING_QUEST.best(MethodAvailability.AVAILABLE));
+		assertEquals(MethodAvailability.IN_BANK, MethodAvailability.IN_BANK.best(MethodAvailability.MISSING_ITEM));
+		assertEquals(MethodAvailability.LOCKED, MethodAvailability.LOCKED.best(null));
+	}
+}

--- a/src/test/java/shortestpath/pathfinder/TestPathfinderConfig.java
+++ b/src/test/java/shortestpath/pathfinder/TestPathfinderConfig.java
@@ -68,6 +68,20 @@ public class TestPathfinderConfig extends PathfinderConfig
 		this.bypassVarPlayerChecks = bypassVarPlayerChecks;
 	}
 
+	protected TestPathfinderConfig(TestPathfinderConfig source)
+	{
+		super(source);
+		this.questState = source.questState;
+		this.bypassVarbitChecks = source.bypassVarbitChecks;
+		this.bypassVarPlayerChecks = source.bypassVarPlayerChecks;
+	}
+
+	@Override
+	protected PathfinderConfig newPlanningCopy()
+	{
+		return new TestPathfinderConfig(this);
+	}
+
 	@Override
 	public QuestState getQuestState(Quest quest)
 	{


### PR DESCRIPTION
Adds a side panel that, for the current destination, lists several alternative routes, each using a different set of teleports/transports, so you can compare them and pick the one that fits the items you have. Everything is additive: the classic shortest-path drawing is unchanged.

- Alternative routes: up to N per query (configurable "Routes to find" + "Show more"), streamed as found and ranked by cost; the list stops at the pure-walk option so nothing slower than walking is shown. Click a card to preview that route on the scene/minimap/world map.
- Teleport-method catalog: collapsible, categorised list of every method with per-method and per-category include/exclude toggles (persisted), and per-method availability markers explaining why a method can't be used (missing item, in the bank, level/quest/unlock).
- Availability modes: Owned (inventory / inventory + bank, routing through a bank to withdraw items) and All (unlocked-only / everything).
- Rendering: new arrow-line path style and an optional teleport pulse on the cast-from tile (both opt-in; existing defaults unchanged).
- Engine: bank-pickup cost so routing through a bank only wins when it saves more than that many tiles ("Bank pick-up threshold").

Routes are generated off-thread by AlternativeRoutes Service via the existing planning-mode pathfinder.

Here are some screenshots:
<img width="242" height="929" alt="catalog" src="https://github.com/user-attachments/assets/b82d74b9-7976-415b-8eac-4396e74c4a4a" />
<img width="245" height="639" alt="panel" src="https://github.com/user-attachments/assets/1ea11195-65c3-4081-b539-b680634702a8" />
<img width="790" height="720" alt="route-preview" src="https://github.com/user-attachments/assets/30e630d5-4e22-4f89-b02b-cbc968af8ae6" />

