### PR TITLE
Add arrow-line path style and teleport pulse highlight

### DIFF
--- a/src/main/java/shortestpath/ArrowHead.java
+++ b/src/main/java/shortestpath/ArrowHead.java
@@ -1,0 +1,45 @@
+package shortestpath;
+
+import java.awt.Graphics2D;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Path2D;
+
+/**
+ * Draws a small triangular arrowhead at the end of a line segment, rotated to the segment's
+ * direction, in the current colour of the graphics context.
+ * <p>
+ * Adapted from Quest Helper's {@code DirectionArrow.drawLineArrowHead}
+ * (Copyright (c) 2021, Zoinkwiz &lt;https://github.com/Zoinkwiz&gt;, BSD 2-Clause licence),
+ * as also used by the port-tasks plugin.
+ */
+public final class ArrowHead
+{
+	private ArrowHead()
+	{
+	}
+
+	/**
+	 * Fills an arrowhead pointing from (x1, y1) towards (x2, y2), with its tip at (x2, y2).
+	 *
+	 * @param size length of the arrowhead in pixels (its width is {@code size})
+	 */
+	public static void draw(Graphics2D graphics, double x1, double y1, double x2, double y2, double size)
+	{
+		Path2D head = new Path2D.Double();
+		head.moveTo(0, 0);
+		head.lineTo(-size / 2.0, -size);
+		head.lineTo(size / 2.0, -size);
+		head.closePath();
+
+		AffineTransform tx = new AffineTransform();
+		double angle = Math.atan2(y2 - y1, x2 - x1);
+		tx.translate(x2, y2);
+		tx.rotate(angle - Math.PI / 2d);
+
+		Graphics2D g = (Graphics2D) graphics.create();
+		// Compose (not replace) so the overlay's existing transform/clip stay intact.
+		g.transform(tx);
+		g.fill(head);
+		g.dispose();
+	}
+}

--- a/src/main/java/shortestpath/PathMapOverlay.java
+++ b/src/main/java/shortestpath/PathMapOverlay.java
@@ -116,16 +116,24 @@ public class PathMapOverlay extends Overlay
 			Color colour = plugin.getPathColor();
 			java.util.List<PathStep> path = plugin.getPathfinder().getPath();
 			Point cursorPos = client.getMouseCanvasPosition();
-			for (int i = 0; i < path.size(); i++)
+			if (TileStyle.ARROW_LINE.equals(plugin.pathStyle))
 			{
 				graphics.setColor(colour);
-				int point = path.get(i).getPackedPosition();
-				int lastPoint = (i > 0) ? path.get(i - 1).getPackedPosition() : point;
-				if (WorldPointUtil.distanceBetween(point, lastPoint) > 1)
+				drawArrowPath(graphics, path);
+			}
+			else
+			{
+				for (int i = 0; i < path.size(); i++)
 				{
-					drawOnMap(graphics, lastPoint, point, true, cursorPos);
+					graphics.setColor(colour);
+					int point = path.get(i).getPackedPosition();
+					int lastPoint = (i > 0) ? path.get(i - 1).getPackedPosition() : point;
+					if (WorldPointUtil.distanceBetween(point, lastPoint) > 1)
+					{
+						drawOnMap(graphics, lastPoint, point, true, cursorPos);
+					}
+					drawOnMap(graphics, point, true, cursorPos);
 				}
-				drawOnMap(graphics, point, true, cursorPos);
 			}
 			for (int target : plugin.getPathfinder().getTargets())
 			{
@@ -138,6 +146,72 @@ public class PathMapOverlay extends Overlay
 		}
 
 		return null;
+	}
+
+	/**
+	 * Draws the path as a directed polyline: consecutive same-direction walking steps are compressed
+	 * into one straight segment, each segment ends in a small arrowhead showing travel direction, and
+	 * teleport/transport jumps are dashed. (Arrowhead technique adapted from Quest Helper's
+	 * DirectionArrow, see {@link ArrowHead}.)
+	 */
+	private void drawArrowPath(Graphics2D graphics, java.util.List<PathStep> path)
+	{
+		final java.awt.Stroke walkStroke = new BasicStroke(2, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
+		final java.awt.Stroke jumpStroke = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[]{9}, 0);
+
+		int i = 0;
+		while (i < path.size() - 1)
+		{
+			int from = path.get(i).getPackedPosition();
+			int next = path.get(i + 1).getPackedPosition();
+
+			if (WorldPointUtil.distanceBetween(from, next) > 1)
+			{
+				// Teleport/transport jump: dashed segment.
+				drawMapSegment(graphics, from, next, jumpStroke);
+				i++;
+				continue;
+			}
+
+			// Extend the straight walking run while the direction stays the same.
+			int dx = WorldPointUtil.unpackWorldX(next) - WorldPointUtil.unpackWorldX(from);
+			int dy = WorldPointUtil.unpackWorldY(next) - WorldPointUtil.unpackWorldY(from);
+			int j = i + 1;
+			while (j < path.size() - 1)
+			{
+				int a = path.get(j).getPackedPosition();
+				int b = path.get(j + 1).getPackedPosition();
+				if (WorldPointUtil.distanceBetween(a, b) > 1
+					|| WorldPointUtil.unpackWorldX(b) - WorldPointUtil.unpackWorldX(a) != dx
+					|| WorldPointUtil.unpackWorldY(b) - WorldPointUtil.unpackWorldY(a) != dy)
+				{
+					break;
+				}
+				j++;
+			}
+			drawMapSegment(graphics, from, path.get(j).getPackedPosition(), walkStroke);
+			i = j;
+		}
+	}
+
+	private void drawMapSegment(Graphics2D graphics, int from, int to, java.awt.Stroke stroke)
+	{
+		int x1 = plugin.mapWorldPointToGraphicsPointX(from);
+		int y1 = plugin.mapWorldPointToGraphicsPointY(from);
+		int x2 = plugin.mapWorldPointToGraphicsPointX(to);
+		int y2 = plugin.mapWorldPointToGraphicsPointY(to);
+		if (x1 == Integer.MIN_VALUE || y1 == Integer.MIN_VALUE
+			|| x2 == Integer.MIN_VALUE || y2 == Integer.MIN_VALUE)
+		{
+			return;
+		}
+		graphics.setStroke(stroke);
+		graphics.drawLine(x1, y1, x2, y2);
+		// Skip the head on segments too short to fit it (e.g. zoomed far out).
+		if (Math.hypot(x2 - x1, y2 - y1) >= 10)
+		{
+			ArrowHead.draw(graphics, x1, y1, x2, y2, 7);
+		}
 	}
 
 	private void drawOnMap(Graphics2D graphics, int point, boolean checkHover, Point cursorPos)

--- a/src/main/java/shortestpath/PathTileOverlay.java
+++ b/src/main/java/shortestpath/PathTileOverlay.java
@@ -7,7 +7,9 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.Stroke;
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -187,13 +189,19 @@ public class PathTileOverlay extends Overlay
 
 			List<PathStep> path = plugin.getPathfinder().getPath();
 			int counter = 0;
-			if (TileStyle.LINES.equals(plugin.pathStyle))
+			if (TileStyle.LINES.equals(plugin.pathStyle) || TileStyle.ARROW_LINE.equals(plugin.pathStyle))
 			{
+				boolean arrows = TileStyle.ARROW_LINE.equals(plugin.pathStyle);
 				for (int i = 1; i < path.size(); i++)
 				{
 					PathStep currentStep = path.get(i - 1);
 					PathStep nextStep = path.get(i);
-					drawLine(graphics, currentStep.getPackedPosition(), nextStep.getPackedPosition(), color, 1 + counter++);
+					// Arrowheads only where they carry information: at direction changes and the end.
+					boolean head = arrows && (i == path.size() - 1
+						|| directionChanges(currentStep.getPackedPosition(), nextStep.getPackedPosition(),
+							path.get(i + 1).getPackedPosition()));
+					drawLine(graphics, currentStep.getPackedPosition(), nextStep.getPackedPosition(), color,
+						1 + counter++, head);
 					drawTransportInfo(graphics, currentStep, nextStep, path, i - 1);
 				}
 			}
@@ -299,7 +307,16 @@ public class PathTileOverlay extends Overlay
 		}
 	}
 
-	private void drawLine(Graphics2D graphics, int startLoc, int endLoc, Color color, int counter)
+	private static boolean directionChanges(int previous, int current, int next)
+	{
+		int dx1 = WorldPointUtil.unpackWorldX(current) - WorldPointUtil.unpackWorldX(previous);
+		int dy1 = WorldPointUtil.unpackWorldY(current) - WorldPointUtil.unpackWorldY(previous);
+		int dx2 = WorldPointUtil.unpackWorldX(next) - WorldPointUtil.unpackWorldX(current);
+		int dy2 = WorldPointUtil.unpackWorldY(next) - WorldPointUtil.unpackWorldY(current);
+		return dx1 != dx2 || dy1 != dy2;
+	}
+
+	private void drawLine(Graphics2D graphics, int startLoc, int endLoc, Color color, int counter, boolean arrowHead)
 	{
 		PrimitiveIntList starts = WorldPointUtil.toLocalInstance(client, startLoc);
 		PrimitiveIntList ends = WorldPointUtil.toLocalInstance(client, endLoc);
@@ -342,6 +359,10 @@ public class PathTileOverlay extends Overlay
 		graphics.setColor(color);
 		graphics.setStroke(new BasicStroke(4));
 		graphics.draw(line);
+		if (arrowHead)
+		{
+			ArrowHead.draw(graphics, p1.getX(), p1.getY(), p2.getX(), p2.getY(), 12);
+		}
 
 		if (counter == 1)
 		{
@@ -408,6 +429,69 @@ public class PathTileOverlay extends Overlay
 			verticalOffset += drawLabelAtCanvasPoint(graphics, p, text, verticalOffset);
 		}
 		return verticalOffset;
+	}
+
+	/**
+	 * A pulsing "teleport from here" highlight: diamond rings expanding out from the tile and fading,
+	 * looping. Drawn every frame (scene overlays repaint continuously) off wall-clock time, so the motion
+	 * stays smooth regardless of game ticks. Anchored to the tile the player casts from — for a
+	 * cast-from-anywhere teleport that sits under the player, drawing the eye to "teleport now".
+	 */
+	private void drawTeleportPulse(Graphics2D graphics, int location)
+	{
+		PrimitiveIntList points = WorldPointUtil.toLocalInstance(client, location);
+		for (int i = 0; i < points.size(); i++)
+		{
+			LocalPoint lp = WorldPointUtil.toLocalPoint(client, points.get(i));
+			if (lp == null)
+			{
+				continue;
+			}
+			Polygon poly = Perspective.getCanvasTilePoly(client, lp);
+			if (poly == null || poly.npoints == 0)
+			{
+				continue;
+			}
+			final double cx = poly.getBounds().getCenterX();
+			final double cy = poly.getBounds().getCenterY();
+
+			final long period = 1400L;
+			final int rings = 2;
+			final Color base = plugin.colourTeleportPulse;
+			final Stroke previousStroke = graphics.getStroke();
+			graphics.setStroke(new BasicStroke(2.2f));
+			for (int r = 0; r < rings; r++)
+			{
+				// Stagger the two rings by half a period so one is always small/bright while the other
+				// is large/faint — a continuous outward pulse.
+				double phase = ((System.currentTimeMillis() + (long) (r * period / (double) rings)) % period)
+					/ (double) period;
+				double scale = 1.0 + phase * 2.6;
+				int alpha = (int) Math.round(170 * (1.0 - phase));
+				if (alpha <= 0)
+				{
+					continue;
+				}
+				Path2D ring = new Path2D.Double();
+				for (int v = 0; v < poly.npoints; v++)
+				{
+					double x = cx + (poly.xpoints[v] - cx) * scale;
+					double y = cy + (poly.ypoints[v] - cy) * scale;
+					if (v == 0)
+					{
+						ring.moveTo(x, y);
+					}
+					else
+					{
+						ring.lineTo(x, y);
+					}
+				}
+				ring.closePath();
+				graphics.setColor(new Color(base.getRed(), base.getGreen(), base.getBlue(), alpha));
+				graphics.draw(ring);
+			}
+			graphics.setStroke(previousStroke);
+		}
 	}
 
 	private double drawLabel(Graphics2D graphics, Point point, String text, int verticalOffset)
@@ -544,6 +628,22 @@ public class PathTileOverlay extends Overlay
 			}
 		}
 		Collection<Transport> transportsToShow = usableTransports.isEmpty() ? candidateTransports : usableTransports;
+
+		// Teleports ("use this item/spell") get a pulsing highlight on the tile you cast from, drawn
+		// once for the edge even if several teleport options share it.
+		boolean teleportEdge = false;
+		for (Transport transport : transportsToShow)
+		{
+			if (transport.getType() != null && transport.getType().isTeleport())
+			{
+				teleportEdge = true;
+				break;
+			}
+		}
+		if (teleportEdge && plugin.showTeleportPulse)
+		{
+			drawTeleportPulse(graphics, location);
+		}
 
 		for (Transport transport : transportsToShow)
 		{

--- a/src/main/java/shortestpath/ShortestPathConfig.java
+++ b/src/main/java/shortestpath/ShortestPathConfig.java
@@ -1021,13 +1021,25 @@ public interface ShortestPathConfig extends Config
 	@ConfigItem(
 		keyName = "pathStyle",
 		name = "Path style",
-		description = "Whether to display the path as tiles or a segmented line",
+		description = "Whether to display the path as tiles, a segmented line, or a line with direction arrows",
 		position = 73,
 		section = sectionDisplay
 	)
 	default TileStyle pathStyle()
 	{
 		return TileStyle.TILES;
+	}
+
+	@ConfigItem(
+		keyName = "showTeleportPulse",
+		name = "Teleport pulse",
+		description = "Animate a pulsing highlight on the tile when the path tells you to use a teleport",
+		position = 74,
+		section = sectionDisplay
+	)
+	default boolean showTeleportPulse()
+	{
+		return true;
 	}
 
 	@ConfigSection(
@@ -1114,6 +1126,18 @@ public interface ShortestPathConfig extends Config
 	default Color colourText()
 	{
 		return Color.WHITE;
+	}
+
+	@ConfigItem(
+		keyName = "colourTeleportPulse",
+		name = "Teleport pulse",
+		description = "Colour of the pulsing teleport highlight",
+		position = 81,
+		section = sectionColours
+	)
+	default Color colourTeleportPulse()
+	{
+		return new Color(0, 255, 255);
 	}
 
 	@ConfigSection(

--- a/src/main/java/shortestpath/ShortestPathPlugin.java
+++ b/src/main/java/shortestpath/ShortestPathPlugin.java
@@ -124,6 +124,8 @@ public class ShortestPathPlugin extends Plugin
 	Color colourPathUnreachable;
 	Color colourText;
 	Color colourTransports;
+	Color colourTeleportPulse;
+	boolean showTeleportPulse;
 	int tileCounterStep;
 	int unreachableTargetDistance;
 	String unreachableText;
@@ -1264,6 +1266,7 @@ public class ShortestPathPlugin extends Plugin
 		colourPathUnreachable = override("colourPathUnreachable", config.colourPathUnreachable());
 		colourText = override("colourText", config.colourText());
 		colourTransports = override("colourTransports", config.colourTransports());
+		colourTeleportPulse = override("colourTeleportPulse", config.colourTeleportPulse());
 
 		tileCounterStep = override("tileCounterStep", config.tileCounterStep());
 		unreachableTargetDistance = override("unreachableTargetDistanceThreshold", config.unreachableTargetDistance());
@@ -1271,6 +1274,7 @@ public class ShortestPathPlugin extends Plugin
 
 		showTileCounter = override("showTileCounter", config.showTileCounter());
 		pathStyle = override("pathStyle", config.pathStyle());
+		showTeleportPulse = override("showTeleportPulse", config.showTeleportPulse());
 	}
 
 	private String simplify(String text)

--- a/src/main/java/shortestpath/TileStyle.java
+++ b/src/main/java/shortestpath/TileStyle.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 public enum TileStyle
 {
 	TILES("Tiles"),
-	LINES("Lines");
+	LINES("Lines"),
+	ARROW_LINE("Arrow line");
 
 	private final String type;
 

--- a/src/test/java/shortestpath/ArrowHeadTest.java
+++ b/src/test/java/shortestpath/ArrowHeadTest.java
@@ -1,0 +1,75 @@
+package shortestpath;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ArrowHeadTest
+{
+	private static final int SIZE = 40;
+	private static final int OPAQUE_WHITE = 0xFFFFFFFF;
+
+	private static BufferedImage drawHead(double x1, double y1, double x2, double y2)
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setColor(Color.WHITE);
+		ArrowHead.draw(graphics, x1, y1, x2, y2, 8);
+		graphics.dispose();
+		return image;
+	}
+
+	private static boolean painted(BufferedImage image, int x, int y)
+	{
+		return (image.getRGB(x, y) >>> 24) != 0;
+	}
+
+	@Test
+	public void tipIsAtSegmentEnd()
+	{
+		BufferedImage image = drawHead(10, 20, 30, 20);
+		assertTrue("A pixel just behind the tip must be painted", painted(image, 29, 20));
+		assertTrue("Nothing may be painted past the tip", !painted(image, 32, 20));
+	}
+
+	@Test
+	public void headPointsAlongSegmentDirection()
+	{
+		// East-pointing: the body extends west of the tip, not north/south of the segment axis by more
+		// than the head's half-width, and nothing lands near the segment's start.
+		BufferedImage east = drawHead(10, 20, 30, 20);
+		assertTrue("Body extends back along the segment", painted(east, 24, 20));
+		assertTrue("Start of the segment stays unpainted", !painted(east, 12, 20));
+
+		// South-pointing: same shape rotated 90°.
+		BufferedImage south = drawHead(20, 10, 20, 30);
+		assertTrue("Body extends back along the segment", painted(south, 20, 24));
+		assertTrue("Start of the segment stays unpainted", !painted(south, 20, 12));
+	}
+
+	@Test
+	public void usesCurrentGraphicsColour()
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setColor(Color.WHITE);
+		ArrowHead.draw(graphics, 10, 20, 30, 20, 8);
+		graphics.dispose();
+		assertEquals("Head is filled with the graphics' current colour", OPAQUE_WHITE, image.getRGB(28, 20));
+	}
+
+	@Test
+	public void restoresGraphicsTransform()
+	{
+		BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setColor(Color.WHITE);
+		java.awt.geom.AffineTransform before = graphics.getTransform();
+		ArrowHead.draw(graphics, 10, 20, 30, 20, 8);
+		assertEquals("Drawing must not disturb the caller's transform", before, graphics.getTransform());
+		graphics.dispose();
+	}
+}


### PR DESCRIPTION
Two rendering additions, both purely opt-in (existing defaults unchanged):

- New "Arrowed line" path style: consecutive same-direction walking steps compress into straight segments ending in a direction arrowhead; teleport jumps draw dashed. Applied on the scene overlay (arrowheads at direction changes and the path end) and the world map overlay. Arrowhead drawing adapted from Quest Helper's DirectionArrow (BSD 2-Clause, credited).
<img width="517" height="428" alt="image" src="https://github.com/user-attachments/assets/ab21ff8a-4492-4506-b10d-43b7c5f7e425" />

- Teleport pulse: when the path's next step is a teleport, expanding rings pulse on the tile the player casts from, so the "use the teleport now" moment is easy to spot. Toggle + colour in config (on by default).
<img width="374" height="364" alt="teleport" src="https://github.com/user-attachments/assets/7820dcbf-e381-4ffe-a101-26d642ccc060" />

ArrowHeadTest covers tip placement, rotation, colour and transform safety.